### PR TITLE
Add 3D autolayout groups and preview controls

### DIFF
--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -50,16 +50,19 @@ export const createSceneTool: Tool = {
     "tracks with keyframes), passes it here, and gets a .hype file the desktop app " +
     "can open. Use this BEFORE render_scene when the scene doesn't already exist.\n\n" +
     "SceneJson shape (top level): { meta?, root?, activeCameraId?, nodes, tracks?, sections? }\n" +
-    "Each node: { id, kind: 'frame'|'rect'|'ellipse'|'text'|'image'|'video'|'audio'|'camera', " +
+    "Each node: { id, kind: 'frame'|'rect'|'ellipse'|'text'|'image'|'video'|'audio'|'component'|'instance'|'camera', " +
     "parent: id|null, children?: id[], transform?, appearance?, size?, layout?, ...kind-specific }\n" +
     "Auto-layout frames take layout: { mode: 'flex', direction: 'row'|'column', justify, align, gap, padding }\n" +
+    "Components can define variants, defaultSelection, variantOverrides, timelines, and interactions. " +
+    "Instances point at componentId and carry selection, overrides, and instance-local interaction additions. " +
+    "Component timelines are local tracks triggered by interactions, e.g. onClick -> playTimeline, and are scoped per instance.\n" +
     "Tracks: { id, nodeId, propertyId, keyframes: [{ id, time, value, easingOut? }], defaultEasing? }\n" +
     "Camera nodes can include focalLength, fieldOfView, pointOfInterestX/Y/Z, nearClip, farClip, " +
-    "depthOfField, focusWorldX/Y/Z, focusTargetNodeId, focusDistance, aperture, iso, blurLevel, " +
+    "depthOfField, focusWorldX/Y/Z, focusTargetNodeId, focusDistance, focusRadius, focusFalloff, aperture, iso, blurLevel, " +
     "blurQuality, and showFocusPlane.\n" +
     "Property IDs you can keyframe: transform.x, transform.y, transform.z, transform.rotation, " +
     "transform.rotationX, transform.rotationY, transform.scaleX, transform.scaleY, " +
-    "camera.focusWorldX, camera.focusWorldY, camera.focusWorldZ, camera.focusDistance, " +
+    "camera.focusWorldX, camera.focusWorldY, camera.focusWorldZ, camera.focusDistance, camera.focusRadius, camera.focusFalloff, " +
     "camera.pointOfInterestX, camera.pointOfInterestY, camera.pointOfInterestZ, " +
     "camera.focalLength, camera.fieldOfView, camera.nearClip, camera.farClip, " +
     "camera.aperture, camera.blurLevel, camera.blurQuality, " +

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -60,6 +60,7 @@ export interface NodeJson {
   locked?: boolean
   position?: 'flow' | 'absolute'
   isMask?: boolean
+  componentSourceId?: string | null
   transform?: {
     x: number
     y: number
@@ -73,6 +74,15 @@ export interface NodeJson {
   appearance?: Record<string, unknown>
   size?: { width: number | 'hug' | 'fill'; height: number | 'hug' | 'fill' }
   layout?: Record<string, unknown>
+  variants?: unknown[]
+  defaultSelection?: Record<string, string>
+  variantOverrides?: unknown[]
+  variantTransition?: unknown
+  timelines?: Record<string, unknown>
+  interactions?: unknown[]
+  componentId?: string
+  selection?: Record<string, string>
+  overrides?: Record<string, Record<string, unknown>>
   clipsContent?: boolean
   layoutGuides?: unknown[]
   // kind-specific
@@ -112,6 +122,8 @@ export interface NodeJson {
   focusWorldZ?: number
   focusTargetNodeId?: string | null
   focusDistance?: number
+  focusRadius?: number
+  focusFalloff?: number
   aperture?: number
   iso?: number
   blurLevel?: number
@@ -238,6 +250,7 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
     y.set('locked', node.locked ?? false)
     y.set('position', node.position ?? 'flow')
     y.set('isMask', node.isMask ?? false)
+    y.set('componentSourceId', node.componentSourceId ?? null)
 
     // kind-specific fields
     if (node.kind === 'frame' || node.kind === 'component') {
@@ -252,6 +265,18 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
       if (node.kind === 'frame') {
         y.set('clipsContent', node.clipsContent ?? true)
         y.set('layoutGuides', node.layoutGuides ?? [])
+      } else {
+        y.set('variants', node.variants ?? [])
+        y.set('defaultSelection', node.defaultSelection ?? {})
+        y.set('variantOverrides', node.variantOverrides ?? [])
+        y.set('variantTransition', node.variantTransition ?? {
+          duration: 0.3,
+          easing: 'ease-in-out',
+          presetId: 'smooth',
+          strength: 50,
+        })
+        y.set('timelines', node.timelines ?? {})
+        y.set('interactions', node.interactions ?? [])
       }
     }
     if (node.kind === 'rect' || node.kind === 'ellipse' || node.kind === 'image') {
@@ -260,6 +285,20 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
     if (node.kind === 'image') {
       y.set('src', node.src ?? '')
       y.set('fit', node.fit ?? 'cover')
+    }
+    if (node.kind === 'instance') {
+      y.set('size', mergeWithDefaults(DEFAULT_SIZE, node.size as Partial<typeof DEFAULT_SIZE>))
+      y.set(
+        'layout',
+        mergeWithDefaults(
+          DEFAULT_LAYOUT as Record<string, unknown>,
+          node.layout,
+        ),
+      )
+      y.set('componentId', node.componentId ?? '')
+      y.set('selection', node.selection ?? {})
+      y.set('overrides', node.overrides ?? {})
+      y.set('interactions', node.interactions ?? [])
     }
     if (node.kind === 'video' || node.kind === 'audio') {
       y.set(
@@ -290,6 +329,8 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
       y.set('color', node.color ?? '#0a0a0c')
     }
     if (node.kind === 'camera') {
+      const centerX = metaIn.canvas.width / 2
+      const centerY = metaIn.canvas.height / 2
       y.set('projection', node.projection ?? '2d')
       y.set('enabled', node.enabled ?? true)
       y.set('background', node.background ?? null)
@@ -301,14 +342,16 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
       y.set('nearClip', node.nearClip ?? 1)
       y.set('farClip', node.farClip ?? 100000)
       y.set('depthOfField', node.depthOfField ?? false)
-      y.set('focusMode', node.focusMode ?? 'plane')
-      y.set('focusX', node.focusX ?? node.transform?.x ?? 0)
-      y.set('focusY', node.focusY ?? node.transform?.y ?? 0)
-      y.set('focusWorldX', node.focusWorldX ?? node.focusX ?? node.transform?.x ?? 0)
-      y.set('focusWorldY', node.focusWorldY ?? node.focusY ?? node.transform?.y ?? 0)
+      y.set('focusMode', node.focusMode ?? 'screen')
+      y.set('focusX', node.focusX ?? centerX)
+      y.set('focusY', node.focusY ?? centerY)
+      y.set('focusWorldX', node.focusWorldX ?? node.focusX ?? centerX)
+      y.set('focusWorldY', node.focusWorldY ?? node.focusY ?? centerY)
       y.set('focusWorldZ', node.focusWorldZ ?? node.focusDistance ?? 0)
       y.set('focusTargetNodeId', node.focusTargetNodeId ?? null)
       y.set('focusDistance', node.focusDistance ?? 0)
+      y.set('focusRadius', node.focusRadius ?? 160)
+      y.set('focusFalloff', node.focusFalloff ?? 180)
       y.set('aperture', node.aperture ?? 0)
       y.set('iso', node.iso ?? 100)
       y.set('blurLevel', node.blurLevel ?? 1)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -171,6 +171,74 @@ process.env.VITE_PUBLIC = app.isPackaged
 const VITE_DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL
 
 let mainWindow: BrowserWindow | null = null
+const RECENT_PROJECTS_LIMIT = 10
+let recentProjects: string[] = []
+
+function recentProjectsStorePath(): string {
+  return path.join(app.getPath('userData'), 'recent-projects.json')
+}
+
+function loadRecentProjects(): void {
+  try {
+    const raw = fs.readFileSync(recentProjectsStorePath(), 'utf8')
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return
+    recentProjects = parsed
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => path.resolve(item))
+      .filter((item, index, all) => all.indexOf(item) === index)
+      .slice(0, RECENT_PROJECTS_LIMIT)
+  } catch {
+    recentProjects = []
+  }
+}
+
+function saveRecentProjects(): void {
+  try {
+    fs.mkdirSync(path.dirname(recentProjectsStorePath()), { recursive: true })
+    fs.writeFileSync(
+      recentProjectsStorePath(),
+      JSON.stringify(recentProjects, null, 2),
+    )
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[recent] write failed: ${err instanceof Error ? err.message : err}`,
+    )
+  }
+}
+
+function refreshRecentProjectsMenu(): void {
+  if (!app.isReady() || isHeadlessOnly) return
+  buildAppMenu()
+}
+
+function addRecentProject(filePath: string): void {
+  const resolved = path.resolve(filePath)
+  recentProjects = [
+    resolved,
+    ...recentProjects.filter((item) => item !== resolved),
+  ].slice(0, RECENT_PROJECTS_LIMIT)
+  app.addRecentDocument(resolved)
+  saveRecentProjects()
+  refreshRecentProjectsMenu()
+}
+
+function removeRecentProject(filePath: string): void {
+  const resolved = path.resolve(filePath)
+  const next = recentProjects.filter((item) => item !== resolved)
+  if (next.length === recentProjects.length) return
+  recentProjects = next
+  saveRecentProjects()
+  refreshRecentProjectsMenu()
+}
+
+function clearRecentProjects(): void {
+  recentProjects = []
+  app.clearRecentDocuments()
+  saveRecentProjects()
+  refreshRecentProjectsMenu()
+}
 
 interface AppUpdateInfo {
   currentVersion: string
@@ -300,6 +368,21 @@ function startUpdateChecks(): void {
  */
 function buildAppMenu() {
   const isMac = process.platform === 'darwin'
+  const recentProjectItems: MenuItemConstructorOptions[] =
+    recentProjects.length === 0
+      ? [{ label: 'No Recent Projects', enabled: false }]
+      : [
+          ...recentProjects.map((projectPath) => ({
+            label: path.basename(projectPath),
+            sublabel: path.dirname(projectPath),
+            click: () => mainWindow?.webContents.send('file:open-path', projectPath),
+          })),
+          { type: 'separator' as const },
+          {
+            label: 'Clear Recent Projects',
+            click: () => clearRecentProjects(),
+          },
+        ]
 
   const template: MenuItemConstructorOptions[] = [
     ...(isMac
@@ -332,6 +415,10 @@ function buildAppMenu() {
           label: 'Open…',
           accelerator: 'CmdOrCtrl+O',
           click: () => mainWindow?.webContents.send('file:open'),
+        },
+        {
+          label: 'Recent Projects',
+          submenu: recentProjectItems,
         },
         { type: 'separator' as const },
         {
@@ -572,6 +659,38 @@ ipcMain.handle('clipboard:writeText', (_e, text: string) => {
 
 ipcMain.handle('updates:check', () => checkForUpdates())
 ipcMain.handle('updates:get-status', () => lastUpdateInfo)
+
+ipcMain.handle('preview:open-window', async () => {
+  const previewWindow = new BrowserWindow({
+    title: 'hyper-motion preview',
+    width: 1280,
+    height: 720,
+    minWidth: 640,
+    minHeight: 360,
+    backgroundColor: '#000000',
+    titleBarStyle: 'default',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.cjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+      webSecurity: true,
+      backgroundThrottling: false,
+    },
+  })
+
+  if (VITE_DEV_SERVER_URL) {
+    await previewWindow.loadURL(`${VITE_DEV_SERVER_URL}?preview=1`)
+  } else {
+    await previewWindow.loadFile(
+      path.join(process.env.DIST_RENDERER!, 'index.html'),
+      { query: { preview: '1' } },
+    )
+  }
+
+  previewWindow.focus()
+  return { ok: true }
+})
 
 /**
  * Export capture bridge.
@@ -1019,6 +1138,7 @@ ipcMain.handle(
     const filePath = result.filePaths[0]
     try {
       const bytes = fs.readFileSync(filePath)
+      addRecentProject(filePath)
       // Buffer → Uint8Array marshals across IPC.
       return { path: filePath, bytes: new Uint8Array(bytes) }
     } catch (err) {
@@ -1034,6 +1154,7 @@ ipcMain.handle(
   (_e, payload: { path: string; bytes: Uint8Array }): boolean => {
     try {
       fs.writeFileSync(payload.path, Buffer.from(payload.bytes))
+      addRecentProject(payload.path)
       return true
     } catch (err) {
       // eslint-disable-next-line no-console
@@ -1050,12 +1171,14 @@ ipcMain.handle(
   (_e, filePath: string): Uint8Array | null => {
     try {
       const bytes = fs.readFileSync(filePath)
+      addRecentProject(filePath)
       return new Uint8Array(bytes)
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error(
         `[file] read failed: ${err instanceof Error ? err.message : err}`,
       )
+      removeRecentProject(filePath)
       return null
     }
   },
@@ -1152,6 +1275,7 @@ app.whenReady().then(() => {
     return
   }
 
+  loadRecentProjects()
   buildAppMenu()
   createMainWindow()
   startUpdateChecks()

--- a/figma-plugin/src/code.ts
+++ b/figma-plugin/src/code.ts
@@ -130,6 +130,8 @@ interface CapturedText extends CapturedNodeBase {
 interface CapturedVector extends CapturedNodeBase {
   type: 'VECTOR'
   svg: string
+  rasterPng?: string
+  rasterReason?: string
 }
 
 type CapturedEffect =
@@ -204,6 +206,13 @@ async function captureNode(
     case 'GROUP':
     case 'COMPONENT':
     case 'INSTANCE':
+      if (shouldRasterizeVectorTree(node)) {
+        return captureVector(
+          node,
+          assets,
+          'Figma exported this icon as nested vector fragments, so Hyper Motion imports it as a PNG to preserve the exact appearance.',
+        )
+      }
       return captureFrame(node as FrameNode, assets)
     case 'RECTANGLE':
       return captureRect(node as RectangleNode, assets)
@@ -275,6 +284,48 @@ async function captureFrame(
   }
 }
 
+function shouldRasterizeVectorTree(node: SceneNode): boolean {
+  if (
+    node.type !== 'FRAME' &&
+    node.type !== 'GROUP' &&
+    node.type !== 'COMPONENT' &&
+    node.type !== 'INSTANCE'
+  ) {
+    return false
+  }
+  const children = (node as ChildrenMixin).children
+  if (!children || children.length === 0) return false
+  const layoutMode = (node as Partial<FrameNode>).layoutMode
+  if (layoutMode && layoutMode !== 'NONE') return false
+  return children.every(isVectorTreeNode)
+}
+
+function isVectorTreeNode(node: SceneNode): boolean {
+  if (!node.visible) return true
+  if (
+    node.type === 'VECTOR' ||
+    node.type === 'STAR' ||
+    node.type === 'POLYGON' ||
+    node.type === 'BOOLEAN_OPERATION' ||
+    node.type === 'LINE'
+  ) {
+    return true
+  }
+  if (
+    node.type === 'FRAME' ||
+    node.type === 'GROUP' ||
+    node.type === 'COMPONENT' ||
+    node.type === 'INSTANCE'
+  ) {
+    const children = (node as ChildrenMixin).children
+    if (!children || children.length === 0) return false
+    const layoutMode = (node as Partial<FrameNode>).layoutMode
+    if (layoutMode && layoutMode !== 'NONE') return false
+    return children.every(isVectorTreeNode)
+  }
+  return false
+}
+
 function nodeTypeAsFrame(t: string): CapturedFrame['type'] {
   if (t === 'FRAME' || t === 'GROUP' || t === 'COMPONENT' || t === 'INSTANCE') {
     return t
@@ -333,6 +384,7 @@ async function captureText(
 async function captureVector(
   node: SceneNode,
   assets: Record<string, string>,
+  rasterReason?: string,
 ): Promise<CapturedVector> {
   const base = await captureBase(
     node as unknown as SceneNode & GeometryMixin,
@@ -351,10 +403,34 @@ async function captureVector(
   } catch (err) {
     console.warn('[hyper-motion] SVG export failed', err)
   }
+  let rasterPng = ''
+  let reason = rasterReason
+  try {
+    const bytes = await (
+      node as unknown as { exportAsync: (s: ExportSettings) => Promise<Uint8Array> }
+    ).exportAsync({ format: 'PNG' })
+    rasterPng = bytesToBase64(bytes)
+  } catch (err) {
+    console.warn('[hyper-motion] PNG vector fallback export failed', err)
+    reason =
+      reason ??
+      'Figma could not export this vector as a fallback image. The SVG may not match exactly.'
+  }
+  if (!svg.trim()) {
+    reason =
+      reason ??
+      'Figma returned an empty SVG for this vector. Hyper Motion used a PNG fallback to preserve the visual result.'
+  } else if (base.width < 1 || base.height < 1) {
+    reason =
+      reason ??
+      'Figma reported collapsed bounds for this stroked vector. Hyper Motion used a PNG fallback to preserve the visual result.'
+  }
   return {
     ...base,
     type: 'VECTOR',
     svg,
+    ...(rasterPng ? { rasterPng } : {}),
+    ...(reason ? { rasterReason: reason } : {}),
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useRef } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
 import { TopBar } from '@/ui/TopBar'
 import { LayersPanel } from '@/ui/LayersPanel'
 import { Canvas } from '@/ui/Canvas'
+import { ComponentEditor } from '@/ui/ComponentEditor'
 import { Inspector } from '@/ui/Inspector'
 import { Timeline } from '@/ui/Timeline'
 import { ContextMenu } from '@/ui/ContextMenu'
@@ -17,13 +24,16 @@ import { useKeyboardShortcuts } from '@/ui/hooks/useKeyboardShortcuts'
 import { useAnim } from '@/ui/hooks/useAnim'
 import { useFigmaPaste } from '@/ui/hooks/useFigmaPaste'
 import { useFileMenu } from '@/ui/hooks/useFileMenu'
+import { getAnimEngine } from '@/anim'
 import {
   centerCameraOnCanvas,
   migrateCameraScaleToZ,
   normalizeRoot,
   pruneCameraScaleYTracks,
   recenterStaleCamera,
+  syncComponentInstances,
 } from '@/ui/actions'
+import type { NodeId } from '@/scene'
 import { useEagerLoadSceneFonts } from '@/ui/fonts/googleFonts'
 import { useCustomFonts } from '@/ui/fonts/useCustomFonts'
 import { useExportProgress } from '@/export/progressStore'
@@ -51,10 +61,42 @@ import { useExportProgress } from '@/export/progressStore'
  * a single place — easier to reason about than scattering listeners.
  */
 export default function App() {
+  const [isPreview, setIsPreview] = useState(
+    () => new URLSearchParams(window.location.search).get('preview') === '1',
+  )
+
+  useEffect(() => {
+    const syncRoute = () => {
+      setIsPreview(
+        new URLSearchParams(window.location.search).get('preview') === '1',
+      )
+    }
+    window.addEventListener('popstate', syncRoute)
+    return () => window.removeEventListener('popstate', syncRoute)
+  }, [])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 'p') {
+        return
+      }
+      event.preventDefault()
+      const url = new URL(window.location.href)
+      if (isPreview) url.searchParams.delete('preview')
+      else url.searchParams.set('preview', '1')
+      url.searchParams.delete('render-window')
+      url.searchParams.delete('requestId')
+      window.history.pushState(null, '', url.toString())
+      window.dispatchEvent(new Event('popstate'))
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [isPreview])
+
   return (
     <ErrorBoundary>
       <SceneProvider fallback={<BootSplash />}>
-        <Shell />
+        {isPreview ? <PreviewShell /> : <Shell />}
       </SceneProvider>
     </ErrorBoundary>
   )
@@ -64,6 +106,7 @@ function Shell() {
   const showLayers = useUI((s) => s.panels.layers)
   const showInspector = useUI((s) => s.panels.inspector)
   const showTimeline = useUI((s) => s.panels.timeline)
+  const componentEditId = useUI((s) => s.componentEditId)
   const api = useSceneAPI()
   const exportPhase = useExportProgress((s) => s.phase)
 
@@ -143,8 +186,9 @@ function Shell() {
   // the previous one. We diff against a previous-size ref so the
   // effect only writes when the size actually changed; this keeps
   // unrelated scene mutations from spamming setNodeProperty.
-  useSceneVersion()
+  const sceneVersion = useSceneVersion()
   const prevCanvasRef = useRef<{ w: number; h: number } | null>(null)
+  const componentSignatureRef = useRef<Record<NodeId, string>>({})
   useEffect(() => {
     const meta = api.getMeta()
     const w = meta.canvas?.width ?? 0
@@ -161,21 +205,427 @@ function Shell() {
     }
   })
 
+  // Keep materialized component instances in sync with their master.
+  // This is deliberately signature-gated: syncing writes to the scene,
+  // which bumps the version, so we only sync when the master's own
+  // subtree actually changed.
+  useEffect(() => {
+    const nextSignatures: Record<NodeId, string> = {}
+    for (const id of api.getAllNodeIds()) {
+      const node = api.getNode(id)
+      if (!node || node.kind !== 'component') continue
+      const signature = componentSignature(api, id)
+      nextSignatures[id] = signature
+      if (componentSignatureRef.current[id] === undefined) continue
+      if (componentSignatureRef.current[id] !== signature) {
+        api.doc.transact(() => {
+          syncComponentInstances(api, id)
+        }, 'component-sync')
+      }
+    }
+    componentSignatureRef.current = nextSignatures
+  }, [api, sceneVersion])
+
   return (
     <div className="flex h-full w-full flex-col bg-app-bg text-text">
       <TopBar />
       <div className="flex min-h-0 flex-1">
         {showLayers && <LayersPanel />}
-        <Canvas />
+        {componentEditId ? <ComponentEditor /> : <Canvas />}
         {showInspector && <Inspector />}
       </div>
-      {showTimeline && <Timeline />}
+      {showTimeline && !componentEditId && <Timeline />}
       <ContextMenu />
       <RenameDialog />
       <ExportRecordingIndicator />
       <UpdateNotice />
     </div>
   )
+}
+
+function PreviewShell() {
+  const api = useSceneAPI()
+  const setPlaying = useUI((s) => s.setPlaying)
+  const setPlayhead = useUI((s) => s.setPlayhead)
+  const setView = useUI((s) => s.setView)
+  const clearSelection = useUI((s) => s.clearSelection)
+  const currentFilePath = useUI((s) => s.currentFilePath)
+  const playing = useUI((s) => s.playing)
+  const playhead = useUI((s) => s.playhead)
+  const setIsolatedRange = useUI((s) => s.setIsolatedRange)
+  const trackRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<PreviewDragState | null>(null)
+  const [workArea, setWorkArea] = useState<PreviewWorkArea>(() => ({
+    start: 0,
+    end: 1,
+  }))
+  useSceneVersion()
+  const meta = api.getMeta()
+  const duration = Math.max(0.1, meta.duration)
+  const frameStep = 1 / Math.max(1, meta.frameRate)
+  const minWorkArea = Math.max(frameStep, 0.05)
+  const normalizedWorkArea = normalizePreviewWorkArea(
+    workArea,
+    duration,
+    minWorkArea,
+  )
+
+  const displayName = (() => {
+    if (currentFilePath) {
+      const base = currentFilePath.replace(/^.*[\\/]/, '')
+      return base.replace(/\.hype$/i, '')
+    }
+    return api.getMeta().name || 'Untitled'
+  })()
+
+  const closePreview = useCallback(() => {
+    setPlaying(false)
+    const url = new URL(window.location.href)
+    url.searchParams.delete('preview')
+    window.history.pushState(null, '', url.toString())
+    window.dispatchEvent(new Event('popstate'))
+  }, [setPlaying])
+
+  useAnim()
+  useEagerLoadSceneFonts()
+  useCustomFonts()
+
+  useEffect(() => {
+    document.body.setAttribute('data-preview-mode', '1')
+    setIsolatedRange(null)
+    const fitPreview = () => {
+      const canvas = api.getMeta().canvas ?? { width: 960, height: 540 }
+      const paddingX = 48
+      const paddingY = 136
+      const zoom = Math.min(
+        2,
+        Math.max(
+          0.05,
+          Math.min(
+            (window.innerWidth - paddingX) / canvas.width,
+            (window.innerHeight - paddingY) / canvas.height,
+          ),
+        ),
+      )
+      setView({ panX: 0, panY: 0, zoom })
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      setPlaying(false)
+      closePreview()
+    }
+
+    clearSelection()
+    setPlayhead(0)
+    setPlaying(true)
+    fitPreview()
+    window.addEventListener('resize', fitPreview)
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      setPlaying(false)
+      document.body.removeAttribute('data-preview-mode')
+      window.removeEventListener('resize', fitPreview)
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [
+    api,
+    clearSelection,
+    closePreview,
+    setIsolatedRange,
+    setPlayhead,
+    setPlaying,
+    setView,
+  ])
+
+  const seekPreview = (next: number) => {
+    const clamped = clamp(next, 0, duration)
+    setPlaying(false)
+    setPlayhead(clamped)
+  }
+
+  const togglePlayback = () => {
+    if (
+      !playing &&
+      (playhead < normalizedWorkArea.start ||
+        playhead >= normalizedWorkArea.end - 0.001)
+    ) {
+      setPlayhead(normalizedWorkArea.start)
+    }
+    setPlaying(!playing)
+  }
+
+  useEffect(() => {
+    setWorkArea((range) => normalizePreviewWorkArea(range, duration, minWorkArea))
+  }, [duration, minWorkArea])
+
+  useEffect(() => {
+    getAnimEngine().setLoopRange(normalizedWorkArea)
+    return () => getAnimEngine().setLoopRange(null)
+  }, [normalizedWorkArea.start, normalizedWorkArea.end])
+
+  useEffect(() => {
+    if (
+      playhead < normalizedWorkArea.start ||
+      playhead > normalizedWorkArea.end
+    ) {
+      setPlayhead(normalizedWorkArea.start)
+    }
+  }, [normalizedWorkArea.start, normalizedWorkArea.end, playhead, setPlayhead])
+
+  const timeFromPreviewPointer = (clientX: number) => {
+    const rect = trackRef.current?.getBoundingClientRect()
+    if (!rect || rect.width <= 0) return 0
+    return clamp(((clientX - rect.left) / rect.width) * duration, 0, duration)
+  }
+
+  const updateWorkAreaDrag = (clientX: number) => {
+    const drag = dragRef.current
+    if (!drag) return
+    const t = timeFromPreviewPointer(clientX)
+    if (drag.mode === 'scrub') {
+      setPlayhead(t)
+      return
+    }
+    if (drag.mode === 'start') {
+      const nextStart = clamp(
+        t,
+        0,
+        normalizedWorkArea.end - minWorkArea,
+      )
+      setWorkArea({ start: nextStart, end: normalizedWorkArea.end })
+      setPlayhead(nextStart)
+      return
+    }
+    if (drag.mode === 'end') {
+      const nextEnd = clamp(
+        t,
+        normalizedWorkArea.start + minWorkArea,
+        duration,
+      )
+      setWorkArea({ start: normalizedWorkArea.start, end: nextEnd })
+      setPlayhead(Math.min(playhead, nextEnd))
+      return
+    }
+    const delta = t - drag.anchorTime
+    const span = drag.startArea.end - drag.startArea.start
+    const nextStart = clamp(drag.startArea.start + delta, 0, duration - span)
+    setWorkArea({ start: nextStart, end: nextStart + span })
+    setPlayhead(clamp(drag.startPlayhead + delta, nextStart, nextStart + span))
+  }
+
+  const beginPreviewDrag = (
+    event: ReactPointerEvent,
+    mode: PreviewDragState['mode'],
+  ) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setPlaying(false)
+    const anchorTime = timeFromPreviewPointer(event.clientX)
+    dragRef.current = {
+      mode,
+      anchorTime,
+      startArea: normalizedWorkArea,
+      startPlayhead: playhead,
+    }
+    if (mode === 'scrub') setPlayhead(anchorTime)
+    trackRef.current?.setPointerCapture(event.pointerId)
+  }
+
+  const continuePreviewDrag = (event: ReactPointerEvent) => {
+    if (!dragRef.current) return
+    event.preventDefault()
+    updateWorkAreaDrag(event.clientX)
+  }
+
+  const endPreviewDrag = (event: ReactPointerEvent) => {
+    if (!dragRef.current) return
+    dragRef.current = null
+    if (trackRef.current?.hasPointerCapture(event.pointerId)) {
+      trackRef.current.releasePointerCapture(event.pointerId)
+    }
+  }
+
+  const restartPreview = () => {
+    seekPreview(normalizedWorkArea.start)
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col bg-black text-text">
+      <div className="flex h-10 shrink-0 items-center gap-1 border-b border-white/10 bg-black px-3 text-white">
+        <button
+          type="button"
+          onClick={closePreview}
+          className="flex h-7 items-center rounded-md px-3 text-[12px] text-white/55 hover:bg-white/10 hover:text-white"
+          title="Return to editor"
+        >
+          {displayName}
+        </button>
+        <span className="text-white/25">/</span>
+        <button
+          type="button"
+          className="flex h-7 items-center gap-2 rounded-md bg-white/12 px-3 text-[12px] font-medium text-white"
+          title="Preview tab"
+        >
+          <span>Preview</span>
+        </button>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={closePreview}
+          className="flex h-7 items-center rounded-md px-3 text-[12px] text-white/55 hover:bg-white/10 hover:text-white"
+          title="Close preview (Esc)"
+        >
+          Esc
+        </button>
+      </div>
+      <div className="flex min-h-0 flex-1">
+        <Canvas />
+      </div>
+      <div className="flex h-16 shrink-0 items-center gap-3 border-t border-white/10 bg-black px-4 text-white">
+        <button
+          type="button"
+          onClick={restartPreview}
+          className="flex h-8 w-8 items-center justify-center rounded-md text-white/60 hover:bg-white/10 hover:text-white"
+          title="Restart preview"
+        >
+          <PreviewStartIcon />
+        </button>
+        <button
+          type="button"
+          onClick={togglePlayback}
+          className="flex h-9 w-9 items-center justify-center rounded-md bg-white text-black hover:brightness-90"
+          title={playing ? 'Pause preview' : 'Play preview'}
+        >
+          {playing ? <PreviewPauseIcon /> : <PreviewPlayIcon />}
+        </button>
+        <span className="w-14 text-right font-mono text-[11px] tabular-nums text-white/70">
+          {formatPreviewTime(Math.min(playhead, duration))}
+        </span>
+        <div
+          ref={trackRef}
+          className="relative h-9 flex-1 cursor-pointer rounded-md bg-white/18"
+          onPointerDown={(event) => beginPreviewDrag(event, 'scrub')}
+          onPointerMove={continuePreviewDrag}
+          onPointerUp={endPreviewDrag}
+          onPointerCancel={endPreviewDrag}
+          title="Click to scrub. Drag the yellow work area to loop a range."
+        >
+          <div
+            className="absolute bottom-0 top-0 border-x border-white/10 bg-white/10"
+            style={{
+              left: `${(Math.min(playhead, duration) / duration) * 100}%`,
+              width: 1,
+            }}
+          />
+          <div
+            className="absolute top-1 bottom-1 rounded border-2 border-[oklch(0.84_0.18_85)] bg-[oklch(0.84_0.18_85)]/14 shadow-[0_0_0_1px_rgba(0,0,0,0.2)]"
+            style={{
+              left: `${(normalizedWorkArea.start / duration) * 100}%`,
+              width: `${
+                ((normalizedWorkArea.end - normalizedWorkArea.start) /
+                  duration) *
+                100
+              }%`,
+            }}
+            onPointerDown={(event) => beginPreviewDrag(event, 'move')}
+          >
+            <div
+              className="absolute -left-1 top-0 bottom-0 w-3 cursor-ew-resize rounded-l bg-[oklch(0.84_0.18_85)]"
+              onPointerDown={(event) => beginPreviewDrag(event, 'start')}
+            />
+            <div
+              className="absolute -right-1 top-0 bottom-0 w-3 cursor-ew-resize rounded-r bg-[oklch(0.84_0.18_85)]"
+              onPointerDown={(event) => beginPreviewDrag(event, 'end')}
+            />
+          </div>
+        </div>
+        <span className="w-14 font-mono text-[11px] tabular-nums text-white/45">
+          {formatPreviewTime(duration)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n))
+}
+
+interface PreviewWorkArea {
+  start: number
+  end: number
+}
+
+interface PreviewDragState {
+  mode: 'scrub' | 'start' | 'end' | 'move'
+  anchorTime: number
+  startArea: PreviewWorkArea
+  startPlayhead: number
+}
+
+function normalizePreviewWorkArea(
+  range: PreviewWorkArea,
+  duration: number,
+  minSpan: number,
+): PreviewWorkArea {
+  const safeDuration = Math.max(0.1, duration)
+  const safeMinSpan = Math.min(Math.max(0.001, minSpan), safeDuration)
+  const start = clamp(range.start, 0, Math.max(0, safeDuration - safeMinSpan))
+  const end = clamp(range.end, start + safeMinSpan, safeDuration)
+  return { start, end }
+}
+
+function formatPreviewTime(seconds: number): string {
+  const safe = Math.max(0, seconds)
+  const whole = Math.floor(safe)
+  const tenths = Math.floor((safe - whole) * 10)
+  const minutes = Math.floor(whole / 60)
+  const secs = whole % 60
+  return `${minutes}:${String(secs).padStart(2, '0')}.${tenths}`
+}
+
+function PreviewStartIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path d="M4 3v10" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+      <path d="M12 4.2 6.5 8l5.5 3.8V4.2Z" fill="currentColor" />
+    </svg>
+  )
+}
+
+function PreviewPlayIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path d="M5.5 3.5v9L12 8 5.5 3.5Z" fill="currentColor" />
+    </svg>
+  )
+}
+
+function PreviewPauseIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path d="M5 3.5v9M11 3.5v9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function componentSignature(api: ReturnType<typeof useSceneAPI>, id: NodeId): string {
+  const visit = (nodeId: NodeId): unknown => {
+    const node = api.getNode(nodeId)
+    if (!node) return null
+    const { id: _id, parent: _parent, children: _children, ...rest } =
+      node as unknown as Record<string, unknown>
+    void _id
+    void _parent
+    void _children
+    return {
+      ...rest,
+      tracks: api.getTracksForNode(nodeId),
+      children: api.getChildren(nodeId).map((child) => visit(child.id)),
+    }
+  }
+  return JSON.stringify(visit(id))
 }
 
 function BootSplash() {

--- a/src/anim/easing.ts
+++ b/src/anim/easing.ts
@@ -34,10 +34,38 @@ export function evaluator(easing: EasingKind | undefined): EasingEvaluator {
   }
   if ('bezier' in easing) return bezierEvaluator(easing.bezier)
   if ('spring' in easing) {
-    // Spring stub — treat as ease-out until the proper solver lands.
-    return bezierEvaluator(PRESETS['ease-out']!)
+    return springEvaluator(easing.spring)
   }
   return IDENTITY
+}
+
+function springEvaluator(spring: {
+  stiffness: number
+  damping: number
+  mass: number
+}): EasingEvaluator {
+  const stiffness = Math.max(1, spring.stiffness)
+  const damping = Math.max(0.1, spring.damping)
+  const mass = Math.max(0.1, spring.mass)
+  const omega0 = Math.sqrt(stiffness / mass)
+  const zeta = damping / (2 * Math.sqrt(stiffness * mass))
+
+  return (t: number) => {
+    if (t <= 0) return 0
+    if (t >= 1) return 1
+    if (zeta < 1) {
+      const omegaD = omega0 * Math.sqrt(1 - zeta * zeta)
+      const envelope = Math.exp(-zeta * omega0 * t)
+      const value =
+        1 -
+        envelope *
+          (Math.cos(omegaD * t) +
+            (zeta * omega0 / omegaD) * Math.sin(omegaD * t))
+      return value
+    }
+    const value = 1 - Math.exp(-omega0 * t) * (1 + omega0 * t)
+    return Math.max(0, Math.min(1.5, value))
+  }
 }
 
 function bezierEvaluator(

--- a/src/anim/engine.ts
+++ b/src/anim/engine.ts
@@ -78,6 +78,8 @@ export interface AnimatedValue {
   focusWorldX?: number
   focusWorldY?: number
   focusWorldZ?: number
+  focusRadius?: number
+  focusFalloff?: number
   pointOfInterestX?: number
   pointOfInterestY?: number
   pointOfInterestZ?: number
@@ -399,6 +401,12 @@ function writeProperty(
       break
     case 'camera.focusWorldZ':
       into.focusWorldZ = value
+      break
+    case 'camera.focusRadius':
+      into.focusRadius = value
+      break
+    case 'camera.focusFalloff':
+      into.focusFalloff = value
       break
     case 'camera.pointOfInterestX':
       into.pointOfInterestX = value

--- a/src/anim/recordKeyframes.ts
+++ b/src/anim/recordKeyframes.ts
@@ -65,6 +65,8 @@ const CAMERA_PROP_IDS: Partial<Record<string, PropertyId>> = {
   focusWorldX: 'camera.focusWorldX',
   focusWorldY: 'camera.focusWorldY',
   focusWorldZ: 'camera.focusWorldZ',
+  focusRadius: 'camera.focusRadius',
+  focusFalloff: 'camera.focusFalloff',
   pointOfInterestX: 'camera.pointOfInterestX',
   pointOfInterestY: 'camera.pointOfInterestY',
   pointOfInterestZ: 'camera.pointOfInterestZ',

--- a/src/export/renderWindowClient.ts
+++ b/src/export/renderWindowClient.ts
@@ -160,23 +160,31 @@ export async function runRenderWindowExport(
   const offProgress = bridge.on('export:render-window-progress', (...args) => {
     const msg = args[0] as ProgressMessage
     if (msg.requestId !== requestId) return
-    if (progress.cancelToken !== startToken) return // user cancelled
+    const currentProgress = useExportProgress.getState()
+    if (currentProgress.cancelToken !== startToken) return // user cancelled
     if (msg.phase === 'encoding') {
-      progress.setPhase('encoding')
+      currentProgress.setPhase('encoding')
       return
     }
     if (typeof msg.frame === 'number') {
-      progress.setFrame(msg.frame)
+      currentProgress.setFrame(msg.frame)
     }
     if (typeof msg.perFrameMs === 'number') {
       smoothedFrameMs = msg.perFrameMs
-      progress.setEta(msg.etaMs ?? 0, smoothedFrameMs)
+      currentProgress.setEta(msg.etaMs ?? 0, smoothedFrameMs)
     }
   })
 
   const offDone = bridge.on('export:render-window-done', (...args) => {
     const msg = args[0] as DoneMessage
     if (msg.requestId !== requestId) return
+    if (useExportProgress.getState().cancelToken !== startToken) {
+      offProgress?.()
+      offDone?.()
+      offError?.()
+      resolveDone()
+      return
+    }
     void handleDone(msg, ctx).finally(() => {
       offProgress?.()
       offDone?.()
@@ -188,7 +196,10 @@ export async function runRenderWindowExport(
   const offError = bridge.on('export:render-window-error', (...args) => {
     const msg = args[0] as ErrorMessage
     if (msg.requestId !== requestId) return
-    progress.setError(msg.message)
+    const currentProgress = useExportProgress.getState()
+    if (currentProgress.cancelToken === startToken) {
+      currentProgress.setError(msg.message)
+    }
     offProgress?.()
     offDone?.()
     offError?.()
@@ -201,9 +212,10 @@ export async function runRenderWindowExport(
   // pending promise then resolves via the error/done path (window
   // destroy fires `closed` which clears the renderJobs entry).
   const cancelInterval = window.setInterval(() => {
-    if (progress.cancelToken !== startToken) {
+    const currentProgress = useExportProgress.getState()
+    if (currentProgress.cancelToken !== startToken) {
       void bridge.invoke('export:cancel-render-window', requestId)
-      progress.setPhase('cancelled')
+      currentProgress.setPhase('cancelled')
       offProgress?.()
       offDone?.()
       offError?.()

--- a/src/import/figma/types.ts
+++ b/src/import/figma/types.ts
@@ -144,6 +144,14 @@ export interface FigmaCapturedVector extends FigmaCapturedNodeBase {
   type: 'VECTOR'
   /** Inline SVG markup, ready to embed via data URL. */
   svg: string
+  /**
+   * Base64 PNG fallback exported by the Figma plugin. Used when SVG
+   * export is blank, collapsed, or a vector-only group is safer to
+   * preserve as an exact raster image.
+   */
+  rasterPng?: string
+  /** User-facing explanation shown when the fallback image is selected. */
+  rasterReason?: string
 }
 
 export type FigmaCapturedEffect =

--- a/src/import/figma/walk.ts
+++ b/src/import/figma/walk.ts
@@ -478,24 +478,81 @@ function createVectorAsImage(
   transform: ReturnType<typeof figmaToTransform>,
   appearance: Appearance,
   position: Position,
-): NodeId {
+): NodeId | null {
   // Encode the captured SVG markup as a data URL and store as an image
   // node. Renders correctly in the existing image path; users can
   // resize and animate transform / opacity. Replacing this with a real
   // SVG node type is a follow-up once vector authoring lands.
-  const svgEncoded = encodeURIComponent(node.svg)
-  const src = `data:image/svg+xml;charset=utf-8,${svgEncoded}`
+  const svg = node.svg.trim()
+  const shouldUseRasterFallback =
+    !!node.rasterPng &&
+    (!!node.rasterReason || !svg || node.width < 1 || node.height < 1)
+  if (!svg && !node.rasterPng) return null
+  const intrinsicSize = readSvgIntrinsicSize(svg)
+  const size = {
+    width: pickVectorAxisSize(node.width, intrinsicSize?.width, node.strokeWeight),
+    height: pickVectorAxisSize(node.height, intrinsicSize?.height, node.strokeWeight),
+  }
+  const svgEncoded = encodeURIComponent(svg)
+  const src = shouldUseRasterFallback
+    ? `data:image/png;base64,${node.rasterPng}`
+    : `data:image/svg+xml;charset=utf-8,${svgEncoded}`
+  const importWarning = shouldUseRasterFallback
+    ? [
+        node.rasterReason ??
+          'Figma SVG export was not reliable for this vector, so Hyper Motion imported a PNG fallback.',
+        'The visual appearance is preserved, but this layer is not editable as vector paths. If you need editable SVG, outline or flatten unusual strokes in Figma and copy again.',
+      ].join(' ')
+    : undefined
   return api.createNode('image', parentId, {
     name: node.name || 'Vector',
     visible: node.visible,
     locked: node.locked,
     transform,
-    appearance,
+    appearance: {
+      ...appearance,
+      fill: null,
+      stroke: null,
+    },
     position,
-    size: { width: node.width, height: node.height },
+    size,
     src,
     fit: 'contain',
+    ...(importWarning ? { importWarning } : {}),
   })
+}
+
+function pickVectorAxisSize(
+  captured: number,
+  intrinsic: number | undefined,
+  strokeWeight: number | undefined,
+): number {
+  if (Number.isFinite(captured) && captured >= 1) return captured
+  if (intrinsic !== undefined && Number.isFinite(intrinsic) && intrinsic > 0) return intrinsic
+  if (strokeWeight !== undefined && Number.isFinite(strokeWeight) && strokeWeight > 0) return strokeWeight
+  return 1
+}
+
+function readSvgIntrinsicSize(svg: string): { width?: number; height?: number } | null {
+  const width = readSvgLength(svg, 'width')
+  const height = readSvgLength(svg, 'height')
+  if (width !== undefined || height !== undefined) return { width, height }
+
+  const viewBox = svg.match(/\bviewBox\s*=\s*["']([^"']+)["']/i)?.[1]
+  if (!viewBox) return null
+  const parts = viewBox
+    .trim()
+    .split(/[\s,]+/)
+    .map((part) => Number.parseFloat(part))
+  if (parts.length !== 4 || parts.some((part) => !Number.isFinite(part))) return null
+  return { width: Math.abs(parts[2]), height: Math.abs(parts[3]) }
+}
+
+function readSvgLength(svg: string, attr: 'width' | 'height'): number | undefined {
+  const raw = svg.match(new RegExp(`\\b${attr}\\s*=\\s*["']([^"']+)["']`, 'i'))?.[1]
+  if (!raw) return undefined
+  const value = Number.parseFloat(raw)
+  return Number.isFinite(value) && value > 0 ? value : undefined
 }
 
 /**

--- a/src/index.css
+++ b/src/index.css
@@ -1,14 +1,12 @@
+@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap');
 @import "tailwindcss";
 
 /*
- * Typography — Apple system stack.
+ * Typography — app chrome.
  *
- * SF Pro on macOS / iOS, Segoe UI Variable on Windows, Inter as a
- * web fallback when the PWA ships beyond Apple devices. The UI text
- * reads "native macOS app" without us shipping any web fonts. Mono is
- * reserved for places where tabular alignment matters (timeline frame
- * counts, coordinate readouts) — applied per use site via `font-mono`,
- * not globally.
+ * UI chrome uses Geist Mono in all caps. Scene/canvas content is reset
+ * below so designed text layers keep their authored font, casing, and
+ * letter spacing.
  */
 
 /*
@@ -45,17 +43,12 @@
   --color-segment-bar-hover: oklch(0.48 0.10 250);
   --color-playhead: oklch(0.70 0.20 250);
 
-  /* Apple system font stacks. SF Pro / -apple-system on macOS &
-     iOS; falls back through native faces on Windows (Segoe UI
-     Variable Display) and Linux (Inter). */
-  --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text",
-    "SF Pro", "Segoe UI Variable", "Segoe UI", "Helvetica Neue",
-    Arial, "Inter", system-ui, sans-serif;
-  --font-display: -apple-system, BlinkMacSystemFont, "SF Pro Display",
-    "SF Pro", "Segoe UI Variable Display", "Segoe UI", "Helvetica Neue",
-    Arial, "Inter", system-ui, sans-serif;
-  --font-mono: ui-monospace, "SF Mono", "Menlo", "Consolas",
-    "Liberation Mono", "Courier New", monospace;
+  --font-sans: "Geist Mono", ui-monospace, "SF Mono", "Menlo",
+    "Consolas", "Liberation Mono", "Courier New", monospace;
+  --font-display: "Geist Mono", ui-monospace, "SF Mono", "Menlo",
+    "Consolas", "Liberation Mono", "Courier New", monospace;
+  --font-mono: "Geist Mono", ui-monospace, "SF Mono", "Menlo",
+    "Consolas", "Liberation Mono", "Courier New", monospace;
 
   /* Spacing scale — Gestalt-proximity rad-spacing rule. Each parent
      level ~1.4× its child, snapped to 4 / 8 px multiples. */
@@ -183,8 +176,35 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
-  letter-spacing: -0.005em;
+  text-transform: uppercase;
+  letter-spacing: 0;
   overflow: hidden; /* the app owns the scrolling, not the page */
+}
+
+[data-canvas-root],
+[data-canvas-root] *,
+[data-node-id],
+[data-node-id] * {
+  text-transform: none;
+}
+
+button,
+input,
+textarea,
+select {
+  font-family: var(--font-sans);
+  text-transform: uppercase;
+}
+
+[data-canvas-root] button,
+[data-canvas-root] input,
+[data-canvas-root] textarea,
+[data-canvas-root] select,
+[data-node-id] button,
+[data-node-id] input,
+[data-node-id] textarea,
+[data-node-id] select {
+  text-transform: none;
 }
 
 /* Mac-style thin scrollbars. */
@@ -242,6 +262,22 @@ body[data-export-recording='1'] {
 body[data-export-recording='1'] main {
   background: #000 !important;
   pointer-events: none !important;
+}
+
+body[data-preview-mode='1'] {
+  background: #000 !important;
+}
+body[data-preview-mode='1'] [data-export-hide],
+body[data-preview-mode='1'] [data-export-hide='1'] {
+  display: none !important;
+}
+body[data-preview-mode='1'] main {
+  background: #000 !important;
+  pointer-events: none !important;
+}
+body[data-preview-mode='1'] [data-canvas-root] {
+  border-color: transparent !important;
+  box-shadow: none !important;
 }
 
 /* Pulse keyframe used by the floating REC indicator during tab

--- a/src/interaction/componentRuntime.ts
+++ b/src/interaction/componentRuntime.ts
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  ComponentNode,
+  ComponentTimeline,
+  Interaction,
+  InteractionAction,
+  InteractionTarget,
+  InstanceNode,
+  KeyframeValue,
+  NodeId,
+  PropertyId,
+  Track,
+  VariantSelection,
+} from '@/scene'
+import type { SceneAPI } from '@/scene/doc'
+import type { AnimatedValue } from '@/anim'
+import { evaluator, type EasingEvaluator } from '@/anim'
+
+export interface ComponentInstanceResolution {
+  instance: InstanceNode
+  component: ComponentNode
+  selection: VariantSelection
+  variantOverrides: Record<NodeId, Record<string, unknown>>
+  overrides: Record<NodeId, Record<string, unknown>>
+  timelines: Record<string, ComponentTimeline>
+  interactions: Interaction[]
+}
+
+export interface ComponentInteractionEvent {
+  type: Interaction['event']
+  /** Concrete instance receiving the event. */
+  targetInstanceId: NodeId
+  /**
+   * Optional node id inside the component definition. Omit to target the
+   * component root. A click on a dropdown item can pass that item id.
+   */
+  sourceNodeId?: NodeId
+  /** Seconds. Defaults to the runtime clock. */
+  now?: number
+}
+
+export interface RunningComponentTimeline {
+  instanceId: NodeId
+  timelineId: string
+  startedAt: number
+}
+
+export interface ComponentInteractionRuntime {
+  dispatch(event: ComponentInteractionEvent): void
+  tick(now?: number): void
+  getInstanceSelection(instanceId: NodeId): VariantSelection
+  getActiveTimelines(instanceId: NodeId): RunningComponentTimeline[]
+  getAnimatedValues(instanceId: NodeId, now?: number): Record<NodeId, AnimatedValue>
+  resolveInstance(instanceId: NodeId): ComponentInstanceResolution | null
+}
+
+interface ScheduledAction {
+  at: number
+  instanceId: NodeId
+  action: InteractionAction
+}
+
+export function createComponentInteractionRuntime(
+  api: SceneAPI,
+): ComponentInteractionRuntime {
+  const selectionByInstance = new Map<NodeId, VariantSelection>()
+  const running = new Map<string, RunningComponentTimeline>()
+  const scheduled: ScheduledAction[] = []
+  const easerCache = new Map<string, EasingEvaluator>()
+
+  const nowSeconds = () => {
+    if (typeof performance !== 'undefined') return performance.now() / 1000
+    return Date.now() / 1000
+  }
+
+  const runtime: ComponentInteractionRuntime = {
+    dispatch(event) {
+      const at = event.now ?? nowSeconds()
+      flushScheduled(at)
+      const resolved = resolveComponentInstance(api, event.targetInstanceId)
+      if (!resolved) return
+      seedSelection(resolved)
+      for (const interaction of resolved.interactions) {
+        if (!interactionMatches(interaction, event)) continue
+        for (const action of interaction.actions) {
+          runAction(event.targetInstanceId, action, at)
+        }
+      }
+    },
+    tick(now = nowSeconds()) {
+      flushScheduled(now)
+      for (const [key, active] of running) {
+        const resolved = resolveComponentInstance(api, active.instanceId)
+        const timeline = resolved?.timelines[active.timelineId]
+        if (!timeline) {
+          running.delete(key)
+          continue
+        }
+        if (!timeline.loop && now - active.startedAt > timeline.duration) {
+          running.delete(key)
+        }
+      }
+    },
+    getInstanceSelection(instanceId) {
+      const resolved = resolveComponentInstance(api, instanceId)
+      if (!resolved) return {}
+      seedSelection(resolved)
+      return { ...(selectionByInstance.get(instanceId) ?? resolved.selection) }
+    },
+    getActiveTimelines(instanceId) {
+      return Array.from(running.values()).filter((t) => t.instanceId === instanceId)
+    },
+    getAnimatedValues(instanceId, now = nowSeconds()) {
+      flushScheduled(now)
+      const resolved = resolveComponentInstance(api, instanceId)
+      if (!resolved) return {}
+      const out: Record<NodeId, AnimatedValue> = {}
+      for (const active of runtime.getActiveTimelines(instanceId)) {
+        const timeline = resolved.timelines[active.timelineId]
+        if (!timeline) continue
+        const localTime = timeline.loop
+          ? positiveModulo(now - active.startedAt, Math.max(0.0001, timeline.duration))
+          : Math.min(timeline.duration, Math.max(0, now - active.startedAt))
+        for (const track of timeline.tracks) {
+          const value = out[track.nodeId] ?? {}
+          applyTrack(track, localTime, value, easerCache)
+          out[track.nodeId] = value
+        }
+      }
+      return out
+    },
+    resolveInstance(instanceId) {
+      return resolveComponentInstance(api, instanceId)
+    },
+  }
+
+  function seedSelection(resolved: ComponentInstanceResolution): void {
+    if (selectionByInstance.has(resolved.instance.id)) return
+    selectionByInstance.set(resolved.instance.id, { ...resolved.selection })
+  }
+
+  function flushScheduled(now: number): void {
+    scheduled.sort((a, b) => a.at - b.at)
+    while (scheduled.length > 0 && scheduled[0]!.at <= now) {
+      const next = scheduled.shift()!
+      runAction(next.instanceId, next.action, next.at)
+    }
+  }
+
+  function runAction(instanceId: NodeId, action: InteractionAction, now: number): void {
+    if (action.type === 'after') {
+      scheduled.push({
+        at: now + Math.max(0, action.delay),
+        instanceId,
+        action: action.action,
+      })
+      return
+    }
+
+    const targetInstanceId = resolveTargetInstanceId(api, instanceId, action.target)
+    if (!targetInstanceId) return
+    const resolved = resolveComponentInstance(api, targetInstanceId)
+    if (!resolved) return
+    seedSelection(resolved)
+
+    if (action.type === 'playTimeline') {
+      if (!resolved.timelines[action.timelineId]) return
+      const key = `${targetInstanceId}:${action.timelineId}`
+      if (action.restart !== false || !running.has(key)) {
+        running.set(key, {
+          instanceId: targetInstanceId,
+          timelineId: action.timelineId,
+          startedAt: now,
+        })
+      }
+      return
+    }
+
+    if (action.type === 'setVariant') {
+      selectionByInstance.set(targetInstanceId, {
+        ...runtime.getInstanceSelection(targetInstanceId),
+        ...action.selection,
+      })
+      return
+    }
+
+    if (action.type === 'toggleVariant') {
+      const current = runtime.getInstanceSelection(targetInstanceId)
+      const next =
+        current[action.axis] === action.values[0]
+          ? action.values[1]
+          : action.values[0]
+      selectionByInstance.set(targetInstanceId, {
+        ...current,
+        [action.axis]: next,
+      })
+    }
+  }
+
+  return runtime
+}
+
+export function resolveComponentInstance(
+  api: SceneAPI,
+  instanceId: NodeId,
+): ComponentInstanceResolution | null {
+  const instance = api.getNode(instanceId)
+  if (!instance || instance.kind !== 'instance') return null
+  const component = api.getNode(instance.componentId)
+  if (!component || component.kind !== 'component') return null
+  const selection = {
+    ...component.defaultSelection,
+    ...instance.selection,
+  }
+  return {
+    instance,
+    component,
+    selection,
+    variantOverrides: resolveVariantOverrides(component, selection),
+    overrides: instance.overrides,
+    timelines: component.timelines,
+    interactions: [...component.interactions, ...instance.interactions],
+  }
+}
+
+export function resolveVariantOverrides(
+  component: ComponentNode,
+  selection: VariantSelection,
+): Record<NodeId, Record<string, unknown>> {
+  const out: Record<NodeId, Record<string, unknown>> = {}
+  for (const variant of component.variantOverrides) {
+    if (!variantMatches(variant.match, selection)) continue
+    for (const [nodeId, patch] of Object.entries(variant.overrides)) {
+      out[nodeId] = { ...(out[nodeId] ?? {}), ...patch }
+    }
+  }
+  return out
+}
+
+function interactionMatches(
+  interaction: Interaction,
+  event: ComponentInteractionEvent,
+): boolean {
+  if (interaction.event !== event.type) return false
+  if (!interaction.sourceNodeId) return !event.sourceNodeId
+  return interaction.sourceNodeId === event.sourceNodeId
+}
+
+function resolveTargetInstanceId(
+  api: SceneAPI,
+  currentInstanceId: NodeId,
+  target: InteractionTarget | undefined,
+): NodeId | null {
+  if (!target || target.kind === 'self') return currentInstanceId
+  if (target.kind === 'instance') return target.instanceId
+  const node = api.getNode(target.nodeId)
+  return node?.kind === 'instance' ? node.id : null
+}
+
+function variantMatches(
+  match: VariantSelection,
+  selection: VariantSelection,
+): boolean {
+  for (const [axis, value] of Object.entries(match)) {
+    if (selection[axis] !== value) return false
+  }
+  return true
+}
+
+function applyTrack(
+  track: Track,
+  t: number,
+  into: AnimatedValue,
+  cache: Map<string, EasingEvaluator>,
+): void {
+  const kfs = track.keyframes
+  if (kfs.length === 0) return
+  let a = kfs[0]!
+  let b = kfs[kfs.length - 1]!
+  if (t <= a.time || kfs.length === 1) {
+    writeProperty(track.propertyId, a.value, into)
+    return
+  }
+  if (t >= b.time) {
+    writeProperty(track.propertyId, b.value, into)
+    return
+  }
+  for (let i = 0; i < kfs.length - 1; i++) {
+    const k0 = kfs[i]!
+    const k1 = kfs[i + 1]!
+    if (t >= k0.time && t <= k1.time) {
+      a = k0
+      b = k1
+      break
+    }
+  }
+  const span = b.time - a.time
+  const rawU = span <= 0 ? 0 : (t - a.time) / span
+  const cacheKey = `${track.id}:${a.id}`
+  let easer = cache.get(cacheKey)
+  if (!easer) {
+    easer = evaluator(a.easingOut ?? track.defaultEasing)
+    cache.set(cacheKey, easer)
+  }
+  const value = interpolateValue(track.propertyId, a.value, b.value, easer(rawU))
+  writeProperty(track.propertyId, value, into)
+}
+
+function interpolateValue(
+  _propertyId: PropertyId,
+  a: KeyframeValue,
+  b: KeyframeValue,
+  u: number,
+): KeyframeValue {
+  if (typeof a === 'number' && typeof b === 'number') return a + (b - a) * u
+  return u < 1 ? a : b
+}
+
+function writeProperty(
+  id: PropertyId,
+  value: KeyframeValue,
+  into: AnimatedValue,
+): void {
+  if (id === 'appearance.fill') {
+    if (typeof value === 'string') into.fill = value
+    return
+  }
+  if (typeof value !== 'number') return
+  switch (id) {
+    case 'transform.x': into.x = value; break
+    case 'transform.y': into.y = value; break
+    case 'transform.z': into.z = value; break
+    case 'transform.rotation': into.rotation = value; break
+    case 'transform.rotationX': into.rotationX = value; break
+    case 'transform.rotationY': into.rotationY = value; break
+    case 'transform.scaleX': into.scaleX = value; break
+    case 'transform.scaleY': into.scaleY = value; break
+    case 'transform.anchorX': into.anchorX = value; break
+    case 'transform.anchorY': into.anchorY = value; break
+    case 'transform.anchorZ': into.anchorZ = value; break
+    case 'appearance.opacity': into.opacity = value; break
+    case 'appearance.cornerRadius': into.cornerRadius = value; break
+    case 'camera.focusDistance': into.focusDistance = value; break
+    case 'camera.focusX': into.focusX = value; break
+    case 'camera.focusY': into.focusY = value; break
+    case 'camera.focusWorldX': into.focusWorldX = value; break
+    case 'camera.focusWorldY': into.focusWorldY = value; break
+    case 'camera.focusWorldZ': into.focusWorldZ = value; break
+    case 'camera.focusRadius': into.focusRadius = value; break
+    case 'camera.pointOfInterestX': into.pointOfInterestX = value; break
+    case 'camera.pointOfInterestY': into.pointOfInterestY = value; break
+    case 'camera.pointOfInterestZ': into.pointOfInterestZ = value; break
+    case 'camera.focalLength': into.focalLength = value; break
+    case 'camera.fieldOfView': into.fieldOfView = value; break
+    case 'camera.nearClip': into.nearClip = value; break
+    case 'camera.farClip': into.farClip = value; break
+    case 'camera.aperture': into.aperture = value; break
+    case 'camera.blurLevel': into.blurLevel = value; break
+    case 'camera.blurQuality': into.blurQuality = value; break
+    default: break
+  }
+}
+
+function positiveModulo(value: number, mod: number): number {
+  return ((value % mod) + mod) % mod
+}

--- a/src/interaction/index.ts
+++ b/src/interaction/index.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export {
+  createComponentInteractionRuntime,
+  resolveComponentInstance,
+  resolveVariantOverrides,
+} from './componentRuntime'
+export type {
+  ComponentInteractionEvent,
+  ComponentInteractionRuntime,
+  ComponentInstanceResolution,
+  RunningComponentTimeline,
+} from './componentRuntime'

--- a/src/layout/engine.ts
+++ b/src/layout/engine.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { loadYoga, type Node as YogaNode, type Yoga } from 'yoga-layout/load'
-import type { NodeId } from '@/scene'
+import type { Node as SceneNode, NodeId, SizeAxis } from '@/scene'
 import type { SceneAPI } from '@/scene/doc'
 import { applyChildLayoutForParent, applyNodeStyle } from '@/layout/mapper'
 import type { ContainerSize, Rect, SolvedLayout } from '@/layout/types'
@@ -55,6 +55,7 @@ export function solveLayout(
     const yNode = yoga.Node.create()
     created.push(yNode)
     applyNodeStyle(yoga, yNode, node)
+    applyComponentHugFallback(yNode, api, node)
 
     const parentLayout = 'layout' in node ? node.layout : null
 
@@ -103,14 +104,19 @@ export function solveLayout(
   const yRoot = build(rootId)
   if (!yRoot) return out
 
-  // The root node IS the artboard. Regardless of what size the root
-  // node stores (stale data, old sample scenes, edits that drift from
-  // meta.canvas), we pin Yoga's root width/height to the container —
-  // so the artboard always fills its visible box. Without this, a 640
-  // root inside a 1470 canvas leaves a dead strip on the right that
-  // users read as "the scene is smaller than the artboard."
-  yRoot.setWidth(container.width)
-  yRoot.setHeight(container.height)
+  // The scene root IS the artboard, so it fills the visible box. A
+  // component root is different: it can be edited as a Figma-style
+  // component whose width/height hug its children. Do not pin a hug
+  // component axis to the editor container or the inspector's Hug mode
+  // appears broken.
+  const rootNode = api.getNode(rootId)
+  const rootIsHugComponent = rootNode?.kind === 'component'
+  if (!rootIsHugComponent || rootNode.size.width !== 'hug') {
+    yRoot.setWidth(container.width)
+  }
+  if (!rootIsHugComponent || rootNode.size.height !== 'hug') {
+    yRoot.setHeight(container.height)
+  }
 
   // Solve into the provided container. Yoga lays out left-to-right; RTL
   // is a future concern, gated by a scene-meta flag we don't have yet.
@@ -141,4 +147,64 @@ export function solveLayout(
   for (const n of created) n.free()
 
   return out
+}
+
+function applyComponentHugFallback(
+  yNode: YogaNode,
+  api: SceneAPI,
+  node: SceneNode,
+): void {
+  if (node.kind !== 'component' || node.layout.mode !== 'none') return
+  const needsWidth = node.size.width === 'hug'
+  const needsHeight = node.size.height === 'hug'
+  if (!needsWidth && !needsHeight) return
+  const bounds = measureAbsoluteChildren(api, node.id)
+  if (!bounds) return
+  if (needsWidth) yNode.setWidth(Math.max(1, bounds.width))
+  if (needsHeight) yNode.setHeight(Math.max(1, bounds.height))
+}
+
+function measureAbsoluteChildren(
+  api: SceneAPI,
+  parentId: NodeId,
+): { width: number; height: number } | null {
+  const children = api.getChildren(parentId)
+  if (children.length === 0) return null
+  let maxX = 0
+  let maxY = 0
+  for (const child of children) {
+    const size = measureNodeSize(api, child)
+    maxX = Math.max(maxX, child.transform.x + size.width)
+    maxY = Math.max(maxY, child.transform.y + size.height)
+  }
+  return { width: maxX, height: maxY }
+}
+
+function measureNodeSize(
+  api: SceneAPI,
+  node: SceneNode,
+): { width: number; height: number } {
+  if (node.kind === 'text') {
+    const textWidth = Math.max(1, node.text.length * node.fontSize * 0.58)
+    const textHeight = Math.max(1, node.fontSize * node.lineHeight)
+    return {
+      width: measureAxis(node.size.width, textWidth),
+      height: measureAxis(node.size.height, textHeight),
+    }
+  }
+  if ('size' in node) {
+    const nested =
+      'layout' in node && node.layout.mode === 'none'
+        ? measureAbsoluteChildren(api, node.id)
+        : null
+    return {
+      width: measureAxis(node.size.width, nested?.width ?? 100),
+      height: measureAxis(node.size.height, nested?.height ?? 100),
+    }
+  }
+  return { width: 100, height: 100 }
+}
+
+function measureAxis(value: SizeAxis, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
 }

--- a/src/render/RenderWindowApp.tsx
+++ b/src/render/RenderWindowApp.tsx
@@ -15,8 +15,7 @@ import { useLayout } from '@/ui/hooks/useLayout'
 import { useAnimatedValues } from '@/ui/hooks/useAnimatedValues'
 import { setLastSolvedLayout } from '@/ui/hooks/lastSolvedLayout'
 import {
-  SceneLayer,
-  CameraFocusBlurOverlay,
+  ScenePostProcessLayer,
   composeInheritedAnim,
   computeCameraDepthOfField,
   resolveCameraFocusTargetPoint,
@@ -287,9 +286,9 @@ function RenderCanvas({ job }: { job: RenderJob }) {
 
   const animated = useAnimatedValues(renderOrder)
   const inherited = useMemo(
-    () => composeInheritedAnim(api, rootId, animated),
+    () => composeInheritedAnim(api, rootId, animated, solved),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [api, rootId, animated, version],
+    [api, rootId, animated, solved, version],
   )
 
   // Camera composition — match the editor's behavior bit-for-bit.
@@ -344,6 +343,7 @@ function RenderCanvas({ job }: { job: RenderJob }) {
         solved ?? {},
         animated,
         inherited,
+        { width: canvasWidth, height: canvasHeight },
       )
       return computeCameraDepthOfField(
         camera && camera.kind === 'camera' ? camera : null,
@@ -434,19 +434,32 @@ function RenderCanvas({ job }: { job: RenderJob }) {
           // become truthy before starting. Defensive marker so a stalled
           // boot is visible during debugging.
           <span style={{ color: '#fff' }}>preparing layout…</span>
-        ) : (
-          <div
-            className="absolute inset-0"
-            style={
+        ) : camera && camera.kind === 'camera' ? (
+          <ScenePostProcessLayer
+            rootId={rootId}
+            solved={solved}
+            order={renderOrder}
+            animated={animated}
+            inherited={inherited}
+            cameraDepthOfField={cameraDepthOfField}
+            sceneFill={sceneFill}
+            canvasWidth={canvasWidth}
+            canvasHeight={canvasHeight}
+            sceneCorner={sceneCorner}
+            includeSceneFill
+            sceneContentStyle={
               cameraTransform
                 ? {
                     transform: cameraTransform,
                     transformOrigin: '0 0',
                     transformStyle: 'preserve-3d',
+                    backfaceVisibility: 'visible',
                   }
                 : undefined
             }
-          >
+          />
+        ) : (
+          <>
             {sceneFill ? (
               <div
                 className="pointer-events-none absolute"
@@ -460,17 +473,7 @@ function RenderCanvas({ job }: { job: RenderJob }) {
                 }}
               />
             ) : null}
-            <SceneLayer
-              rootId={rootId}
-              solved={solved}
-              order={renderOrder}
-              animated={animated}
-              inherited={inherited}
-              cameraDepthOfField={cameraDepthOfField}
-              // No-op — render window has no selection to drive.
-              onNodeClick={() => {}}
-            />
-            <CameraFocusBlurOverlay
+            <ScenePostProcessLayer
               rootId={rootId}
               solved={solved}
               order={renderOrder}
@@ -482,7 +485,7 @@ function RenderCanvas({ job }: { job: RenderJob }) {
               canvasHeight={canvasHeight}
               sceneCorner={sceneCorner}
             />
-          </div>
+          </>
         )}
       </div>
     </div>
@@ -617,6 +620,15 @@ async function runExportLoop(
               e instanceof Error ? e.message : String(e)
             }`,
           )
+        }
+        const focusEffect = resolveRenderWindowFocusEffect(
+          api,
+          engine.getSnapshot(),
+          sceneCanvas,
+          { width: canvasEl.width, height: canvasEl.height },
+        )
+        if (focusEffect) {
+          canvasEl = applyCanvasFocusBlur(canvasEl, focusEffect)
         }
 
         if (!encoder) {
@@ -768,6 +780,160 @@ function mimeForFormat(format: 'mp4' | 'webm' | 'gif'): string {
     case 'gif':
       return 'image/gif'
   }
+}
+
+interface ExportFocusEffect {
+  focusX: number
+  focusY: number
+  radius: number
+  feather: number
+  blurPx: number
+}
+
+function resolveRenderWindowFocusEffect(
+  api: ReturnType<typeof useSceneAPI>,
+  animated: ReturnType<ReturnType<typeof getAnimEngine>['getSnapshot']>,
+  sceneCanvas: { width: number; height: number },
+  outputCanvas: { width: number; height: number },
+): ExportFocusEffect | null {
+  const cameraId = api.getActiveCameraId()
+  const camera = cameraId ? api.getNode(cameraId) : null
+  if (!camera || camera.kind !== 'camera' || !camera.depthOfField) return null
+  const cameraAnim = animated[cameraId]
+  const cameraFocalLength = Math.max(50, camera.focalLength ?? 1000)
+  const cameraZ = cameraAnim?.z ?? camera.transform.z
+  const cameraDollyZ = cameraZ / 100
+  const cameraScale =
+    cameraFocalLength / Math.max(1, cameraFocalLength - cameraDollyZ)
+  const dof = computeCameraDepthOfField(
+    camera,
+    cameraAnim,
+    cameraScale,
+    sceneCanvas.width,
+    sceneCanvas.height,
+    null,
+  )
+  if (!dof || !dof.enabled || dof.blurPx <= 0.05) {
+    return null
+  }
+  const scaleX = outputCanvas.width / sceneCanvas.width
+  const scaleY = outputCanvas.height / sceneCanvas.height
+  const scale = (scaleX + scaleY) / 2
+  return {
+    focusX: dof.focusX * scaleX,
+    focusY: dof.focusY * scaleY,
+    radius: Math.max(1, dof.focusRadius * scale),
+    feather: Math.max(1, dof.featherPx * scale),
+    blurPx: Math.max(0, dof.blurPx * scale),
+  }
+}
+
+function applyCanvasFocusBlur(
+  source: HTMLCanvasElement,
+  focus: ExportFocusEffect,
+): HTMLCanvasElement {
+  const width = source.width
+  const height = source.height
+  const blur = Math.max(0, Math.min(128, focus.blurPx))
+  if (width <= 0 || height <= 0 || blur <= 0.05) return source
+
+  const blurred = document.createElement('canvas')
+  blurred.width = width
+  blurred.height = height
+  const blurredCtx = blurred.getContext('2d', { alpha: false })
+  if (!blurredCtx) return source
+
+  // Blur needs pixels outside the frame. If we blur the exact-size canvas,
+  // Chromium samples transparent/black beyond the edges, which creates a
+  // dark vignette at high blur values. Build a padded edge-clamped copy
+  // first, blur that, then crop the original frame region back out.
+  const pad = Math.max(8, Math.ceil(blur * 3))
+  const padded = document.createElement('canvas')
+  padded.width = width + pad * 2
+  padded.height = height + pad * 2
+  const paddedCtx = padded.getContext('2d', { alpha: false })
+  if (!paddedCtx) return source
+  paddedCtx.drawImage(source, pad, pad, width, height)
+  paddedCtx.drawImage(source, 0, 0, width, 1, pad, 0, width, pad)
+  paddedCtx.drawImage(
+    source,
+    0,
+    height - 1,
+    width,
+    1,
+    pad,
+    pad + height,
+    width,
+    pad,
+  )
+  paddedCtx.drawImage(source, 0, 0, 1, height, 0, pad, pad, height)
+  paddedCtx.drawImage(
+    source,
+    width - 1,
+    0,
+    1,
+    height,
+    pad + width,
+    pad,
+    pad,
+    height,
+  )
+  paddedCtx.drawImage(source, 0, 0, 1, 1, 0, 0, pad, pad)
+  paddedCtx.drawImage(source, width - 1, 0, 1, 1, pad + width, 0, pad, pad)
+  paddedCtx.drawImage(source, 0, height - 1, 1, 1, 0, pad + height, pad, pad)
+  paddedCtx.drawImage(
+    source,
+    width - 1,
+    height - 1,
+    1,
+    1,
+    pad + width,
+    pad + height,
+    pad,
+    pad,
+  )
+
+  const paddedBlur = document.createElement('canvas')
+  paddedBlur.width = padded.width
+  paddedBlur.height = padded.height
+  const paddedBlurCtx = paddedBlur.getContext('2d', { alpha: false })
+  if (!paddedBlurCtx) return source
+  paddedBlurCtx.filter = `blur(${Number(blur.toFixed(2))}px)`
+  paddedBlurCtx.drawImage(padded, 0, 0)
+  blurredCtx.drawImage(paddedBlur, pad, pad, width, height, 0, 0, width, height)
+
+  const sharp = document.createElement('canvas')
+  sharp.width = width
+  sharp.height = height
+  const sharpCtx = sharp.getContext('2d')
+  if (!sharpCtx) return source
+  sharpCtx.drawImage(source, 0, 0, width, height)
+  sharpCtx.globalCompositeOperation = 'destination-in'
+  const radius = Math.max(1, focus.radius)
+  const feather = Math.max(1, focus.feather)
+  const gradient = sharpCtx.createRadialGradient(
+    focus.focusX,
+    focus.focusY,
+    radius,
+    focus.focusX,
+    focus.focusY,
+    radius + feather,
+  )
+  gradient.addColorStop(0, 'rgba(0, 0, 0, 1)')
+  gradient.addColorStop(0.35, 'rgba(0, 0, 0, 0.85)')
+  gradient.addColorStop(0.72, 'rgba(0, 0, 0, 0.38)')
+  gradient.addColorStop(1, 'rgba(0, 0, 0, 0)')
+  sharpCtx.fillStyle = gradient
+  sharpCtx.fillRect(0, 0, width, height)
+
+  const output = document.createElement('canvas')
+  output.width = width
+  output.height = height
+  const outputCtx = output.getContext('2d', { alpha: false })
+  if (!outputCtx) return source
+  outputCtx.drawImage(blurred, 0, 0)
+  outputCtx.drawImage(sharp, 0, 0)
+  return output
 }
 
 function waitForFrames(n: number): Promise<void> {

--- a/src/render/SnapshotCompositor.tsx
+++ b/src/render/SnapshotCompositor.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react'
+
+export interface SnapshotFocusEffect {
+  enabled: boolean
+  focusX: number
+  focusY: number
+  radius: number
+  feather: number
+  blurPx: number
+  iso?: number
+}
+
+interface SnapshotCompositorProps {
+  width: number
+  height: number
+  focus?: SnapshotFocusEffect | null
+  children: ReactNode
+}
+
+/**
+ * Snapshot/effects compositor boundary.
+ *
+ * Today this uses DOM/CSS passes as a live-editor preview. The important
+ * architectural point is the boundary: callers render scene content once
+ * as `children`, and this component owns the effect passes. The WebGL
+ * version can replace each pass with a rasterized texture + shader
+ * without changing scene layout, camera controls, or group3d behavior.
+ */
+export function SnapshotCompositor({
+  width,
+  height,
+  focus,
+  children,
+}: SnapshotCompositorProps) {
+  if (!focus?.enabled || focus.blurPx <= 0.05) return <>{children}</>
+
+  const radius = Math.max(1, focus.radius)
+  const feather = Math.max(1, focus.feather)
+  const blur = Number(focus.blurPx.toFixed(2))
+  const mask =
+    `radial-gradient(circle at ${focus.focusX}px ${focus.focusY}px, ` +
+    `black 0px, ` +
+    `black ${Number(radius.toFixed(2))}px, ` +
+    `rgba(0,0,0,0.88) ${Number((radius + feather * 0.18).toFixed(2))}px, ` +
+    `rgba(0,0,0,0.4) ${Number((radius + feather * 0.55).toFixed(2))}px, ` +
+    `transparent ${Number((radius + feather).toFixed(2))}px)`
+  const baseScale = 1 + Math.min(0.035, blur / Math.max(width, height))
+  const grainSize = Math.max(2, 900 / Math.max(100, focus.iso ?? 100))
+  const isRenderWindow =
+    typeof window !== 'undefined' &&
+    new URLSearchParams(window.location.search).get('render-window') === '1'
+  if (isRenderWindow) return <>{children}</>
+
+  return (
+    <div
+      className="absolute inset-0"
+      data-snapshot-compositor="1"
+      data-snapshot-backend="css-preview"
+      style={{ width, height }}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        data-snapshot-pass="blurred-base"
+        style={{
+          filter: `blur(${blur}px)`,
+          transform: `scale(${Number(baseScale.toFixed(4))}) translateZ(0)`,
+          transformOrigin: 'center center',
+          willChange: 'filter, transform',
+        }}
+      >
+        {children}
+      </div>
+      <div
+        className="absolute inset-0"
+        data-snapshot-pass="sharp-focus-mask"
+        style={{
+          WebkitMaskImage: mask,
+          maskImage: mask,
+          WebkitMaskRepeat: 'no-repeat',
+          maskRepeat: 'no-repeat',
+          willChange: 'mask-image, -webkit-mask-image',
+        }}
+      >
+        {children}
+      </div>
+      {(focus.iso ?? 100) > 100 ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 opacity-[0.035] mix-blend-multiply"
+          data-snapshot-pass="grain"
+          style={{
+            backgroundImage:
+              'radial-gradient(circle at 20% 30%, #000 0 0.7px, transparent 0.8px), radial-gradient(circle at 70% 60%, #000 0 0.6px, transparent 0.7px)',
+            backgroundSize: `${grainSize}px ${grainSize}px`,
+          }}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/render3d/ThreeSceneViewport.tsx
+++ b/src/render3d/ThreeSceneViewport.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 import type { AnimatedValue } from '@/anim'
 import type { Rect, SolvedLayout } from '@/layout'
@@ -57,6 +57,7 @@ export function ThreeSceneViewport({
   const cameraRef = useRef<THREE.PerspectiveCamera | null>(null)
   const planesRef = useRef<Map<NodeId, PlaneRecord>>(new Map())
   const helpersRef = useRef<THREE.Group | null>(null)
+  const [webglUnavailable, setWebglUnavailable] = useState(false)
 
   const resolvedCamera = useMemo(
     () => resolveCamera3D(camera, cameraAnim, { width, height }),
@@ -68,9 +69,17 @@ export function ThreeSceneViewport({
   )
 
   useEffect(() => {
+    if (webglUnavailable) return
     const host = hostRef.current
     if (!host) return
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
+    let renderer: THREE.WebGLRenderer
+    try {
+      renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
+    } catch (error) {
+      console.warn('3D helper disabled: WebGL context creation failed.', error)
+      setWebglUnavailable(true)
+      return
+    }
     renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1))
     renderer.setSize(width, height, false)
     renderer.sortObjects = true
@@ -109,18 +118,20 @@ export function ThreeSceneViewport({
     }
     // Create renderer once per mount; resizing is handled below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [webglUnavailable])
 
   useEffect(() => {
+    if (webglUnavailable) return
     const renderer = rendererRef.current
     const perspective = cameraRef.current
     if (!renderer || !perspective) return
     renderer.setSize(width, height, false)
     perspective.aspect = width / Math.max(1, height)
     perspective.updateProjectionMatrix()
-  }, [width, height])
+  }, [webglUnavailable, width, height])
 
   useEffect(() => {
+    if (webglUnavailable) return
     const scene = sceneRef.current
     const perspective = cameraRef.current
     const renderer = rendererRef.current
@@ -153,7 +164,9 @@ export function ThreeSceneViewport({
     )
 
     renderer.render(scene, perspective)
-  }, [api, layout, planes, resolvedCamera, sceneFill, selectedIds, showHelpers, showPlanes, focusWorldPoint, width, height])
+  }, [api, layout, planes, resolvedCamera, sceneFill, selectedIds, showHelpers, showPlanes, focusWorldPoint, width, height, webglUnavailable])
+
+  if (webglUnavailable) return null
 
   return (
     <div
@@ -290,6 +303,7 @@ function queueDomPlaneTexture(
   scene: THREE.Scene,
   perspective: THREE.PerspectiveCamera,
 ) {
+  if (plane.contentMode === 'self') return
   const request = record.textureRequest + 1
   record.textureRequest = request
   renderDomPlaneTexture(plane.rect, blurPx).then((canvas) => {
@@ -369,6 +383,9 @@ function renderPlaneCanvas(
   plane: Plane3D,
   blurPx: number,
 ): HTMLCanvasElement {
+  if (plane.contentMode === 'self') {
+    return renderPlaneTexture(plane.node, plane.rect, blurPx)
+  }
   return (
     renderSubtreeTexture(api, layout, plane.nodeId, plane.rect, blurPx) ??
     renderPlaneTexture(plane.node, plane.rect, blurPx)

--- a/src/render3d/scene3d.ts
+++ b/src/render3d/scene3d.ts
@@ -42,6 +42,7 @@ export interface Plane3D {
   nodeId: NodeId
   node: Node
   rect: Rect
+  contentMode: 'self' | 'subtree'
   paintOrder: number
   center: Vec3
   rotation: Vec3
@@ -73,9 +74,11 @@ export interface FocusHit3D {
 }
 
 const IDENTITY_INHERITED = {
-  x: 0,
-  y: 0,
-  z: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  anchor: { x: 0, y: 0, z: 0 },
+  basisX: { x: 1, y: 0, z: 0 },
+  basisY: { x: 0, y: 1, z: 0 },
+  basisZ: { x: 0, y: 0, z: 1 },
   rotation: 0,
   rotationX: 0,
   rotationY: 0,
@@ -84,9 +87,11 @@ const IDENTITY_INHERITED = {
 }
 
 interface Inherited3D {
-  x: number
-  y: number
-  z: number
+  origin: Vec3
+  anchor: Vec3
+  basisX: Vec3
+  basisY: Vec3
+  basisZ: Vec3
   rotation: number
   rotationX: number
   rotationY: number
@@ -261,6 +266,24 @@ export function buildWorldPlanes(
   if (!rootId) return []
   const planes: Plane3D[] = []
 
+  const mapPoint = (transform: Inherited3D, point: Vec3): Vec3 =>
+    add3(
+      transform.origin,
+      add3(
+        add3(
+          mul3(transform.basisX, point.x - transform.anchor.x),
+          mul3(transform.basisY, point.y - transform.anchor.y),
+        ),
+        mul3(transform.basisZ, point.z - transform.anchor.z),
+      ),
+    )
+
+  const mapLocalVector = (transform: Inherited3D, vector: Vec3): Vec3 =>
+    add3(
+      add3(mul3(transform.basisX, vector.x), mul3(transform.basisY, vector.y)),
+      mul3(transform.basisZ, vector.z),
+    )
+
   const visit = (id: NodeId, inherited: Inherited3D): void => {
     const node = api.getNode(id)
     const rect = layout[id]
@@ -280,24 +303,29 @@ export function buildWorldPlanes(
       y: (a?.anchorY ?? node.transform.anchorY ?? 0.5) * rect.height,
       z: a?.anchorZ ?? node.transform.anchorZ ?? 0,
     }
-    const nextInherited: Inherited3D = isRoot
-      ? {
-          ...inherited,
-          z: inherited.z + z,
-          rotation: inherited.rotation + rotation,
-          rotationX: inherited.rotationX + rotationX,
-          rotationY: inherited.rotationY + rotationY,
-        }
-      : {
-          x: inherited.x + x,
-          y: inherited.y + y,
-          z: inherited.z + z,
-          rotation: inherited.rotation + rotation,
-          rotationX: inherited.rotationX + rotationX,
-          rotationY: inherited.rotationY + rotationY,
-          scaleX: inherited.scaleX * scaleX,
-          scaleY: inherited.scaleY * scaleY,
-        }
+    const anchorPoint = {
+      x: rect.x + anchor.x,
+      y: rect.y + anchor.y,
+      z: anchor.z,
+    }
+    const translation = isRoot
+      ? mapLocalVector(inherited, { x: 0, y: 0, z })
+      : mapLocalVector(inherited, { x, y, z })
+    const localBasisX = rotateEuler({ x: isRoot ? 1 : scaleX, y: 0, z: 0 }, rotationX, rotationY, rotation)
+    const localBasisY = rotateEuler({ x: 0, y: isRoot ? 1 : scaleY, z: 0 }, rotationX, rotationY, rotation)
+    const localBasisZ = rotateEuler({ x: 0, y: 0, z: 1 }, rotationX, rotationY, rotation)
+    const nextInherited: Inherited3D = {
+      origin: add3(mapPoint(inherited, anchorPoint), translation),
+      anchor: anchorPoint,
+      basisX: mapLocalVector(inherited, localBasisX),
+      basisY: mapLocalVector(inherited, localBasisY),
+      basisZ: mapLocalVector(inherited, localBasisZ),
+      rotation: inherited.rotation + rotation,
+      rotationX: inherited.rotationX + rotationX,
+      rotationY: inherited.rotationY + rotationY,
+      scaleX: isRoot ? inherited.scaleX : inherited.scaleX * scaleX,
+      scaleY: isRoot ? inherited.scaleY : inherited.scaleY * scaleY,
+    }
 
     const parent = node.parent ? api.getNode(node.parent) : null
     const renderMode = node.transform.renderMode ?? 'flat'
@@ -314,18 +342,19 @@ export function buildWorldPlanes(
       const rotX = nextInherited.rotationX
       const rotY = nextInherited.rotationY
       const rotZ = nextInherited.rotation
-      const right = norm3(rotateEuler({ x: 1, y: 0, z: 0 }, rotX, rotY, rotZ))
-      const down = norm3(rotateEuler({ x: 0, y: 1, z: 0 }, rotX, rotY, rotZ))
-      const normal = norm3(rotateEuler({ x: 0, y: 0, z: 1 }, rotX, rotY, rotZ))
-      const center = {
-        x: rect.x + rect.width / 2 + nextInherited.x,
-        y: rect.y + rect.height / 2 + nextInherited.y,
-        z: nextInherited.z,
-      }
+      const right = norm3(nextInherited.basisX)
+      const down = norm3(nextInherited.basisY)
+      const normal = norm3(nextInherited.basisZ)
+      const center = mapPoint(nextInherited, {
+        x: rect.x + rect.width / 2,
+        y: rect.y + rect.height / 2,
+        z: 0,
+      })
       planes.push({
         nodeId: id,
         node,
         rect,
+        contentMode: renderMode === 'group3d' ? 'self' : 'subtree',
         paintOrder: planes.length,
         center,
         rotation: { x: rotX, y: rotY, z: rotZ },

--- a/src/scene/doc.ts
+++ b/src/scene/doc.ts
@@ -171,6 +171,7 @@ export interface NodeBaseMutable {
   size: Size
   visible: boolean
   locked: boolean
+  position: import('@/scene/types').Position
   text: string
   // image-kind fields — settable via Inspector on ImageNode. The scene
   // API doesn't (yet) enforce that these keys only land on an image
@@ -178,6 +179,7 @@ export interface NodeBaseMutable {
   // `node.kind === 'image'`.
   src: string
   fit: 'cover' | 'contain' | 'fill' | 'none'
+  importWarning: string
   // camera-kind fields — settable via Inspector on CameraNode.
   /** Camera's viewport-wide background fill. Null = no fill. */
   background: Fill | null
@@ -199,6 +201,8 @@ export interface NodeBaseMutable {
   focusWorldZ: number
   focusTargetNodeId: NodeId | null
   focusDistance: number
+  focusRadius: number
+  focusFalloff: number
   aperture: number
   iso: number
   blurLevel: number
@@ -314,6 +318,13 @@ function normalizeLayout(raw: unknown): Layout {
 
 const DEFAULT_SIZE: Size = { width: 100, height: 100 }
 
+const DEFAULT_VARIANT_TRANSITION: import('@/scene/types').VariantTransition = {
+  duration: 0.3,
+  easing: 'ease-in-out',
+  presetId: 'smooth',
+  strength: 50,
+}
+
 // ---------------------------------------------------------------------------
 // Y.Doc factory + API
 // ---------------------------------------------------------------------------
@@ -370,13 +381,21 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
   }
 
   const yNodeToNode = (y: Y.Map<unknown>): Node => {
-    const childrenArr = y.get('children') as Y.Array<NodeId> | undefined
+    const childrenValue = y.get('children') as
+      | Y.Array<NodeId>
+      | NodeId[]
+      | undefined
+    const children = Array.isArray(childrenValue)
+      ? childrenValue
+      : childrenValue
+        ? childrenValue.toArray()
+        : []
     const base = {
       id: y.get('id') as NodeId,
       name: (y.get('name') as string) ?? 'Layer',
       kind: y.get('kind') as NodeKind,
       parent: (y.get('parent') as NodeId | null) ?? null,
-      children: childrenArr ? childrenArr.toArray() : [],
+      children,
       // Ensure `z` exists on every read — older docs predate the
       // 3D-camera era and persisted Transform without `z`. Spread
       // defaults under the persisted shape so the field is always
@@ -395,6 +414,9 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
       // mask feature. createNode writes false explicitly so newly-
       // created nodes are also non-masks until the user opts in.
       isMask: ((y.get('isMask') as boolean | undefined) ?? false),
+      componentSourceId:
+        (y.get('componentSourceId') as NodeId | null | undefined) ?? null,
+      workspaceOnly: (y.get('workspaceOnly') as boolean | undefined) ?? false,
     }
     const kind = base.kind
     switch (kind) {
@@ -418,7 +440,11 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
           kind,
           size: (y.get('size') as Size) ?? DEFAULT_SIZE,
           ...(kind === 'image'
-            ? { src: (y.get('src') as string) ?? '', fit: (y.get('fit') as 'cover' | 'contain' | 'fill' | 'none') ?? 'cover' }
+            ? {
+                src: (y.get('src') as string) ?? '',
+                fit: (y.get('fit') as 'cover' | 'contain' | 'fill' | 'none') ?? 'cover',
+                importWarning: (y.get('importWarning') as string | undefined) ?? undefined,
+              }
             : {}),
         } as Node
       case 'video':
@@ -471,19 +497,44 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
           kind,
           size: (y.get('size') as Size) ?? DEFAULT_SIZE,
           layout: normalizeLayout(y.get('layout')),
-          variants: (y.get('variants') as never[]) ?? [],
-          defaultSelection: (y.get('defaultSelection') as Record<string, string>) ?? {},
-          variantOverrides: (y.get('variantOverrides') as never[]) ?? [],
+          variants:
+            (y.get('variants') as import('@/scene/types').VariantAxis[]) ?? [],
+          defaultSelection:
+            (y.get('defaultSelection') as Record<string, string>) ?? {},
+          variantOverrides:
+            (y.get('variantOverrides') as import('@/scene/types').VariantOverride[]) ?? [],
+          variantPositions:
+            (y.get('variantPositions') as import('@/scene/types').ComponentNode['variantPositions']) ?? {},
+          componentProperties:
+            (y.get('componentProperties') as import('@/scene/types').ComponentPropertyDefinition[]) ?? [],
+          variantTransition:
+            (y.get('variantTransition') as import('@/scene/types').VariantTransition) ??
+            DEFAULT_VARIANT_TRANSITION,
+          timelines:
+            (y.get('timelines') as import('@/scene/types').ComponentNode['timelines']) ?? {},
+          interactions:
+            (y.get('interactions') as import('@/scene/types').Interaction[]) ?? [],
         } as Node
       case 'instance':
         return {
           ...base,
           kind,
+          size: (y.get('size') as Size) ?? DEFAULT_SIZE,
+          layout: normalizeLayout(y.get('layout')),
           componentId: y.get('componentId') as NodeId,
           selection: (y.get('selection') as Record<string, string>) ?? {},
           overrides: (y.get('overrides') as Record<NodeId, Record<string, unknown>>) ?? {},
+          interactions:
+            (y.get('interactions') as import('@/scene/types').Interaction[]) ?? [],
         } as Node
       case 'camera': {
+        const canvas =
+          (meta.get('canvas') as SceneMeta['canvas'] | undefined) ??
+          DEFAULT_META.canvas
+        const centerX = canvas.width / 2
+        const centerY = canvas.height / 2
+        const rawFocusX = y.get('focusX') as number | undefined
+        const rawFocusY = y.get('focusY') as number | undefined
         return {
           ...base,
           kind,
@@ -515,27 +566,23 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
           farClip: (y.get('farClip') as number | undefined) ?? 100000,
           depthOfField: (y.get('depthOfField') as boolean | undefined) ?? false,
           focusMode:
-            (y.get('focusMode') as CameraNode['focusMode'] | undefined) ?? 'plane',
-          focusX:
-            (y.get('focusX') as number | undefined) ??
-            ((y.get('transform') as Transform | undefined)?.x ?? 0),
-          focusY:
-            (y.get('focusY') as number | undefined) ??
-            ((y.get('transform') as Transform | undefined)?.y ?? 0),
+            (y.get('focusMode') as CameraNode['focusMode'] | undefined) ?? 'screen',
+          focusX: rawFocusX ?? centerX,
+          focusY: rawFocusY ?? centerY,
           focusWorldX:
             (y.get('focusWorldX') as number | undefined) ??
-            ((y.get('focusX') as number | undefined) ??
-              ((y.get('transform') as Transform | undefined)?.x ?? 0)),
+            (rawFocusX ?? centerX),
           focusWorldY:
             (y.get('focusWorldY') as number | undefined) ??
-            ((y.get('focusY') as number | undefined) ??
-              ((y.get('transform') as Transform | undefined)?.y ?? 0)),
+            (rawFocusY ?? centerY),
           focusWorldZ:
             (y.get('focusWorldZ') as number | undefined) ??
             ((y.get('focusDistance') as number | undefined) ?? 0),
           focusTargetNodeId:
             (y.get('focusTargetNodeId') as NodeId | null | undefined) ?? null,
           focusDistance: (y.get('focusDistance') as number | undefined) ?? 0,
+          focusRadius: (y.get('focusRadius') as number | undefined) ?? 160,
+          focusFalloff: (y.get('focusFalloff') as number | undefined) ?? 180,
           aperture: (y.get('aperture') as number | undefined) ?? 0,
           iso: (y.get('iso') as number | undefined) ?? 100,
           blurLevel: (y.get('blurLevel') as number | undefined) ?? 1,
@@ -602,9 +649,16 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
     getChildren: (id) => {
       const y = nodes.get(id)
       if (!y) return []
-      const arr = y.get('children') as Y.Array<NodeId> | undefined
-      if (!arr) return []
-      return arr.toArray()
+      const childrenValue = y.get('children') as
+        | Y.Array<NodeId>
+        | NodeId[]
+        | undefined
+      const childIds = Array.isArray(childrenValue)
+        ? childrenValue
+        : childrenValue
+          ? childrenValue.toArray()
+          : []
+      return childIds
         .map((cid) => nodes.get(cid))
         .filter((n): n is Y.Map<unknown> => !!n)
         .map(yNodeToNode)
@@ -655,6 +709,11 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
         y.set('position', (props as { position?: 'flow' | 'absolute' })?.position ?? 'flow')
         // Mask flag — see NodeBase.isMask for semantics. Default false.
         y.set('isMask', (props as { isMask?: boolean })?.isMask ?? false)
+        y.set(
+          'componentSourceId',
+          (props as { componentSourceId?: NodeId | null })?.componentSourceId ?? null,
+        )
+        y.set('workspaceOnly', (props as { workspaceOnly?: boolean })?.workspaceOnly ?? false)
 
         // kind-specific defaults
         if (kind === 'frame' || kind === 'component') {
@@ -666,6 +725,15 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
               'layoutGuides',
               (props as Partial<FrameNode>)?.layoutGuides ?? [],
             )
+          } else {
+            const cp = props as Partial<import('@/scene/types').ComponentNode> | undefined
+            y.set('variants', cp?.variants ?? [])
+            y.set('defaultSelection', cp?.defaultSelection ?? {})
+            y.set('variantOverrides', cp?.variantOverrides ?? [])
+            y.set('componentProperties', cp?.componentProperties ?? [])
+            y.set('variantTransition', cp?.variantTransition ?? DEFAULT_VARIANT_TRANSITION)
+            y.set('timelines', cp?.timelines ?? {})
+            y.set('interactions', cp?.interactions ?? [])
           }
         }
         if (kind === 'rect' || kind === 'ellipse' || kind === 'image') {
@@ -708,6 +776,16 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
           const ip = props as Partial<ImageNode> | undefined
           y.set('src', ip?.src ?? '')
           y.set('fit', ip?.fit ?? 'cover')
+          if (ip?.importWarning) y.set('importWarning', ip.importWarning)
+        }
+        if (kind === 'instance') {
+          const ip = props as Partial<import('@/scene/types').InstanceNode> | undefined
+          y.set('size', ip?.size ?? DEFAULT_SIZE)
+          y.set('layout', ip?.layout ?? DEFAULT_LAYOUT)
+          y.set('componentId', ip?.componentId ?? '')
+          y.set('selection', ip?.selection ?? {})
+          y.set('overrides', ip?.overrides ?? {})
+          y.set('interactions', ip?.interactions ?? [])
         }
         if (kind === 'text') {
           // Text boxes default to hug/hug so a plain stamp ("click with
@@ -751,15 +829,22 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
           y.set('pointOfInterestZ', cp?.pointOfInterestZ ?? (cp?.focusWorldZ ?? 0))
           y.set('nearClip', cp?.nearClip ?? 1)
           y.set('farClip', cp?.farClip ?? 100000)
+          const canvas =
+            (meta.get('canvas') as SceneMeta['canvas'] | undefined) ??
+            DEFAULT_META.canvas
+          const centerX = canvas.width / 2
+          const centerY = canvas.height / 2
           y.set('depthOfField', cp?.depthOfField ?? false)
-          y.set('focusMode', cp?.focusMode ?? 'plane')
-          y.set('focusX', cp?.focusX ?? (cp?.transform?.x ?? 0))
-          y.set('focusY', cp?.focusY ?? (cp?.transform?.y ?? 0))
-          y.set('focusWorldX', cp?.focusWorldX ?? (cp?.focusX ?? (cp?.transform?.x ?? 0)))
-          y.set('focusWorldY', cp?.focusWorldY ?? (cp?.focusY ?? (cp?.transform?.y ?? 0)))
+          y.set('focusMode', cp?.focusMode ?? 'screen')
+          y.set('focusX', cp?.focusX ?? centerX)
+          y.set('focusY', cp?.focusY ?? centerY)
+          y.set('focusWorldX', cp?.focusWorldX ?? (cp?.focusX ?? centerX))
+          y.set('focusWorldY', cp?.focusWorldY ?? (cp?.focusY ?? centerY))
           y.set('focusWorldZ', cp?.focusWorldZ ?? (cp?.focusDistance ?? 0))
           y.set('focusTargetNodeId', cp?.focusTargetNodeId ?? null)
           y.set('focusDistance', cp?.focusDistance ?? 0)
+          y.set('focusRadius', cp?.focusRadius ?? 160)
+          y.set('focusFalloff', cp?.focusFalloff ?? 180)
           y.set('aperture', cp?.aperture ?? 0)
           y.set('iso', cp?.iso ?? 100)
           y.set('blurLevel', cp?.blurLevel ?? 1)
@@ -774,7 +859,11 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
           const p = ensureNode(parent)
           const arr = p.get('children') as Y.Array<NodeId>
           arr.push([id])
-        } else if (!scene.get('root') && kind !== 'camera') {
+        } else if (
+          !scene.get('root') &&
+          kind !== 'camera' &&
+          !((props as { workspaceOnly?: boolean })?.workspaceOnly ?? false)
+        ) {
           // First parentless non-camera node becomes the root. Cameras
           // are always parent=null but must never win root — the root
           // slot is reserved for the artboard Frame.
@@ -1043,6 +1132,30 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
             scaleX: 1,
             scaleY: 1,
           } satisfies Transform)
+        })
+      }
+      const hasFocusPositionTrack = Array.from(tracks.values()).some((track) => {
+        if ((track.get('nodeId') as NodeId | undefined) !== existingId) return false
+        const propertyId = track.get('propertyId') as PropertyId | undefined
+        return propertyId === 'camera.focusX' || propertyId === 'camera.focusY'
+      })
+      const focusMode = camY.get('focusMode') as CameraNode['focusMode'] | undefined
+      const focusX = camY.get('focusX') as number | undefined
+      const focusY = camY.get('focusY') as number | undefined
+      const isOldPlaneOriginFocus =
+        !hasFocusPositionTrack &&
+        (focusMode === undefined || focusMode === 'plane' || focusMode === 'screen') &&
+        (focusX === undefined || focusX === 0) &&
+        (focusY === undefined || focusY === 0)
+      if (isOldPlaneOriginFocus) {
+        doc.transact(() => {
+          camY.set('focusMode', 'screen')
+          camY.set('focusX', targetX)
+          camY.set('focusY', targetY)
+          camY.set('focusWorldX', targetX)
+          camY.set('focusWorldY', targetY)
+          camY.set('focusWorldZ', camY.get('focusWorldZ') ?? 0)
+          camY.set('focusTargetNodeId', null)
         })
       }
     }

--- a/src/scene/props.ts
+++ b/src/scene/props.ts
@@ -107,6 +107,14 @@ export const PROPERTIES: Record<PropertyId, PropertyDescriptor> = {
     id: 'camera.focusWorldZ', group: 'camera', label: 'Focus Z',
     layoutAffecting: false, interpolation: 'numeric', defaultValue: 0,
   },
+  'camera.focusRadius': {
+    id: 'camera.focusRadius', group: 'camera', label: 'Focus Radius',
+    layoutAffecting: false, interpolation: 'numeric', defaultValue: 160,
+  },
+  'camera.focusFalloff': {
+    id: 'camera.focusFalloff', group: 'camera', label: 'Focus Falloff',
+    layoutAffecting: false, interpolation: 'numeric', defaultValue: 180,
+  },
   'camera.pointOfInterestX': {
     id: 'camera.pointOfInterestX', group: 'camera', label: 'POI X',
     layoutAffecting: false, interpolation: 'numeric', defaultValue: 0,

--- a/src/scene/sample.ts
+++ b/src/scene/sample.ts
@@ -38,12 +38,13 @@ export function createSampleScene(api: SceneAPI): void {
       scaleX: 1,
       scaleY: 1,
     },
-    focusMode: 'plane',
+    focusMode: 'screen',
     focusX: canvasW / 2,
     focusY: canvasH / 2,
     focusWorldX: canvasW / 2,
     focusWorldY: canvasH / 2,
     focusWorldZ: 0,
+    focusRadius: 160,
   })
   api.setActiveCameraId(camId)
 

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -20,6 +20,8 @@ export type NodeId = string
 export type TrackId = string
 export type KeyframeId = string
 export type ComponentId = NodeId
+export type ComponentTimelineId = string
+export type InteractionId = string
 
 /** Size in canvas pixels, or an intrinsic-sizing token. */
 export type SizeAxis = number | 'hug' | 'fill'
@@ -426,6 +428,18 @@ interface NodeBase {
   /** Layout participation; 'flow' by default. See {@link Position}. */
   position: Position
   /**
+   * For materialized component instances, this points at the node inside
+   * the master component that this rendered copy mirrors. Null/undefined
+   * means the node is authored directly in the scene.
+   */
+  componentSourceId?: NodeId | null
+  /**
+   * Pasteboard-only nodes live beside the scene artboard. They are editable
+   * design assets, but they are not part of the scene root, timeline, camera
+   * view, or export output.
+   */
+  workspaceOnly?: boolean
+  /**
    * When true, this node acts as a mask for the layer immediately
    * above it among its parent's children — Figma's mask convention,
    * where the bottom shape clips everything stacked above it within
@@ -492,6 +506,12 @@ export interface ImageNode extends NodeBase {
   size: Size
   src: string
   fit: 'cover' | 'contain' | 'fill' | 'none'
+  /**
+   * Optional user-facing import note. Used for Figma fallbacks where the
+   * visual was preserved as a bitmap because SVG/vector reconstruction
+   * would not match the original.
+   */
+  importWarning?: string
 }
 
 /**
@@ -620,9 +640,9 @@ export interface CameraNode extends NodeBase {
   farClip: number
   /** Enables camera depth-of-field blur. */
   depthOfField: boolean
-  /** Camera focus behavior. Plane is the physical default. */
+  /** Camera focus behavior. Screen focus is the editor default. */
   focusMode: 'plane' | 'target' | 'screen'
-  /** Canvas-space point used by screen-focus mode and as picker metadata. */
+  /** Camera-viewport point used by screen-focus mode and as picker metadata. */
   focusX: number
   focusY: number
   /** World-space point hit by the focus picker. Projected for the reticle. */
@@ -633,6 +653,10 @@ export interface CameraNode extends NodeBase {
   focusTargetNodeId: NodeId | null
   /** Z-depth plane that remains sharp, in canvas depth units. */
   focusDistance: number
+  /** Radius, in scene pixels, that remains sharp around the focus point. */
+  focusRadius: number
+  /** Feather distance, in scene pixels, from sharp focus to full blur. */
+  focusFalloff: number
   /** Lens opening multiplier. Larger values blur out-of-focus layers more. */
   aperture: number
   /** Sensor sensitivity. Higher values add stronger camera grain. */
@@ -660,15 +684,40 @@ export interface ComponentNode extends NodeBase {
   variants: VariantAxis[]
   defaultSelection: VariantSelection
   variantOverrides: VariantOverride[]
+  /** Freeform positions for variant tiles in the component editor board. */
+  variantPositions?: Record<string, { x: number; y: number }>
+  componentProperties: ComponentPropertyDefinition[]
+  variantTransition: VariantTransition
+  /**
+   * Reusable local timelines owned by this component definition.
+   * Unlike scene-level tracks, these do not run against the global
+   * playhead by default. An interaction starts them for one concrete
+   * instance, so ten button instances can all share the same "click"
+   * motion while each instance plays independently.
+   */
+  timelines: Record<ComponentTimelineId, ComponentTimeline>
+  /**
+   * Default event wiring for every instance of this component. Instance
+   * additions are merged at runtime, letting repeated items keep the
+   * shared press/hover feel while adding item-specific actions.
+   */
+  interactions: Interaction[]
 }
 
 /** A use of a component. Has its own variant selection and property overrides. */
 export interface InstanceNode extends NodeBase {
   kind: 'instance'
+  size: Size
+  layout: Layout
   componentId: ComponentId
   selection: VariantSelection
   /** Per-inner-node overrides, keyed by the inner node id inside the component. */
   overrides: Record<NodeId, Record<string, unknown>>
+  /**
+   * Instance-local interaction additions. These are appended to the
+   * component's default interactions for this one instance only.
+   */
+  interactions: Interaction[]
 }
 
 export type Node =
@@ -704,6 +753,94 @@ export interface VariantOverride {
   overrides: Record<NodeId, Record<string, unknown>>
 }
 
+export type ComponentPropertyType =
+  | 'text'
+  | 'fill'
+  | 'color'
+  | 'number'
+  | 'size'
+  | 'stroke'
+  | 'boolean'
+
+export interface ComponentPropertyDefinition {
+  id: string
+  name: string
+  nodeId: NodeId
+  path: string
+  type: ComponentPropertyType
+}
+
+export interface VariantTransition {
+  duration: number
+  easing: EasingKind
+  presetId?: string
+  strength?: number
+}
+
+// ---------------------------------------------------------------------------
+// Component motion + interactions
+// ---------------------------------------------------------------------------
+
+export interface ComponentTimeline {
+  id: ComponentTimelineId
+  name: string
+  /** Local duration in seconds. */
+  duration: number
+  /**
+   * Tracks target node ids inside the component definition. Runtime
+   * scopes the result to the clicked instance before applying it.
+   */
+  tracks: Track[]
+  loop?: boolean
+}
+
+export type InteractionEventKind =
+  | 'click'
+  | 'pointerDown'
+  | 'pointerUp'
+  | 'hoverIn'
+  | 'hoverOut'
+
+export type InteractionTarget =
+  | { kind: 'self' }
+  | { kind: 'instance'; instanceId: NodeId }
+  | { kind: 'node'; nodeId: NodeId }
+
+export type InteractionAction =
+  | {
+      type: 'playTimeline'
+      timelineId: ComponentTimelineId
+      target?: InteractionTarget
+      restart?: boolean
+    }
+  | {
+      type: 'setVariant'
+      selection: VariantSelection
+      target?: InteractionTarget
+    }
+  | {
+      type: 'toggleVariant'
+      axis: string
+      values: [string, string]
+      target?: InteractionTarget
+    }
+  | {
+      type: 'after'
+      delay: number
+      action: InteractionAction
+    }
+
+export interface Interaction {
+  id: InteractionId
+  /**
+   * Node inside the component definition that receives the event. If
+   * omitted, the component root handles the event.
+   */
+  sourceNodeId?: NodeId
+  event: InteractionEventKind
+  actions: InteractionAction[]
+}
+
 // ---------------------------------------------------------------------------
 // Animation: tracks, keyframes, property descriptors
 // ---------------------------------------------------------------------------
@@ -734,6 +871,8 @@ export type PropertyId =
   | 'camera.focusWorldX'
   | 'camera.focusWorldY'
   | 'camera.focusWorldZ'
+  | 'camera.focusRadius'
+  | 'camera.focusFalloff'
   | 'camera.pointOfInterestX'
   | 'camera.pointOfInterestY'
   | 'camera.pointOfInterestZ'

--- a/src/state/ui.ts
+++ b/src/state/ui.ts
@@ -79,26 +79,6 @@ function writeStoredNumber(key: string, value: number): void {
   }
 }
 
-/**
- * Read a stored string from localStorage, validating it against an
- * allowed set. Used for the timeline mode toggle so we don't have to
- * widen storage to arbitrary strings.
- */
-function readStoredEnum<T extends string>(
-  key: string,
-  allowed: readonly T[],
-  fallback: T,
-): T {
-  if (typeof window === 'undefined') return fallback
-  try {
-    const v = window.localStorage.getItem(key)
-    if (v && (allowed as readonly string[]).includes(v)) return v as T
-    return fallback
-  } catch {
-    return fallback
-  }
-}
-
 function readStoredTheme(): ThemePreference {
   if (typeof window === 'undefined') return 'system'
   try {
@@ -202,6 +182,7 @@ interface UIState {
   playing: boolean
   inspectorMode: InspectorMode
   view: WorkspaceView
+  componentEditId: string | null
   contextMenu: ContextMenuState | null
   /**
    * Layers-panel collapse state: set of node IDs whose children are
@@ -337,6 +318,7 @@ interface UIState {
   setPlaying: (p: boolean) => void
   setInspectorMode: (mode: InspectorMode) => void
   setView: (patch: Partial<WorkspaceView>) => void
+  setComponentEditId: (id: string | null) => void
   /**
    * Zoom around an origin-relative workspace point.
    *
@@ -498,6 +480,7 @@ export const useUI = create<UIState>((set) => ({
   playing: false,
   inspectorMode: 'properties',
   view: { zoom: 1, panX: 0, panY: 0 },
+  componentEditId: null,
   contextMenu: null,
   layersCollapsed: new Set<string>(),
   easingPresetId: 'smooth',
@@ -608,6 +591,14 @@ export const useUI = create<UIState>((set) => ({
   setPlaying: (p) => set({ playing: p }),
   setInspectorMode: (mode) => set({ inspectorMode: mode }),
   setView: (patch) => set((s) => ({ view: { ...s.view, ...patch } })),
+  setComponentEditId: (id) =>
+    set({
+      componentEditId: id,
+      selectedTrackId: null,
+      selectedTrackIds: [],
+      selectedKeyframes: [],
+      playing: false,
+    }),
   zoomAt: (nextZoom, originX, originY) =>
     set((s) => {
       const z = clamp(nextZoom, MIN_ZOOM, MAX_ZOOM)

--- a/src/ui/Canvas.tsx
+++ b/src/ui/Canvas.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import {
   useSceneAPI,
   useSceneVersion,
@@ -29,7 +29,9 @@ import { useDragToMove } from '@/ui/hooks/useDragToMove'
 import { buildNodeContextMenu } from '@/ui/contextMenuActions'
 import { importImageFiles, isImageFile } from '@/ui/importImage'
 import { importMediaFiles, isMediaFile } from '@/ui/importMedia'
+import { instantiateComponent } from '@/ui/actions'
 import { FloatingDock } from '@/ui/FloatingDock'
+import { SnapshotCompositor } from '@/render/SnapshotCompositor'
 import { ThreeSceneViewport } from '@/render3d/ThreeSceneViewport'
 import {
   buildWorldPlanes,
@@ -39,6 +41,7 @@ import {
 } from '@/render3d/scene3d'
 import {
   recordKeyframesForPatch,
+  stampToActiveTracksForPatch,
 } from '@/anim'
 
 /**
@@ -51,12 +54,11 @@ import {
  * parent (e.g. a Slide preset on a card) leaves its children stuck in
  * place while the parent alone slides — clearly broken.
  *
- * For each descendant we fold in every ancestor's (static + animated)
- *   translate   → additive
- *   rotation    → additive (uses each child's own pivot — approximate,
- *                 good enough for MVP pure-slide / pure-rotate)
- *   scaleX/Y    → multiplicative (same pivot caveat)
- *   opacity     → multiplicative
+ * When the layout snapshot is available we use a small 2D affine matrix
+ * for ancestor translation / rotationZ / scale around the ancestor pivot.
+ * That keeps children attached to rotated cards even though the DOM paint
+ * is still flat. 3D rotateX/Y/Z-depth are still carried as metadata and
+ * composed by NodeView.
  *
  * The root / artboard contributes nothing — its transform is clamped
  * to identity by `NodeView` so even if stale scene state had it tilted,
@@ -78,6 +80,72 @@ export interface InheritedAnim {
   opacity: number
 }
 
+interface Matrix2D {
+  a: number
+  b: number
+  c: number
+  d: number
+  e: number
+  f: number
+}
+
+const IDENTITY_MATRIX_2D: Matrix2D = {
+  a: 1,
+  b: 0,
+  c: 0,
+  d: 1,
+  e: 0,
+  f: 0,
+}
+
+function multiplyMatrix2D(left: Matrix2D, right: Matrix2D): Matrix2D {
+  return {
+    a: left.a * right.a + left.c * right.b,
+    b: left.b * right.a + left.d * right.b,
+    c: left.a * right.c + left.c * right.d,
+    d: left.b * right.c + left.d * right.d,
+    e: left.a * right.e + left.c * right.f + left.e,
+    f: left.b * right.e + left.d * right.f + left.f,
+  }
+}
+
+function transformPoint2D(matrix: Matrix2D, x: number, y: number): { x: number; y: number } {
+  return {
+    x: matrix.a * x + matrix.c * y + matrix.e,
+    y: matrix.b * x + matrix.d * y + matrix.f,
+  }
+}
+
+function nodeMatrix2D(
+  rect: Rect,
+  tx: number,
+  ty: number,
+  rotation: number,
+  scaleX: number,
+  scaleY: number,
+  anchorX: number,
+  anchorY: number,
+): Matrix2D {
+  const originX = rect.x + rect.width * anchorX
+  const originY = rect.y + rect.height * anchorY
+  const r = degToRad(rotation)
+  const c = Math.cos(r)
+  const s = Math.sin(r)
+  return multiplyMatrix2D(
+    { ...IDENTITY_MATRIX_2D, e: tx, f: ty },
+    multiplyMatrix2D(
+      { ...IDENTITY_MATRIX_2D, e: originX, f: originY },
+      multiplyMatrix2D(
+        { a: c, b: s, c: -s, d: c, e: 0, f: 0 },
+        multiplyMatrix2D(
+          { a: scaleX, b: 0, c: 0, d: scaleY, e: 0, f: 0 },
+          { ...IDENTITY_MATRIX_2D, e: -originX, f: -originY },
+        ),
+      ),
+    ),
+  )
+}
+
 export interface CameraDepthOfField {
   enabled: boolean
   mode: CameraNode['focusMode']
@@ -87,6 +155,7 @@ export interface CameraDepthOfField {
   focusWorldY: number
   focusWorldZ: number
   focusRadius: number
+  focusFalloff: number
   focusDistance: number
   aperture: number
   blurPx: number
@@ -95,6 +164,7 @@ export interface CameraDepthOfField {
   cameraZ: number
   cameraScale: number
   iso: number
+  blurQuality: number
   blurAxisDeg: number
 }
 
@@ -108,25 +178,8 @@ function degToRad(deg: number): number {
   return (deg * Math.PI) / 180
 }
 
-function dot3(a: Vec3, b: Vec3): number {
-  return a.x * b.x + a.y * b.y + a.z * b.z
-}
-
 function sub3(a: Vec3, b: Vec3): Vec3 {
   return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z }
-}
-
-function add3(a: Vec3, b: Vec3): Vec3 {
-  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z }
-}
-
-function mul3(v: Vec3, n: number): Vec3 {
-  return { x: v.x * n, y: v.y * n, z: v.z * n }
-}
-
-function norm3(v: Vec3): Vec3 {
-  const len = Math.hypot(v.x, v.y, v.z) || 1
-  return { x: v.x / len, y: v.y / len, z: v.z / len }
 }
 
 function rotateX(v: Vec3, deg: number): Vec3 {
@@ -148,10 +201,6 @@ function rotateZ(v: Vec3, deg: number): Vec3 {
   const c = Math.cos(r)
   const s = Math.sin(r)
   return { x: v.x * c - v.y * s, y: v.x * s + v.y * c, z: v.z }
-}
-
-function rotateEuler(v: Vec3, rotX: number, rotY: number, rotZ: number): Vec3 {
-  return rotateZ(rotateY(rotateX(v, rotX), rotY), rotZ)
 }
 
 function inverseRotateEuler(v: Vec3, rotX: number, rotY: number, rotZ: number): Vec3 {
@@ -209,11 +258,50 @@ export function composeInheritedAnim(
   api: SceneAPI,
   rootId: NodeId | null,
   animated: Record<NodeId, AnimatedValue>,
+  solved?: SolvedLayout | null,
 ): Record<NodeId, InheritedAnim> {
   const out: Record<NodeId, InheritedAnim> = {}
   if (!rootId) return out
-  const visit = (id: NodeId, inherited: InheritedAnim) => {
-    out[id] = inherited
+
+  interface InheritanceContext extends InheritedAnim {
+    matrix: Matrix2D
+  }
+  const identityContext: InheritanceContext = {
+    ...IDENTITY_INHERITED,
+    matrix: IDENTITY_MATRIX_2D,
+  }
+
+  const inheritForNode = (id: NodeId, context: InheritanceContext): InheritedAnim => {
+    const rect = solved?.[id]
+    if (!rect) {
+      return {
+        x: context.x,
+        y: context.y,
+        z: context.z,
+        rotation: context.rotation,
+        rotationX: context.rotationX,
+        rotationY: context.rotationY,
+        scaleX: context.scaleX,
+        scaleY: context.scaleY,
+        opacity: context.opacity,
+      }
+    }
+    const topLeft = transformPoint2D(context.matrix, rect.x, rect.y)
+    return {
+      x: topLeft.x - rect.x,
+      y: topLeft.y - rect.y,
+      z: context.z,
+      rotation: context.rotation,
+      rotationX: context.rotationX,
+      rotationY: context.rotationY,
+      scaleX: context.scaleX,
+      scaleY: context.scaleY,
+      opacity: context.opacity,
+    }
+  }
+
+  const visit = (id: NodeId, context: InheritanceContext) => {
+    out[id] = inheritForNode(id, context)
     const node = api.getNode(id)
     if (!node) return
     // Root translation/scale/opacity are treated as identity so the
@@ -235,32 +323,46 @@ export function composeInheritedAnim(
     const effSX = a?.scaleX ?? node.transform.scaleX
     const effSY = a?.scaleY ?? node.transform.scaleY
     const effOp = a?.opacity ?? node.appearance.opacity
+    const anchorX = a?.anchorX ?? node.transform.anchorX ?? 0.5
+    const anchorY = a?.anchorY ?? node.transform.anchorY ?? 0.5
+    const rect = solved?.[id]
     // Z is propagated as depth metadata for camera depth-of-field, but
     // it is still not included in the regular DOM transform below.
     // This keeps the surface visually 2D while letting a frame move an
     // entire subtree closer to or farther from the camera's focus plane.
-    const nextInherited: InheritedAnim = isRoot
+    const nodeMatrix =
+      rect && !isRoot
+        ? nodeMatrix2D(rect, effX, effY, effRot, effSX, effSY, anchorX, anchorY)
+        : rect && isRoot
+          ? nodeMatrix2D(rect, 0, 0, effRot, 1, 1, 0.5, 0.5)
+          : null
+    const nextMatrix = nodeMatrix
+      ? multiplyMatrix2D(context.matrix, nodeMatrix)
+      : context.matrix
+    const nextInherited: InheritanceContext = isRoot
       ? {
-          ...inherited,
-          z: inherited.z + effZ,
-          rotation: inherited.rotation + effRot,
-          rotationX: inherited.rotationX + effRotX,
-          rotationY: inherited.rotationY + effRotY,
+          ...context,
+          matrix: nextMatrix,
+          z: context.z + effZ,
+          rotation: context.rotation + effRot,
+          rotationX: context.rotationX + effRotX,
+          rotationY: context.rotationY + effRotY,
         }
       : {
-          x: inherited.x + effX,
-          y: inherited.y + effY,
-          z: inherited.z + effZ,
-          rotation: inherited.rotation + effRot,
-          rotationX: inherited.rotationX + effRotX,
-          rotationY: inherited.rotationY + effRotY,
-          scaleX: inherited.scaleX * effSX,
-          scaleY: inherited.scaleY * effSY,
-          opacity: inherited.opacity * effOp,
+          x: context.x + effX,
+          y: context.y + effY,
+          z: context.z + effZ,
+          rotation: context.rotation + effRot,
+          rotationX: context.rotationX + effRotX,
+          rotationY: context.rotationY + effRotY,
+          scaleX: context.scaleX * effSX,
+          scaleY: context.scaleY * effSY,
+          opacity: context.opacity * effOp,
+          matrix: nextMatrix,
         }
     for (const child of api.getChildren(id)) visit(child.id, nextInherited)
   }
-  visit(rootId, IDENTITY_INHERITED)
+  visit(rootId, identityContext)
   return out
 }
 
@@ -281,31 +383,46 @@ export function computeCameraDepthOfField(
   if (!camera || !camera.depthOfField) return null
   const focusDistance = cameraAnim?.focusDistance ?? camera.focusDistance ?? 0
   const aperture = Math.max(0, cameraAnim?.aperture ?? camera.aperture ?? 0)
-  const maxBlur = Math.max(0, Math.min(64, cameraAnim?.blurLevel ?? camera.blurLevel ?? 1))
+  const focusZ = cameraAnim?.focusWorldZ ?? camera.focusWorldZ ?? focusDistance
+  const maxBlur = Math.max(0, Math.min(128, cameraAnim?.blurLevel ?? camera.blurLevel ?? 1))
   const focalLength = Math.max(50, camera.focalLength ?? 1000)
   const cameraZ = cameraAnim?.z ?? camera.transform.z
   const rotationX = cameraAnim?.rotationX ?? camera.transform.rotationX
   const rotationY = cameraAnim?.rotationY ?? camera.transform.rotationY
   const safeCameraScale = Math.max(0.05, cameraScale)
   const focalFactor = Math.max(0.35, Math.min(6, focalLength / 1000))
-  const zoomFactor = Math.max(0.25, Math.min(8, safeCameraScale))
   const dollyFactor = Math.max(0.5, Math.min(5, 1 + Math.max(0, cameraZ) / focalLength))
-  const blurPx = Math.min(maxBlur, aperture * maxBlur * focalFactor * Math.sqrt(zoomFactor) * dollyFactor)
-  const effectiveFocusRadius =
-    Math.max(28, 220 / Math.sqrt(Math.max(1, aperture + 0.5))) /
-    Math.sqrt(focalFactor * zoomFactor)
-  const mode = camera.focusMode ?? 'plane'
+  const apertureFactor =
+    aperture <= 0 ? 1 : Math.max(0.25, Math.min(5, Math.pow(aperture / 10, 1.15)))
+  const focusDepthFactor = Math.max(
+    0.75,
+    Math.min(5, 1 + Math.abs(focusZ - cameraZ) / Math.max(120, focalLength * 0.55)),
+  )
+  const blurPx = Math.min(
+    160,
+    maxBlur * apertureFactor * focusDepthFactor * Math.sqrt(focalFactor) * dollyFactor,
+  )
+  const effectiveFocusRadius = Math.max(
+    4,
+    cameraAnim?.focusRadius ?? camera.focusRadius ?? 160,
+  )
+  const focusFalloff = Math.max(
+    1,
+    cameraAnim?.focusFalloff ?? camera.focusFalloff ?? 180,
+  )
+  const mode = camera.focusMode ?? 'screen'
+  const focusScreen = {
+    x: cameraAnim?.focusX ?? camera.focusX ?? canvasWidth / 2,
+    y: cameraAnim?.focusY ?? camera.focusY ?? canvasHeight / 2,
+  }
   const focusWorld = focusWorldOverride ?? {
-    x: cameraAnim?.focusWorldX ?? camera.focusWorldX ?? camera.focusX ?? camera.transform.x,
-    y: cameraAnim?.focusWorldY ?? camera.focusWorldY ?? camera.focusY ?? camera.transform.y,
-    z: cameraAnim?.focusWorldZ ?? camera.focusWorldZ ?? focusDistance,
+    x: cameraAnim?.focusWorldX ?? camera.focusWorldX ?? focusScreen.x,
+    y: cameraAnim?.focusWorldY ?? camera.focusWorldY ?? focusScreen.y,
+    z: focusZ,
   }
   const projected =
     mode === 'screen'
-      ? {
-          x: cameraAnim?.focusX ?? camera.focusX ?? camera.transform.x,
-          y: cameraAnim?.focusY ?? camera.focusY ?? camera.transform.y,
-        }
+      ? focusScreen
       : projectWorldPointThroughCamera(
           focusWorld,
           camera,
@@ -322,14 +439,16 @@ export function computeCameraDepthOfField(
     focusWorldY: focusWorld.y,
     focusWorldZ: focusWorld.z,
     focusRadius: effectiveFocusRadius,
+    focusFalloff,
     focusDistance: mode === 'screen' ? focusDistance : focusWorld.z,
     aperture,
     blurPx,
-    featherPx: Math.max(24, effectiveFocusRadius * 0.75),
+    featherPx: focusFalloff,
     focalLength,
     cameraZ,
     cameraScale: safeCameraScale,
     iso: Math.max(0, camera.iso ?? 100),
+    blurQuality: Math.max(1, Math.min(8, cameraAnim?.blurQuality ?? camera.blurQuality ?? 4)),
     blurAxisDeg:
       Math.abs(rotationX) + Math.abs(rotationY) < 0.001
         ? 90
@@ -361,108 +480,13 @@ function projectWorldPointThroughCamera(
   }
 }
 
-interface FocusHit {
-  nodeId: NodeId
-  point: Vec3
-  screen: { x: number; y: number }
-  focusDistance: number
-}
-
-function findCameraFocusHit({
-  api,
-  order,
-  solved,
-  animated,
-  inherited,
-  camera,
-  cameraAnim,
-  canvasX,
-  canvasY,
-  canvasWidth,
-  canvasHeight,
-}: {
-  api: SceneAPI
-  order: NodeId[]
-  solved: SolvedLayout
-  animated: Record<NodeId, AnimatedValue>
-  inherited: Record<NodeId, InheritedAnim>
-  camera: CameraNode
-  cameraAnim: AnimatedValue | undefined
-  canvasX: number
-  canvasY: number
-  canvasWidth: number
-  canvasHeight: number
-}): FocusHit | null {
-  const focalLength = Math.max(50, camera.focalLength ?? 1000)
-  const cx = cameraAnim?.x ?? camera.transform.x
-  const cy = cameraAnim?.y ?? camera.transform.y
-  const cz = cameraAnim?.z ?? camera.transform.z
-  const rX = cameraAnim?.rotationX ?? camera.transform.rotationX
-  const rY = cameraAnim?.rotationY ?? camera.transform.rotationY
-  const rZ = cameraAnim?.rotation ?? camera.transform.rotation
-  const origin: Vec3 = { x: cx, y: cy, z: -focalLength + cz }
-  const localRay = norm3({
-    x: canvasX - canvasWidth / 2,
-    y: canvasY - canvasHeight / 2,
-    z: focalLength,
-  })
-  const direction = norm3(rotateEuler(localRay, rX, rY, rZ))
-  let best: (FocusHit & { t: number }) | null = null
-
-  for (let i = order.length - 1; i >= 0; i--) {
-    const id = order[i]!
-    const node = api.getNode(id)
-    const rect = solved[id]
-    if (!node || !rect || node.kind === 'camera' || id === api.getRoot()) continue
-    if (!node.visible || node.locked) continue
-    const inherit = inherited[id] ?? IDENTITY_INHERITED
-    const anim = animated[id]
-    const ownX = anim?.x ?? node.transform.x
-    const ownY = anim?.y ?? node.transform.y
-    const ownZ = anim?.z ?? node.transform.z
-    const ownRot = anim?.rotation ?? node.transform.rotation
-    const ownRotX = anim?.rotationX ?? node.transform.rotationX
-    const ownRotY = anim?.rotationY ?? node.transform.rotationY
-    const ownSX = anim?.scaleX ?? node.transform.scaleX
-    const ownSY = anim?.scaleY ?? node.transform.scaleY
-    const center: Vec3 = {
-      x: rect.x + rect.width / 2 + inherit.x + ownX,
-      y: rect.y + rect.height / 2 + inherit.y + ownY,
-      z: inherit.z + ownZ,
-    }
-    const rotZ = inherit.rotation + ownRot
-    const rotX = inherit.rotationX + ownRotX
-    const rotY = inherit.rotationY + ownRotY
-    const u = norm3(rotateEuler({ x: 1, y: 0, z: 0 }, rotX, rotY, rotZ))
-    const v = norm3(rotateEuler({ x: 0, y: 1, z: 0 }, rotX, rotY, rotZ))
-    const normal = norm3(rotateEuler({ x: 0, y: 0, z: 1 }, rotX, rotY, rotZ))
-    const denom = dot3(direction, normal)
-    if (Math.abs(denom) < 0.0001) continue
-    const t = dot3(sub3(center, origin), normal) / denom
-    if (t <= 0 || (best && t >= best.t)) continue
-    const point = add3(origin, mul3(direction, t))
-    const rel = sub3(point, center)
-    const localX = dot3(rel, u) / Math.max(0.0001, Math.abs(ownSX * inherit.scaleX)) + rect.width / 2
-    const localY = dot3(rel, v) / Math.max(0.0001, Math.abs(ownSY * inherit.scaleY)) + rect.height / 2
-    if (localX < 0 || localX > rect.width || localY < 0 || localY > rect.height) continue
-    best = {
-      nodeId: id,
-      point,
-      screen: projectWorldPointThroughCamera(point, camera, cameraAnim, canvasWidth, canvasHeight),
-      focusDistance: point.z,
-      t,
-    }
-  }
-
-  return best
-}
-
 export function resolveCameraFocusTargetPoint(
   api: SceneAPI,
   camera: CameraNode | null,
   solved: SolvedLayout,
   animated: Record<NodeId, AnimatedValue>,
   inherited: Record<NodeId, InheritedAnim>,
+  viewport?: { width: number; height: number },
 ): Vec3 | null {
   if (!camera || (camera.focusMode ?? 'plane') !== 'target') return null
   const targetId = camera.focusTargetNodeId
@@ -470,6 +494,12 @@ export function resolveCameraFocusTargetPoint(
   const target = api.getNode(targetId)
   const rect = solved[targetId]
   if (!target || !rect) return null
+  if (viewport) {
+    const resolvedCamera = resolveCamera3D(camera, animated[camera.id], viewport)
+    const targetPlane = buildWorldPlanes(api, solved, animated, resolvedCamera)
+      .find((plane) => plane.nodeId === targetId)
+    if (targetPlane) return targetPlane.center
+  }
   const inherit = inherited[targetId] ?? IDENTITY_INHERITED
   const anim = animated[targetId]
   return {
@@ -477,26 +507,6 @@ export function resolveCameraFocusTargetPoint(
     y: rect.y + rect.height / 2 + inherit.y + (anim?.y ?? target.transform.y),
     z: inherit.z + (anim?.z ?? target.transform.z),
   }
-}
-
-function depthOfFieldBlurForNode(
-  cameraDepthOfField: CameraDepthOfField | null | undefined,
-  node: SceneNode,
-  anim: AnimatedValue | undefined,
-  inherit: InheritedAnim,
-  isRoot: boolean,
-): number {
-  void cameraDepthOfField
-  void node
-  void anim
-  void inherit
-  void isRoot
-  // Camera lens blur must not be applied as a per-layer CSS filter. That
-  // turns DOF into a regular "Layer blur" effect and smears the whole
-  // plane uniformly. The photographic preview is handled by
-  // CameraFocusBlurOverlay, which masks blurred scene passes around the
-  // selected focus band/point.
-  return 0
 }
 
 /**
@@ -584,6 +594,22 @@ export function Canvas() {
     visit(rootId)
     return out
   }, [api, rootId, version])
+
+  const workspaceOrder = useMemo<NodeId[]>(() => {
+    const roots = api
+      .getAllNodeIds()
+      .filter((id) => {
+        const node = api.getNode(id)
+        return !!node && !!node.workspaceOnly && node.parent === null
+      })
+    const out: NodeId[] = []
+    const visit = (id: NodeId) => {
+      out.push(id)
+      for (const child of api.getChildren(id)) visit(child.id)
+    }
+    for (const id of roots) visit(id)
+    return out
+  }, [api, version])
 
   // Animated values (opacity, transform offsets) from the anim engine,
   // keyed by node id. Empty object while no tracks exist, which is the
@@ -704,9 +730,9 @@ export function Canvas() {
   // required so pure-scene mutations (e.g. dragging a node) re-run the
   // ancestor walk even when the anim snapshot identity hasn't changed.
   const inherited = useMemo(
-    () => composeInheritedAnim(api, rootId, animated),
+    () => composeInheritedAnim(api, rootId, animated, solved),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [api, rootId, animated, version],
+    [api, rootId, animated, solved, version],
   )
 
   const focusTargetWorld = useMemo(
@@ -717,6 +743,7 @@ export function Canvas() {
         solved ?? {},
         animated,
         inherited,
+        { width: canvasWidth, height: canvasHeight },
       ),
     [api, camera, solved, animated, inherited],
   )
@@ -771,8 +798,11 @@ export function Canvas() {
     pointerId: number
     startX: number
     startY: number
+    workspaceOnly: boolean
   } | null>(null)
-  const [drawPreview, setDrawPreview] = useState<Rect | null>(null)
+  const [drawPreview, setDrawPreview] = useState<
+    (Rect & { workspaceOnly?: boolean }) | null
+  >(null)
 
   // Marquee (rubber-band) selection state. Active only with the select
   // tool, clicking the empty workspace background. Holding Shift at
@@ -783,8 +813,11 @@ export function Canvas() {
     startY: number
     additive: boolean
     initialSelection: NodeId[]
+    workspaceOnly: boolean
   } | null>(null)
-  const [marqueeRect, setMarqueeRect] = useState<Rect | null>(null)
+  const [marqueeRect, setMarqueeRect] = useState<
+    (Rect & { workspaceOnly?: boolean }) | null
+  >(null)
   const cameraControlRef = useRef<{
     pointerId: number
     cameraId: NodeId
@@ -795,13 +828,43 @@ export function Canvas() {
     latestTransform: CameraNode['transform']
     moved: boolean
   } | null>(null)
+  const focusMaskDragRef = useRef<{
+    pointerId: number
+    cameraId: NodeId
+    startX: number
+    startY: number
+    latestPatch: Record<string, number>
+    moved: boolean
+  } | null>(null)
+
+  const stampCanvasPatch = useCallback(
+    (
+      nodeId: NodeId,
+      group: 'transform' | 'appearance' | 'size' | 'camera',
+      patch: Record<string, unknown>,
+    ) => {
+      const ui = useUI.getState()
+      if (ui.recording) {
+        recordKeyframesForPatch(api, nodeId, ui.playhead, group, patch)
+      } else {
+        stampToActiveTracksForPatch(api, nodeId, ui.playhead, group, patch)
+      }
+    },
+    [api],
+  )
 
   const stampCanvasTransformPatch = useCallback(
     (nodeId: NodeId, patch: Record<string, unknown>) => {
-      const ui = useUI.getState()
-      recordKeyframesForPatch(api, nodeId, ui.playhead, 'transform', patch)
+      stampCanvasPatch(nodeId, 'transform', patch)
     },
-    [api],
+    [stampCanvasPatch],
+  )
+
+  const stampCanvasCameraPatch = useCallback(
+    (nodeId: NodeId, patch: Record<string, unknown>) => {
+      stampCanvasPatch(nodeId, 'camera', patch)
+    },
+    [stampCanvasPatch],
   )
 
   const clientToViewport = useCallback(
@@ -819,6 +882,31 @@ export function Canvas() {
       }
     },
     [view.panX, view.panY, view.zoom, canvasWidth, canvasHeight],
+  )
+
+  const hitTestWorkspace = useCallback(
+    (clientX: number, clientY: number): NodeId | null => {
+      const point = clientToViewport(clientX, clientY)
+      if (!point) return null
+      for (const id of [...workspaceOrder].reverse()) {
+        const node = api.getNode(id)
+        if (!node || !node.visible) continue
+        const rect = workspaceRectForNode(node)
+        const inherit = workspaceInheritedTransform(api, node)
+        const x = rect.x + node.transform.x + inherit.x
+        const y = rect.y + node.transform.y + inherit.y
+        if (
+          point.x >= x &&
+          point.x <= x + rect.width &&
+          point.y >= y &&
+          point.y <= y + rect.height
+        ) {
+          return id
+        }
+      }
+      return null
+    },
+    [api, clientToViewport, workspaceOrder],
   )
 
   const resolvedCamera3D = useMemo(
@@ -936,6 +1024,16 @@ export function Canvas() {
     ],
   )
 
+  const isInsideArtboard = useCallback(
+    (point: { x: number; y: number } | null): point is { x: number; y: number } =>
+      !!point &&
+      point.x >= 0 &&
+      point.y >= 0 &&
+      point.x <= canvasWidth &&
+      point.y <= canvasHeight,
+    [canvasWidth, canvasHeight],
+  )
+
   const DRAW_TOOLS: Tool[] = ['rect', 'ellipse', 'text', 'frame']
   const isDrawTool = DRAW_TOOLS.includes(tool)
   const [spacePanning, setSpacePanning] = useState(false)
@@ -968,7 +1066,7 @@ export function Canvas() {
   }, [])
 
   const onFocusPickPointerDownCapture = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
+    (e: React.PointerEvent<HTMLElement>) => {
       if (e.button !== 0) return
       if (!focusPickingCameraId && spacePanning) {
         panStateRef.current = {
@@ -1011,31 +1109,34 @@ export function Canvas() {
       }
       if (!focusPickingCameraId) return
       const point = clientToViewport(e.clientX, e.clientY)
+      const canvasPoint = clientToCanvas(e.clientX, e.clientY)
       const focusCamera = api.getNode(focusPickingCameraId)
-      if (!point || !focusCamera || focusCamera.kind !== 'camera') {
+      if (!point || !canvasPoint || !focusCamera || focusCamera.kind !== 'camera') {
         setFocusPickingCameraId(null)
         return
       }
-      if (!solved) {
-        e.preventDefault()
-        e.stopPropagation()
-        return
-      }
-      const hit = hitTestCanvas3D(e.clientX, e.clientY)
-      if (!hit) {
-        e.preventDefault()
-        e.stopPropagation()
-        return
+      const focusWorld = {
+        x: canvasPoint.x,
+        y: canvasPoint.y,
+        z: focusCamera.focusWorldZ ?? focusCamera.focusDistance ?? 0,
       }
       api.doc.transact(() => {
-        api.setNodeProperty(focusCamera.id, 'focusX', hit.viewport.x)
-        api.setNodeProperty(focusCamera.id, 'focusY', hit.viewport.y)
-        api.setNodeProperty(focusCamera.id, 'focusWorldX', hit.point.x)
-        api.setNodeProperty(focusCamera.id, 'focusWorldY', hit.point.y)
-        api.setNodeProperty(focusCamera.id, 'focusWorldZ', hit.point.z)
-        api.setNodeProperty(focusCamera.id, 'focusDistance', hit.cameraDepth)
-        api.setNodeProperty(focusCamera.id, 'focusMode', 'plane')
+        api.setNodeProperty(focusCamera.id, 'focusX', point.x)
+        api.setNodeProperty(focusCamera.id, 'focusY', point.y)
+        api.setNodeProperty(focusCamera.id, 'focusWorldX', focusWorld.x)
+        api.setNodeProperty(focusCamera.id, 'focusWorldY', focusWorld.y)
+        api.setNodeProperty(focusCamera.id, 'focusWorldZ', focusWorld.z)
+        api.setNodeProperty(focusCamera.id, 'focusDistance', focusWorld.z)
+        api.setNodeProperty(focusCamera.id, 'focusMode', 'screen')
         api.setNodeProperty(focusCamera.id, 'focusTargetNodeId', null)
+      })
+      stampCanvasCameraPatch(focusCamera.id, {
+        focusX: point.x,
+        focusY: point.y,
+        focusWorldX: focusWorld.x,
+        focusWorldY: focusWorld.y,
+        focusWorldZ: focusWorld.z,
+        focusDistance: focusWorld.z,
       })
       setSelection([focusCamera.id])
       setFocusPickingCameraId(null)
@@ -1045,11 +1146,12 @@ export function Canvas() {
     [
       api,
       clientToViewport,
+      clientToCanvas,
       solved,
-      hitTestCanvas3D,
       focusPickingCameraId,
       setFocusPickingCameraId,
       setSelection,
+      stampCanvasCameraPatch,
       camera,
       displayedCameraTransform,
       selection,
@@ -1058,6 +1160,115 @@ export function Canvas() {
       view.panX,
       view.panY,
     ],
+  )
+
+  const focusPatchFromClientPoint = useCallback(
+    (
+      cameraNode: CameraNode,
+      clientX: number,
+      clientY: number,
+    ): Record<string, number> | null => {
+      const viewportPoint = clientToViewport(clientX, clientY)
+      const canvasPoint = clientToCanvas(clientX, clientY)
+      if (!viewportPoint || !canvasPoint) return null
+      const focusWorld = {
+        x: canvasPoint.x,
+        y: canvasPoint.y,
+        z: cameraNode.focusWorldZ ?? cameraNode.focusDistance ?? 0,
+      }
+      return {
+        focusX: viewportPoint.x,
+        focusY: viewportPoint.y,
+        focusWorldX: focusWorld.x,
+        focusWorldY: focusWorld.y,
+        focusWorldZ: focusWorld.z,
+        focusDistance: focusWorld.z,
+      }
+    },
+    [clientToCanvas, clientToViewport],
+  )
+
+  const applyFocusMaskPatch = useCallback(
+    (cameraNode: CameraNode, patch: Record<string, number>) => {
+      api.doc.transact(() => {
+        api.setNodeProperty(cameraNode.id, 'focusX', patch.focusX)
+        api.setNodeProperty(cameraNode.id, 'focusY', patch.focusY)
+        api.setNodeProperty(cameraNode.id, 'focusWorldX', patch.focusWorldX)
+        api.setNodeProperty(cameraNode.id, 'focusWorldY', patch.focusWorldY)
+        api.setNodeProperty(cameraNode.id, 'focusWorldZ', patch.focusWorldZ)
+        api.setNodeProperty(cameraNode.id, 'focusDistance', patch.focusDistance)
+        api.setNodeProperty(cameraNode.id, 'focusMode', 'screen')
+        api.setNodeProperty(cameraNode.id, 'focusTargetNodeId', null)
+      })
+    },
+    [api],
+  )
+
+  const onFocusMaskPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      if (e.button !== 0 || !camera || camera.kind !== 'camera') return
+      const patch = focusPatchFromClientPoint(camera, e.clientX, e.clientY)
+      if (!patch) return
+      focusMaskDragRef.current = {
+        pointerId: e.pointerId,
+        cameraId: camera.id,
+        startX: e.clientX,
+        startY: e.clientY,
+        latestPatch: patch,
+        moved: false,
+      }
+      applyFocusMaskPatch(camera, patch)
+      setSelection([camera.id])
+      e.currentTarget.setPointerCapture(e.pointerId)
+      e.preventDefault()
+      e.stopPropagation()
+    },
+    [
+      applyFocusMaskPatch,
+      camera,
+      focusPatchFromClientPoint,
+      setSelection,
+    ],
+  )
+
+  const onFocusMaskPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      const drag = focusMaskDragRef.current
+      if (!drag || e.pointerId !== drag.pointerId) return
+      const focusCamera = api.getNode(drag.cameraId)
+      if (!focusCamera || focusCamera.kind !== 'camera') return
+      const dx = e.clientX - drag.startX
+      const dy = e.clientY - drag.startY
+      if (!drag.moved && Math.hypot(dx, dy) < 1) return
+      const patch = focusPatchFromClientPoint(focusCamera, e.clientX, e.clientY)
+      if (!patch) return
+      drag.moved = true
+      drag.latestPatch = patch
+      applyFocusMaskPatch(focusCamera, patch)
+      e.preventDefault()
+      e.stopPropagation()
+    },
+    [api, applyFocusMaskPatch, focusPatchFromClientPoint],
+  )
+
+  const onFocusMaskPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = focusMaskDragRef.current
+      if (!drag || e.pointerId !== drag.pointerId) return
+      const focusCamera = api.getNode(drag.cameraId)
+      if (drag.moved && focusCamera?.kind === 'camera') {
+        stampCanvasCameraPatch(focusCamera.id, drag.latestPatch)
+      }
+      focusMaskDragRef.current = null
+      try {
+        ;(e.target as HTMLElement).releasePointerCapture(e.pointerId)
+      } catch {
+        /* already released */
+      }
+      e.preventDefault()
+      e.stopPropagation()
+    },
+    [api, stampCanvasCameraPatch],
   )
 
 	  const onBackgroundPointerDown = useCallback(
@@ -1087,19 +1298,44 @@ export function Canvas() {
       }
 
       if (isDrawTool) {
-        const start = clientToCanvas(e.clientX, e.clientY)
+        const viewportStart = clientToViewport(e.clientX, e.clientY)
+        const workspaceOnly = !isInsideArtboard(viewportStart)
+        const start = workspaceOnly
+          ? viewportStart
+          : clientToCanvas(e.clientX, e.clientY)
         if (!start) return
         drawStateRef.current = {
           kind: toolToKind(tool),
           pointerId: e.pointerId,
           startX: start.x,
           startY: start.y,
+          workspaceOnly,
         }
-        setDrawPreview({ x: start.x, y: start.y, width: 0, height: 0 })
+        setDrawPreview({
+          x: start.x,
+          y: start.y,
+          width: 0,
+          height: 0,
+          workspaceOnly,
+        })
         ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
         e.preventDefault()
         e.stopPropagation()
         return
+      }
+
+      if (tool === 'select' && !onExistingNode) {
+        const workspaceHit = hitTestWorkspace(e.clientX, e.clientY)
+        if (workspaceHit) {
+          if (e.shiftKey || e.metaKey || e.ctrlKey) {
+            useUI.getState().toggleInSelection(workspaceHit, true)
+          } else {
+            setSelection([workspaceHit])
+          }
+          e.preventDefault()
+          e.stopPropagation()
+          return
+        }
       }
 
 	      if (!onExistingNode) {
@@ -1145,7 +1381,11 @@ export function Canvas() {
         // recompute union-with-marquee idempotently without losing the
         // user's prior picks halfway through a Shift drag.
         if (tool === 'select') {
-          const start = clientToCanvas(e.clientX, e.clientY)
+          const viewportStart = clientToViewport(e.clientX, e.clientY)
+          const workspaceOnly = !isInsideArtboard(viewportStart)
+          const start = workspaceOnly
+            ? viewportStart
+            : clientToCanvas(e.clientX, e.clientY)
           if (start) {
             marqueeRef.current = {
               pointerId: e.pointerId,
@@ -1155,8 +1395,15 @@ export function Canvas() {
               initialSelection: e.shiftKey
                 ? [...useUI.getState().selection]
                 : [],
+              workspaceOnly,
             }
-            setMarqueeRect({ x: start.x, y: start.y, width: 0, height: 0 })
+            setMarqueeRect({
+              x: start.x,
+              y: start.y,
+              width: 0,
+              height: 0,
+              workspaceOnly,
+            })
             ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
             // Only clear when starting a non-additive marquee. With
             // shift, hold the previous selection until pointer-up so
@@ -1173,6 +1420,9 @@ export function Canvas() {
 	      tool,
 	      isDrawTool,
 	      clientToCanvas,
+	      clientToViewport,
+      isInsideArtboard,
+      hitTestWorkspace,
 	      hitTestCanvas3D,
 	      setSelection,
 		      camera,
@@ -1233,27 +1483,31 @@ export function Canvas() {
       }
       const d = drawStateRef.current
       if (d && e.pointerId === d.pointerId) {
-        const cur = clientToCanvas(e.clientX, e.clientY)
+        const cur = d.workspaceOnly
+          ? clientToViewport(e.clientX, e.clientY)
+          : clientToCanvas(e.clientX, e.clientY)
         if (!cur) return
         const x = Math.min(d.startX, cur.x)
         const y = Math.min(d.startY, cur.y)
         const width = Math.abs(cur.x - d.startX)
         const height = Math.abs(cur.y - d.startY)
-        setDrawPreview({ x, y, width, height })
+        setDrawPreview({ x, y, width, height, workspaceOnly: d.workspaceOnly })
         return
       }
       const m = marqueeRef.current
       if (m && e.pointerId === m.pointerId) {
-        const cur = clientToCanvas(e.clientX, e.clientY)
+        const cur = m.workspaceOnly
+          ? clientToViewport(e.clientX, e.clientY)
+          : clientToCanvas(e.clientX, e.clientY)
         if (!cur) return
         const x = Math.min(m.startX, cur.x)
         const y = Math.min(m.startY, cur.y)
         const width = Math.abs(cur.x - m.startX)
         const height = Math.abs(cur.y - m.startY)
-        setMarqueeRect({ x, y, width, height })
+        setMarqueeRect({ x, y, width, height, workspaceOnly: m.workspaceOnly })
       }
 	    },
-	    [api, cameraScaleFromZ, clientToCanvas, setView, view.zoom],
+	    [api, cameraScaleFromZ, clientToCanvas, clientToViewport, setView, view.zoom],
 	  )
 
 	  const onBackgroundPointerUp = useCallback(
@@ -1301,11 +1555,14 @@ export function Canvas() {
         } catch {
           /* already released */
         }
-        const cur = clientToCanvas(e.clientX, e.clientY)
+        const cur = m.workspaceOnly
+          ? clientToViewport(e.clientX, e.clientY)
+          : clientToCanvas(e.clientX, e.clientY)
         const startX = m.startX
         const startY = m.startY
         const additive = m.additive
         const prior = m.initialSelection
+        const workspaceOnly = m.workspaceOnly
         marqueeRef.current = null
         setMarqueeRect(null)
         if (!cur) return
@@ -1324,23 +1581,46 @@ export function Canvas() {
           return
         }
 
-        // Hit-test: every solved rect that intersects the marquee
-        // counts as "inside." Excludes root (no point selecting the
-        // artboard itself with a drag) and cameras (they don't paint
-        // and a marquee over the viewfinder shouldn't grab them).
         const hits: NodeId[] = []
-        const layoutRects = solved ?? {}
-        for (const [id, rect] of Object.entries(layoutRects)) {
-          if (id === rootId) continue
-          const n = api.getNode(id)
-          if (!n || n.kind === 'camera') continue
-          if (
-            rect.x + rect.width >= bx &&
-            rect.x <= bx + bw &&
-            rect.y + rect.height >= by &&
-            rect.y <= by + bh
-          ) {
-            hits.push(id)
+        if (workspaceOnly) {
+          for (const id of workspaceOrder) {
+            const n = api.getNode(id)
+            if (!n || !n.visible) continue
+            const rect = workspaceRectForNode(n)
+            const inherit = workspaceInheritedTransform(api, n)
+            const worldRect = {
+              x: rect.x + n.transform.x + inherit.x,
+              y: rect.y + n.transform.y + inherit.y,
+              width: rect.width,
+              height: rect.height,
+            }
+            if (
+              worldRect.x + worldRect.width >= bx &&
+              worldRect.x <= bx + bw &&
+              worldRect.y + worldRect.height >= by &&
+              worldRect.y <= by + bh
+            ) {
+              hits.push(id)
+            }
+          }
+        } else {
+          // Hit-test: every solved rect that intersects the marquee
+          // counts as "inside." Excludes root (no point selecting the
+          // artboard itself with a drag) and cameras (they don't paint
+          // and a marquee over the viewfinder shouldn't grab them).
+          const layoutRects = solved ?? {}
+          for (const [id, rect] of Object.entries(layoutRects)) {
+            if (id === rootId) continue
+            const n = api.getNode(id)
+            if (!n || n.kind === 'camera') continue
+            if (
+              rect.x + rect.width >= bx &&
+              rect.x <= bx + bw &&
+              rect.y + rect.height >= by &&
+              rect.y <= by + bh
+            ) {
+              hits.push(id)
+            }
           }
         }
 
@@ -1359,10 +1639,12 @@ export function Canvas() {
         } catch {
           /* already released */
         }
-        const cur = clientToCanvas(e.clientX, e.clientY)
+        const cur = d.workspaceOnly
+          ? clientToViewport(e.clientX, e.clientY)
+          : clientToCanvas(e.clientX, e.clientY)
         drawStateRef.current = null
         setDrawPreview(null)
-        if (!cur || !rootId) return
+        if (!cur || (!rootId && !d.workspaceOnly)) return
 
         // Commit. Dragged bounds → size + transform.x/y under root.
         // A tiny drag (< 2px) becomes a default-sized rect at the point,
@@ -1381,10 +1663,10 @@ export function Canvas() {
         // it jump?" If the parent is mode='none' (free canvas), we keep
         // the dragged position as the transform so click-drag lands
         // exactly where the user pointed.
-        const parentNode = api.getNode(rootId)
+        const parentNode = d.workspaceOnly || !rootId ? null : api.getNode(rootId)
         const parentMode =
           parentNode && 'layout' in parentNode ? parentNode.layout.mode : 'none'
-        const useAbsolute = parentMode === 'none'
+        const useAbsolute = d.workspaceOnly || parentMode === 'none'
 
         // Sizing rules:
         // - Text always prefers hug when drawn into a flex/grid parent
@@ -1438,8 +1720,10 @@ export function Canvas() {
             : undefined
 
         const appearance = appearanceForKind(d.kind)
-        const newId = api.createNode(d.kind, rootId, {
+        const newId = api.createNode(d.kind, d.workspaceOnly ? null : rootId, {
           ...baseProps,
+          position: useAbsolute ? 'absolute' : 'flow',
+          workspaceOnly: d.workspaceOnly,
           ...(appearance ? { appearance } : {}),
         } as never)
 
@@ -1456,7 +1740,17 @@ export function Canvas() {
         }
       }
     },
-    [api, rootId, clientToCanvas, setSelection, setTool, solved, clearSelection],
+    [
+      api,
+      rootId,
+      clientToCanvas,
+      clientToViewport,
+      setSelection,
+      setTool,
+      solved,
+      workspaceOrder,
+      clearSelection,
+    ],
   )
 
   // --- wheel: cmd/ctrl + wheel = zoom, otherwise pan -------------------
@@ -1505,8 +1799,8 @@ export function Canvas() {
     }
     // React only synthesizes wheel as passive; we need to preventDefault
     // to stop the page from scrolling under Cmd+wheel, so attach native.
-    el.addEventListener('wheel', onWheel, { passive: false })
-    return () => el.removeEventListener('wheel', onWheel)
+    el.addEventListener('wheel', onWheel, { capture: true, passive: false })
+    return () => el.removeEventListener('wheel', onWheel, { capture: true })
   }, [
     api,
     camera,
@@ -1531,7 +1825,7 @@ export function Canvas() {
         ? 'crosshair'
         : undefined
 
-  // --- native drag-drop: image import ----------------------------------
+  // --- native drag-drop: component / image import ----------------------
   // Tracks the "a dragged file is hovering over the canvas" state so the
   // UI can show a visible drop target. dragenter/dragover fire many times
   // during a hover; a boolean is enough — we don't need to count enters.
@@ -1539,13 +1833,19 @@ export function Canvas() {
   const dragDepthRef = useRef(0)
 
   const handleDragEnter = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    if (!e.dataTransfer.types.includes('Files')) return
+    if (
+      !e.dataTransfer.types.includes('Files') &&
+      !e.dataTransfer.types.includes('text/hyper-motion-component')
+    ) return
     dragDepthRef.current += 1
     setIsFileDragging(true)
   }, [])
 
   const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    if (!e.dataTransfer.types.includes('Files')) return
+    if (
+      !e.dataTransfer.types.includes('Files') &&
+      !e.dataTransfer.types.includes('text/hyper-motion-component')
+    ) return
     // Required to allow `drop` to fire — the browser assumes you're
     // rejecting the drag unless you preventDefault on dragover.
     e.preventDefault()
@@ -1553,7 +1853,10 @@ export function Canvas() {
   }, [])
 
   const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    if (!e.dataTransfer.types.includes('Files')) return
+    if (
+      !e.dataTransfer.types.includes('Files') &&
+      !e.dataTransfer.types.includes('text/hyper-motion-component')
+    ) return
     // Nested elements fire leave/enter pairs during traversal. Use a
     // depth counter so the highlight only clears when the drag truly
     // exits the workspace, not when crossing a child boundary.
@@ -1563,11 +1866,35 @@ export function Canvas() {
 
   const handleDrop = useCallback(
     async (e: React.DragEvent<HTMLDivElement>) => {
-      if (!e.dataTransfer.files || e.dataTransfer.files.length === 0) return
+      const componentId = e.dataTransfer.getData('text/hyper-motion-component')
+      if (
+        !componentId &&
+        (!e.dataTransfer.files || e.dataTransfer.files.length === 0)
+      ) return
       e.preventDefault()
       dragDepthRef.current = 0
       setIsFileDragging(false)
-      if (!rootId) return
+      const viewportDrop = clientToViewport(e.clientX, e.clientY)
+      const workspaceOnly = !isInsideArtboard(viewportDrop)
+      if (!rootId && !workspaceOnly) return
+
+      const dropPos = workspaceOnly
+        ? viewportDrop ?? undefined
+        : clientToCanvas(e.clientX, e.clientY) ?? undefined
+      if (componentId) {
+        const id = instantiateComponent(api, componentId, workspaceOnly ? null : rootId, {
+          absolute: true,
+          workspaceOnly,
+          position: dropPos
+            ? { x: Math.round(dropPos.x), y: Math.round(dropPos.y) }
+            : undefined,
+        })
+        if (id) {
+          setSelection([id])
+          setTool('select')
+        }
+        return
+      }
 
       const allFiles = Array.from(e.dataTransfer.files)
       const imageFiles = allFiles.filter(isImageFile)
@@ -1582,19 +1909,20 @@ export function Canvas() {
 
       // Drop at the pointer location in canvas coordinates so the asset
       // lands where the user let go, not at the artboard center.
-      const dropPos = clientToCanvas(e.clientX, e.clientY) ?? undefined
       const ids: NodeId[] = []
       if (imageFiles.length > 0) {
         ids.push(
-          ...(await importImageFiles(imageFiles, api, rootId, {
+          ...(await importImageFiles(imageFiles, api, workspaceOnly ? null : rootId, {
             dropPos: dropPos ?? undefined,
+            workspaceOnly,
           })),
         )
       }
       if (mediaFiles.length > 0) {
         ids.push(
-          ...(await importMediaFiles(mediaFiles, api, rootId, {
+          ...(await importMediaFiles(mediaFiles, api, workspaceOnly ? null : rootId, {
             dropPos: dropPos ?? undefined,
+            workspaceOnly,
           })),
         )
       }
@@ -1603,7 +1931,7 @@ export function Canvas() {
         setTool('select')
       }
     },
-    [api, rootId, clientToCanvas, setSelection, setTool],
+    [api, rootId, clientToCanvas, clientToViewport, isInsideArtboard, setSelection, setTool],
   )
 
   return (
@@ -1745,10 +2073,19 @@ export function Canvas() {
                       }
                     />
                   ) : null}
-                  <div
-                    data-three-texture-source="1"
-                    className="absolute inset-0"
-                    style={
+                  <ScenePostProcessLayer
+                    rootId={rootId}
+                    solved={solved}
+                    order={renderOrder}
+                    animated={animated}
+                    inherited={inherited}
+                    cameraDepthOfField={previewCameraDepthOfField}
+                    sceneFill={sceneFill}
+                    canvasWidth={canvasWidth}
+                    canvasHeight={canvasHeight}
+                    sceneCorner={sceneCorner}
+                    includeSceneFill
+                    sceneContentStyle={
                       cameraTransform
                         ? {
                             transform: cameraTransform,
@@ -1758,57 +2095,29 @@ export function Canvas() {
                           }
                         : undefined
                     }
-                  >
-                    {sceneFill ? (
-                      <div
-                        className="pointer-events-none absolute"
-                        style={{
-                          left: 0,
-                          top: 0,
-                          width: canvasWidth,
-                          height: canvasHeight,
-                          background: sceneFill,
-                          borderRadius: Math.max(0, sceneCorner),
-                        }}
-                      />
-                    ) : null}
-                    <SceneLayer
-                      rootId={rootId}
-                      solved={solved}
-                      order={renderOrder}
-                      animated={animated}
-                      inherited={inherited}
-	                      cameraDepthOfField={previewCameraDepthOfField}
-                      onNodeClick={(id, additive) => {
-                        if (additive) {
-                          useUI.getState().toggleInSelection(id, true)
-                        } else {
-                          setSelection([id])
-                        }
-                      }}
-                    />
-                    <CameraFocusBlurOverlay
-                      rootId={rootId}
-                      solved={solved}
-                      order={renderOrder}
-                      animated={animated}
-                      inherited={inherited}
-	                      cameraDepthOfField={previewCameraDepthOfField}
-                      sceneFill={sceneFill}
-                      canvasWidth={canvasWidth}
-                      canvasHeight={canvasHeight}
-                      sceneCorner={sceneCorner}
-                    />
-                    {camera.showFocusPlane || focusPickingCameraId === camera.id ? (
+                  />
+                  {camera.showFocusPlane || focusPickingCameraId === camera.id ? (
+                    <div
+                      className="pointer-events-none absolute inset-0"
+                      style={
+                        cameraTransform
+                          ? {
+                              transform: cameraTransform,
+                              transformOrigin: '0 0',
+                              transformStyle: 'preserve-3d',
+                            }
+                          : undefined
+                      }
+                    >
                       <DomFocusPlaneOverlay
                         camera={camera}
                         cameraAnim={cameraAnim}
-	                        cameraDepthOfField={previewCameraDepthOfField}
+                        cameraDepthOfField={previewCameraDepthOfField}
                         canvasWidth={canvasWidth}
                         canvasHeight={canvasHeight}
                       />
-                    ) : null}
-                  </div>
+                    </div>
+                  ) : null}
                 </>
               ) : (
                 <>
@@ -1825,28 +2134,13 @@ export function Canvas() {
                       }}
                     />
                   ) : null}
-                  <SceneLayer
+                  <ScenePostProcessLayer
                     rootId={rootId}
                     solved={solved}
                     order={renderOrder}
                     animated={animated}
                     inherited={inherited}
-	                    cameraDepthOfField={previewCameraDepthOfField}
-                    onNodeClick={(id, additive) => {
-                      if (additive) {
-                        useUI.getState().toggleInSelection(id, true)
-                      } else {
-                        setSelection([id])
-                      }
-                    }}
-                  />
-                  <CameraFocusBlurOverlay
-                    rootId={rootId}
-                    solved={solved}
-                    order={renderOrder}
-                    animated={animated}
-                    inherited={inherited}
-	                    cameraDepthOfField={previewCameraDepthOfField}
+                    cameraDepthOfField={previewCameraDepthOfField}
                     sceneFill={sceneFill}
                     canvasWidth={canvasWidth}
                     canvasHeight={canvasHeight}
@@ -1858,10 +2152,46 @@ export function Canvas() {
           )}
         </div>
 
-        {/* Selection outline lives outside the `overflow:hidden` canvas box
-            so a selected node near the edge doesn't get its frame clipped.
-            It's still in canvas coordinates — same transform — so positions
-            map 1:1 to what the user sees.
+        <WorkspaceLayer
+          order={workspaceOrder}
+          canvasWidth={canvasWidth}
+          canvasHeight={canvasHeight}
+          zoom={view.zoom}
+        />
+        {drawPreview?.workspaceOnly ? (
+          <div
+            className="pointer-events-none absolute"
+            data-export-hide="1"
+            style={{
+              left: -canvasWidth / 2 + drawPreview.x,
+              top: -canvasHeight / 2 + drawPreview.y,
+              width: Math.max(1, drawPreview.width),
+              height: Math.max(1, drawPreview.height),
+              border: `${1 / Math.max(view.zoom, 0.001)}px dashed var(--color-accent)`,
+              background: 'var(--color-accent-soft)',
+              borderRadius: tool === 'ellipse' ? '9999px' : 2,
+            }}
+          />
+        ) : null}
+        {marqueeRect?.workspaceOnly ? (
+          <div
+            className="pointer-events-none absolute"
+            data-export-hide="1"
+            style={{
+              left: -canvasWidth / 2 + marqueeRect.x,
+              top: -canvasHeight / 2 + marqueeRect.y,
+              width: Math.max(1, marqueeRect.width),
+              height: Math.max(1, marqueeRect.height),
+              border: `${1 / Math.max(view.zoom, 0.001)}px solid var(--color-accent)`,
+              background:
+                'color-mix(in oklab, var(--color-accent) 12%, transparent)',
+            }}
+          />
+        ) : null}
+
+        {/* Selection/editor overlays sit in canvas coordinates. Keep this
+            clipped to the artboard bounds so camera tilt / dolly helpers
+            never spill into the neutral workspace beside the scene.
 
             `data-export-hide="1"` removes this entire chrome layer
             (selection rings, resize handles, camera viewfinder gizmo,
@@ -1869,13 +2199,14 @@ export function Canvas() {
             export. None of these are scene content — they're editor
             affordances that don't belong in the output WebM. */}
         <div
-          className="pointer-events-none absolute"
+          className="pointer-events-none absolute overflow-hidden"
           data-export-hide="1"
           style={{
             left: -canvasWidth / 2,
             top: -canvasHeight / 2,
             width: canvasWidth,
             height: canvasHeight,
+            borderRadius: Math.max(0, sceneCorner),
           }}
         >
           {/* Camera viewfinder gizmo. Drawn OUTSIDE the camera-transform
@@ -1892,26 +2223,6 @@ export function Canvas() {
               canvasHeight={canvasHeight}
               zoom={view.zoom}
               selected={selection.includes(camera.id)}
-            />
-          ) : null}
-          {previewCameraDepthOfField?.enabled &&
-          camera &&
-          camera.kind === 'camera' &&
-          (camera.focusMode ?? 'plane') === 'screen' &&
-          (selection.includes(camera.id) ||
-            focusPickingCameraId === camera.id ||
-            camera.showFocusPlane) ? (
-            <div
-              className="pointer-events-none absolute -translate-x-1/2 -translate-y-1/2"
-              style={{
-                left: previewCameraDepthOfField.focusX,
-                top: previewCameraDepthOfField.focusY,
-                width: 18 / Math.max(view.zoom, 0.001),
-                height: 18 / Math.max(view.zoom, 0.001),
-                border: `${1.5 / Math.max(view.zoom, 0.001)}px solid var(--color-accent)`,
-                borderRadius: 999,
-                boxShadow: `0 0 0 ${4 / Math.max(view.zoom, 0.001)}px color-mix(in oklab, var(--color-accent) 16%, transparent)`,
-              }}
             />
           ) : null}
           <div
@@ -1945,7 +2256,7 @@ export function Canvas() {
                 rootId={rootId}
               />
             )}
-            {drawPreview ? (
+            {drawPreview && !drawPreview.workspaceOnly ? (
               <div
                 className="pointer-events-none absolute"
                 style={{
@@ -1959,7 +2270,7 @@ export function Canvas() {
                 }}
               />
             ) : null}
-            {marqueeRect ? (
+            {marqueeRect && !marqueeRect.workspaceOnly ? (
               <div
                 className="pointer-events-none absolute"
                 style={{
@@ -1978,6 +2289,25 @@ export function Canvas() {
             ) : null}
           </div>
         </div>
+        {previewCameraDepthOfField?.enabled &&
+        camera &&
+        camera.kind === 'camera' &&
+        (selection.includes(camera.id) ||
+          focusPickingCameraId === camera.id ||
+          camera.showFocusPlane) ? (
+          <CameraFocusMaskOverlay
+            cameraDepthOfField={previewCameraDepthOfField}
+            canvasWidth={canvasWidth}
+            canvasHeight={canvasHeight}
+            zoom={view.zoom}
+            sceneCorner={sceneCorner}
+            onPointerMove={onFocusMaskPointerMove}
+            onPointerUp={onFocusMaskPointerUp}
+            onHandlePointerDown={onFocusMaskPointerDown}
+            onHandlePointerMove={onFocusMaskPointerMove}
+            onHandlePointerUp={onFocusMaskPointerUp}
+          />
+        ) : null}
       </div>
 
       {/* Zoom indicator. `data-export-hide` removes it from any
@@ -2042,6 +2372,169 @@ function toolToKind(tool: Tool): NodeKind {
 // Scene paint layer
 // ---------------------------------------------------------------------------
 
+function WorkspaceLayer({
+  order,
+  canvasWidth,
+  canvasHeight,
+  zoom,
+}: {
+  order: NodeId[]
+  canvasWidth: number
+  canvasHeight: number
+  zoom: number
+}) {
+  const api = useSceneAPI()
+  const openContextMenu = useUI((s) => s.openContextMenu)
+  const selection = useUI((s) => s.selection)
+  const setSelection = useUI((s) => s.setSelection)
+
+  const inherited = useMemo(() => {
+    const map: Record<NodeId, InheritedAnim> = {}
+    const visit = (id: NodeId, inherit: InheritedAnim) => {
+      const node = api.getNode(id)
+      if (!node) return
+      map[id] = inherit
+      const next: InheritedAnim = {
+        x: inherit.x + node.transform.x,
+        y: inherit.y + node.transform.y,
+        z: inherit.z + node.transform.z,
+        rotation: inherit.rotation + node.transform.rotation,
+        rotationX: inherit.rotationX + node.transform.rotationX,
+        rotationY: inherit.rotationY + node.transform.rotationY,
+        scaleX: inherit.scaleX * node.transform.scaleX,
+        scaleY: inherit.scaleY * node.transform.scaleY,
+        opacity: inherit.opacity * node.appearance.opacity,
+      }
+      for (const child of api.getChildren(id)) visit(child.id, next)
+    }
+    for (const id of order) {
+      const node = api.getNode(id)
+      if (node?.parent === null) visit(id, IDENTITY_INHERITED)
+    }
+    return map
+  }, [api, order])
+
+  if (order.length === 0) return null
+
+  return (
+    <div
+      className="absolute overflow-visible"
+      data-export-hide="1"
+      style={{
+        left: -canvasWidth / 2,
+        top: -canvasHeight / 2,
+        width: canvasWidth,
+        height: canvasHeight,
+      }}
+    >
+      {order.map((id) => {
+        const node = api.getNode(id)
+        if (!node || !node.visible) return null
+        const rect = workspaceRectForNode(node)
+        const inherit = inherited[id] ?? IDENTITY_INHERITED
+        const selected = selection.includes(id)
+        const selectedX = rect.x + node.transform.x + inherit.x
+        const selectedY = rect.y + node.transform.y + inherit.y
+        return (
+          <div key={id} className="absolute left-0 top-0">
+            <NodeView
+              node={node}
+              rect={rect}
+              anim={undefined}
+              inherit={inherit}
+              isRoot={false}
+              isSelected={selected}
+              onClick={(e) => {
+                e.stopPropagation()
+              }}
+              onContextMenu={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                const targetIds = selection.includes(id) ? selection : [id]
+                if (!selection.includes(id)) setSelection([id])
+                openContextMenu({
+                  x: e.clientX,
+                  y: e.clientY,
+                  items: buildNodeContextMenu(api, targetIds),
+                })
+              }}
+            />
+            {selected ? (
+              <div
+                className="pointer-events-none absolute"
+                style={{
+                  left: selectedX,
+                  top: selectedY,
+                  width: rect.width,
+                  height: rect.height,
+                  border: `${1.5 / Math.max(zoom, 0.001)}px solid oklch(0.64 0.24 300)`,
+                  boxShadow: `0 0 0 ${3 / Math.max(zoom, 0.001)}px oklch(0.64 0.24 300 / 0.16)`,
+                }}
+              />
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function workspaceRectForNode(node: SceneNode): Rect {
+  const width =
+    'size' in node
+      ? numericSizeAxis(node.size.width, node.kind === 'text' ? 72 : 100)
+      : 100
+  const height =
+    'size' in node
+      ? numericSizeAxis(node.size.height, node.kind === 'text' ? 24 : 100)
+      : 100
+  if (node.kind === 'text') {
+    const textWidth = Math.max(24, node.text.length * node.fontSize * 0.58)
+    return {
+      x: 0,
+      y: 0,
+      width: node.size.width === 'hug' ? textWidth : width,
+      height: node.size.height === 'hug' ? node.fontSize * node.lineHeight : height,
+    }
+  }
+  return {
+    x: 0,
+    y: 0,
+    width,
+    height,
+  }
+}
+
+function workspaceInheritedTransform(api: SceneAPI, node: SceneNode): InheritedAnim {
+  let inherit = IDENTITY_INHERITED
+  let parentId = node.parent
+  const ancestors: SceneNode[] = []
+  while (parentId) {
+    const parent = api.getNode(parentId)
+    if (!parent) break
+    ancestors.push(parent)
+    parentId = parent.parent
+  }
+  for (const parent of ancestors.reverse()) {
+    inherit = {
+      x: inherit.x + parent.transform.x,
+      y: inherit.y + parent.transform.y,
+      z: inherit.z + parent.transform.z,
+      rotation: inherit.rotation + parent.transform.rotation,
+      rotationX: inherit.rotationX + parent.transform.rotationX,
+      rotationY: inherit.rotationY + parent.transform.rotationY,
+      scaleX: inherit.scaleX * parent.transform.scaleX,
+      scaleY: inherit.scaleY * parent.transform.scaleY,
+      opacity: inherit.opacity * parent.appearance.opacity,
+    }
+  }
+  return inherit
+}
+
+function numericSizeAxis(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
 /**
  * Paints the scene graph into an absolutely-positioned tree of NodeView
  * divs. Exported so the render-window shell can reuse the exact same
@@ -2057,16 +2550,12 @@ export function SceneLayer({
   order,
   animated,
   inherited,
-  cameraDepthOfField,
-  onNodeClick,
 }: {
   rootId: NodeId | null
   solved: SolvedLayout
   order: NodeId[]
   animated: Record<NodeId, AnimatedValue>
   inherited: Record<NodeId, InheritedAnim>
-  cameraDepthOfField?: CameraDepthOfField | null
-  onNodeClick: (id: NodeId, additive: boolean) => void
 }) {
   const api = useSceneAPI()
   const sceneVersion = useSceneVersion() // re-render on mutations
@@ -2254,14 +2743,12 @@ export function SceneLayer({
             rect={rect}
             anim={animated[id]}
             inherit={inherit}
-            cameraDepthOfField={cameraDepthOfField}
             isRoot={id === rootId}
             isSelected={selection.includes(id)}
             ancestorClip={ancestorClip[id]}
             maskedBy={maskInfo[id]}
             onClick={(e) => {
               e.stopPropagation()
-              onNodeClick(id, e.shiftKey || e.metaKey)
             }}
             onContextMenu={(e) => {
               // Skip context menu on the root — there's nothing useful
@@ -2285,7 +2772,6 @@ export function SceneLayer({
             rect={rect}
             anim={animated[id]}
             inherit={inherited[id] ?? IDENTITY_INHERITED}
-            cameraDepthOfField={cameraDepthOfField}
             isRoot={id === rootId}
           />
         )
@@ -2308,14 +2794,12 @@ function ClippedFrameStrokeOverlay({
   rect,
   anim,
   inherit,
-  cameraDepthOfField,
   isRoot,
 }: {
   node: SceneNode
   rect: Rect
   anim: AnimatedValue | undefined
   inherit: InheritedAnim
-  cameraDepthOfField?: CameraDepthOfField | null
   isRoot: boolean
 }) {
   if (isRoot || node.kind !== 'frame' || !node.clipsContent) return null
@@ -2344,6 +2828,10 @@ function ClippedFrameStrokeOverlay({
   const sx = ownSX * inherit.scaleX
   const sy = ownSY * inherit.scaleY
   const opacity = ownOp * inherit.opacity
+  const anchorX = anim?.anchorX ?? node.transform.anchorX ?? 0.5
+  const anchorY = anim?.anchorY ?? node.transform.anchorY ?? 0.5
+  const anchorZ = anim?.anchorZ ?? node.transform.anchorZ ?? 0
+  const transformOrigin = `${Number((anchorX * 100).toFixed(3))}% ${Number((anchorY * 100).toFixed(3))}% ${Number(anchorZ.toFixed(3))}px`
 
   const parts: string[] = []
   const transformSpace = node.transform.space ?? 'local'
@@ -2354,14 +2842,6 @@ function ClippedFrameStrokeOverlay({
   if (rotation !== 0) parts.push(`rotate(${rotation}deg)`)
   if (transformSpace === 'local' && tz !== 0) parts.push(`translateZ(${tz}px)`)
   if (sx !== 1 || sy !== 1) parts.push(`scale(${sx}, ${sy})`)
-  const depthBlur = depthOfFieldBlurForNode(
-    cameraDepthOfField,
-    node,
-    anim,
-    inherit,
-    isRoot,
-  )
-
   return (
     <div
       aria-hidden
@@ -2373,9 +2853,8 @@ function ClippedFrameStrokeOverlay({
         height: rect.height,
         opacity,
         transform: parts.length > 0 ? parts.join(' ') : undefined,
-        transformOrigin: 'center center',
+        transformOrigin,
         transformStyle: 'preserve-3d',
-        filter: depthBlur > 0.05 ? `blur(${Number(depthBlur.toFixed(2))}px)` : undefined,
       }}
     >
       <StrokeOverlay
@@ -2391,7 +2870,16 @@ function ClippedFrameStrokeOverlay({
   )
 }
 
-export function CameraFocusBlurOverlay({
+/**
+ * Scene-level effects compositor.
+ *
+ * This is intentionally a whole-scene pass, not a NodeView/per-layer
+ * filter. Future shader work should plug in here: render a source scene
+ * pass, then apply masks/effects to the composed scene or to explicitly
+ * selected subtrees. `group3d` remains below this layer in the normal
+ * scene renderer, so DOM auto-layout and 3D grouping are preserved.
+ */
+export function ScenePostProcessLayer({
   rootId,
   solved,
   order,
@@ -2402,6 +2890,8 @@ export function CameraFocusBlurOverlay({
   canvasWidth,
   canvasHeight,
   sceneCorner,
+  sceneContentStyle,
+  includeSceneFill = false,
 }: {
   rootId: NodeId | null
   solved: SolvedLayout
@@ -2413,116 +2903,162 @@ export function CameraFocusBlurOverlay({
   canvasWidth: number
   canvasHeight: number
   sceneCorner: number
+  sceneContentStyle?: CSSProperties
+  includeSceneFill?: boolean
 }) {
-  if (
-    !cameraDepthOfField?.enabled ||
-    cameraDepthOfField.aperture <= 0 ||
-    cameraDepthOfField.blurPx <= 0.05
-  ) {
-    return null
-  }
-
-  const radius = Math.max(1, cameraDepthOfField.focusRadius)
-  const feather = Math.max(1, cameraDepthOfField.featherPx)
-  const blur = Number(cameraDepthOfField.blurPx.toFixed(2))
-  const angle = Number(cameraDepthOfField.blurAxisDeg.toFixed(2))
-  const horizontalBias =
-    Math.abs(Math.cos(degToRad(angle))) > Math.abs(Math.sin(degToRad(angle)))
-  const centerPct = Math.max(
-    8,
-    Math.min(
-      92,
-      horizontalBias
-        ? (cameraDepthOfField.focusX / Math.max(1, canvasWidth)) * 100
-        : (cameraDepthOfField.focusY / Math.max(1, canvasHeight)) * 100,
-    ),
-  )
-  const bandPct = Math.max(
-    2,
-    Math.min(
-      24,
-      (Math.max(radius, feather) /
-        Math.max(1, horizontalBias ? canvasWidth : canvasHeight)) *
-        100,
-    ),
-  )
-  const linearMask = (innerScale: number, outerScale: number) => {
-    const inner = bandPct * innerScale
-    const outer = bandPct * outerScale
-    return `linear-gradient(${angle}deg, black 0%, rgba(0,0,0,0.82) ${Math.max(0, centerPct - outer)}%, transparent ${Math.max(0, centerPct - inner)}%, transparent ${Math.min(100, centerPct + inner)}%, rgba(0,0,0,0.82) ${Math.min(100, centerPct + outer)}%, black 100%)`
-  }
-  const passes =
-    cameraDepthOfField.mode === 'screen'
-      ? [
-          {
-            blur: blur * 0.28,
-            mask: `radial-gradient(circle at ${cameraDepthOfField.focusX}px ${cameraDepthOfField.focusY}px, transparent 0px, transparent ${radius * 0.38}px, black ${radius * 0.95}px, transparent ${radius * 1.55}px)`,
-          },
-          {
-            blur: blur * 0.58,
-            mask: `radial-gradient(circle at ${cameraDepthOfField.focusX}px ${cameraDepthOfField.focusY}px, transparent 0px, transparent ${radius * 0.78}px, black ${radius + feather * 0.9}px, transparent ${radius + feather * 1.65}px)`,
-          },
-          {
-            blur,
-            mask: `radial-gradient(circle at ${cameraDepthOfField.focusX}px ${cameraDepthOfField.focusY}px, transparent 0px, transparent ${radius}px, rgba(0,0,0,0.35) ${radius + feather * 0.45}px, black ${radius + feather}px)`,
-          },
-        ]
-      : [
-          { blur: blur * 0.22, mask: linearMask(0.9, 1.9) },
-          { blur: blur * 0.55, mask: linearMask(1.35, 3.1) },
-          { blur, mask: linearMask(2.0, 5.2) },
-        ]
-
-  return (
+  const sceneBody = (
     <>
-      {passes.map((pass, index) => (
+      {includeSceneFill && sceneFill ? (
         <div
-          key={index}
-          aria-hidden
-          className="pointer-events-none absolute inset-0"
+          className="pointer-events-none absolute"
           style={{
-            filter: `blur(${Number(pass.blur.toFixed(2))}px)`,
-            WebkitMaskImage: pass.mask,
-            maskImage: pass.mask,
-            WebkitMaskRepeat: 'no-repeat',
-            maskRepeat: 'no-repeat',
-          }}
-        >
-          {sceneFill ? (
-            <div
-              className="pointer-events-none absolute"
-              style={{
-                left: 0,
-                top: 0,
-                width: canvasWidth,
-                height: canvasHeight,
-                background: sceneFill,
-                borderRadius: Math.max(0, sceneCorner),
-              }}
-            />
-          ) : null}
-          <SceneLayer
-            rootId={rootId}
-            solved={solved}
-            order={order}
-            animated={animated}
-            inherited={inherited}
-            onNodeClick={() => {}}
-          />
-        </div>
-      ))}
-      {cameraDepthOfField.iso > 100 ? (
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 opacity-[0.035] mix-blend-multiply"
-          style={{
-            backgroundImage:
-              'radial-gradient(circle at 20% 30%, #000 0 0.7px, transparent 0.8px), radial-gradient(circle at 70% 60%, #000 0 0.6px, transparent 0.7px)',
-            backgroundSize: `${Math.max(2, 900 / cameraDepthOfField.iso)}px ${Math.max(2, 900 / cameraDepthOfField.iso)}px`,
+            left: 0,
+            top: 0,
+            width: canvasWidth,
+            height: canvasHeight,
+            background: sceneFill,
+            borderRadius: Math.max(0, sceneCorner),
           }}
         />
       ) : null}
+      <SceneLayer
+        rootId={rootId}
+        solved={solved}
+        order={order}
+        animated={animated}
+        inherited={inherited}
+      />
     </>
+  )
+  const scene = sceneContentStyle ? (
+    <div
+      data-three-texture-source="1"
+      className="absolute inset-0"
+      style={sceneContentStyle}
+    >
+      {sceneBody}
+    </div>
+  ) : (
+    sceneBody
+  )
+  if (
+    !cameraDepthOfField?.enabled ||
+    cameraDepthOfField.blurPx <= 0.05
+  ) {
+    return scene
+  }
+
+  const radius = Math.max(1, cameraDepthOfField.focusRadius)
+  const feather = Math.max(24, cameraDepthOfField.featherPx * 1.4)
+  const blur = Number(cameraDepthOfField.blurPx.toFixed(2))
+
+  return (
+    <SnapshotCompositor
+      width={canvasWidth}
+      height={canvasHeight}
+      focus={{
+        enabled: true,
+        focusX: cameraDepthOfField.focusX,
+        focusY: cameraDepthOfField.focusY,
+        radius,
+        feather,
+        blurPx: blur,
+        iso: cameraDepthOfField.iso,
+      }}
+    >
+      {scene}
+    </SnapshotCompositor>
+  )
+}
+
+function CameraFocusMaskOverlay({
+  cameraDepthOfField,
+  canvasWidth,
+  canvasHeight,
+  zoom,
+  sceneCorner,
+  onPointerMove,
+  onPointerUp,
+  onHandlePointerDown,
+  onHandlePointerMove,
+  onHandlePointerUp,
+}: {
+  cameraDepthOfField: CameraDepthOfField
+  canvasWidth: number
+  canvasHeight: number
+  zoom: number
+  sceneCorner: number
+  onPointerMove: (e: React.PointerEvent<HTMLElement>) => void
+  onPointerUp: (e: React.PointerEvent<HTMLElement>) => void
+  onHandlePointerDown: (e: React.PointerEvent<HTMLButtonElement>) => void
+  onHandlePointerMove: (e: React.PointerEvent<HTMLElement>) => void
+  onHandlePointerUp: (e: React.PointerEvent<HTMLElement>) => void
+}) {
+  const safeZoom = Math.max(zoom, 0.001)
+  const radius = Math.max(1, cameraDepthOfField.focusRadius)
+  const falloff = Math.max(1, cameraDepthOfField.focusFalloff)
+  const outerRadius = radius + falloff
+  const x = cameraDepthOfField.focusX
+  const y = cameraDepthOfField.focusY
+  const stroke = 1.5 / safeZoom
+  const handleSize = 18 / safeZoom
+  return (
+    <div
+      data-export-hide="1"
+      className="pointer-events-none absolute overflow-hidden"
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      style={{
+        left: -canvasWidth / 2,
+        top: -canvasHeight / 2,
+        width: canvasWidth,
+        height: canvasHeight,
+        borderRadius: Math.max(0, sceneCorner),
+      }}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute rounded-full"
+        style={{
+          left: x - outerRadius,
+          top: y - outerRadius,
+          width: outerRadius * 2,
+          height: outerRadius * 2,
+          border: `${stroke}px dashed color-mix(in oklab, var(--color-accent) 34%, transparent)`,
+          background:
+            'radial-gradient(circle, transparent 0, transparent 58%, color-mix(in oklab, var(--color-accent) 5%, transparent) 100%)',
+        }}
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute rounded-full"
+        style={{
+          left: x - radius,
+          top: y - radius,
+          width: radius * 2,
+          height: radius * 2,
+          border: `${stroke}px solid color-mix(in oklab, var(--color-accent) 62%, white 12%)`,
+          boxShadow: `0 0 0 ${4 / safeZoom}px color-mix(in oklab, var(--color-accent) 12%, transparent)`,
+        }}
+      />
+      <button
+        type="button"
+        aria-label="Move camera focus"
+        title="Move camera focus"
+        className="pointer-events-auto absolute cursor-grab rounded-full border-0 bg-accent p-0 shadow-lg active:cursor-grabbing"
+        onPointerDown={onHandlePointerDown}
+        onPointerMove={onHandlePointerMove}
+        onPointerUp={onHandlePointerUp}
+        style={{
+          left: x,
+          top: y,
+          width: handleSize,
+          height: handleSize,
+          transform: 'translate(-50%, -50%)',
+          boxShadow: `0 0 0 ${3 / safeZoom}px color-mix(in oklab, var(--color-accent) 20%, transparent), 0 ${8 / safeZoom}px ${18 / safeZoom}px color-mix(in oklab, var(--color-accent) 20%, transparent)`,
+        }}
+      />
+    </div>
   )
 }
 
@@ -2637,7 +3173,6 @@ function NodeView({
   rect,
   anim,
   inherit,
-  cameraDepthOfField,
   isRoot,
   isSelected,
   ancestorClip,
@@ -2649,7 +3184,6 @@ function NodeView({
   rect: Rect
   anim: AnimatedValue | undefined
   inherit: InheritedAnim
-  cameraDepthOfField?: CameraDepthOfField | null
   isRoot: boolean
   isSelected: boolean
   /**
@@ -2730,7 +3264,8 @@ function NodeView({
   // noise that even bled into video exports. If you want a
   // permanent silhouette around a frame, set a faint stroke or fill
   // on it; the editor outline is just an interaction affordance.
-  const needsDashedOutline = isEmptyFrame && (hovered || isSelected)
+  const needsDashedOutline =
+    isEmptyFrame && (hovered || isSelected || !!node.workspaceOnly)
 
   // Root is the artboard — no transform, no rotation, no scale. Even
   // if stale state has a non-identity transform on it, we paint it
@@ -2860,6 +3395,15 @@ function NodeView({
   if (transformSpace === 'local' && tz !== 0) parts.push(`translateZ(${tz}px)`)
   if (sx !== 1 || sy !== 1) parts.push(`scale(${sx}, ${sy})`)
   const transform = parts.length > 0 ? parts.join(' ') : undefined
+  const anchorX = isRoot ? 0.5 : anim?.anchorX ?? node.transform.anchorX ?? 0.5
+  const anchorY = isRoot ? 0.5 : anim?.anchorY ?? node.transform.anchorY ?? 0.5
+  const anchorZ = isRoot ? 0 : anim?.anchorZ ?? node.transform.anchorZ ?? 0
+  const transformOrigin = `${Number((anchorX * 100).toFixed(3))}% ${Number((anchorY * 100).toFixed(3))}% ${Number(anchorZ.toFixed(3))}px`
+  const hasProjected3D =
+    Math.abs(rotationX) > 0.001 ||
+    Math.abs(rotationY) > 0.001 ||
+    Math.abs(rotation) > 0.001 ||
+    Math.abs(tz) > 0.001
 
   const clips = node.kind === 'frame' && node.clipsContent
 
@@ -2955,16 +3499,6 @@ function NodeView({
     }
   }
   const effectShadowCss = effectShadowParts.join(', ')
-  const depthBlur = depthOfFieldBlurForNode(
-    cameraDepthOfField,
-    node,
-    anim,
-    inherit,
-    isRoot,
-  )
-  if (depthBlur > 0.05) {
-    effectFilterParts.push(`blur(${Number(depthBlur.toFixed(2))}px)`)
-  }
   const effectFilterCss = effectFilterParts.join(' ')
 
   // Compose the final box-shadow string. Stroke shadow first so a
@@ -3001,18 +3535,19 @@ function NodeView({
   //
   // When there's no clipping ancestor, render the styled box directly
   // (no wrapper) so unrelated nodes pay no DOM cost.
+  const effectiveAncestorClip = hasProjected3D ? undefined : ancestorClip
   const clipWrapperStyle =
-    ancestorClip && !isRoot
+    effectiveAncestorClip && !isRoot
       ? ({
           position: 'absolute' as const,
-          left: ancestorClip.rect.x,
-          top: ancestorClip.rect.y,
-          width: ancestorClip.rect.width,
-          height: ancestorClip.rect.height,
+          left: effectiveAncestorClip.rect.x,
+          top: effectiveAncestorClip.rect.y,
+          width: effectiveAncestorClip.rect.width,
+          height: effectiveAncestorClip.rect.height,
           overflow: 'hidden' as const,
           borderRadius: cornerRadiusCss(
-            ancestorClip.cornerRadius,
-            ancestorClip.cornerRadii,
+            effectiveAncestorClip.cornerRadius,
+            effectiveAncestorClip.cornerRadii,
           ),
           // Clip wrapper itself shouldn't intercept clicks — it's an
           // invisible mask. Inner re-enables pointer events so clicks
@@ -3035,8 +3570,8 @@ function NodeView({
 
   // Inner box position. When wrapped, left/top become relative to the
   // clip wrapper's local coords; when not wrapped, they're world coords.
-  const innerLeft = clipWrapperStyle ? rect.x - ancestorClip!.rect.x : rect.x
-  const innerTop = clipWrapperStyle ? rect.y - ancestorClip!.rect.y : rect.y
+  const innerLeft = clipWrapperStyle ? rect.x - effectiveAncestorClip!.rect.x : rect.x
+  const innerTop = clipWrapperStyle ? rect.y - effectiveAncestorClip!.rect.y : rect.y
 
   const innerBox = (
     <div
@@ -3045,6 +3580,16 @@ function NodeView({
       onClick={onClick}
       onContextMenu={onContextMenu}
       onDoubleClick={(e) => {
+        if (node.kind === 'component' || node.kind === 'instance') {
+          e.stopPropagation()
+          useUI
+            .getState()
+            .setComponentEditId(node.kind === 'instance' ? node.componentId : node.id)
+          useUI
+            .getState()
+            .setSelection([node.kind === 'instance' ? node.componentId : node.id])
+          return
+        }
         // Double-click on a text node enters inline edit mode —
         // matches Figma. Pointer-down already started a drag, but
         // contentEditable's focus will take over the keystroke
@@ -3073,7 +3618,7 @@ function NodeView({
         boxShadow: composedBoxShadow || undefined,
         ...(strokeBorderCss ?? {}),
         transform,
-        transformOrigin: 'center center',
+        transformOrigin,
         transformStyle: 'preserve-3d',
         filter: effectFilterCss || undefined,
         overflow: clips ? 'hidden' : undefined,

--- a/src/ui/ComponentEditor.tsx
+++ b/src/ui/ComponentEditor.tsx
@@ -1,0 +1,1356 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
+import { useSceneAPI, useSceneVersion } from '@/scene'
+import type { ComponentNode, NodeId } from '@/scene'
+import { useUI } from '@/state/ui'
+import { useLayout } from '@/ui/hooks/useLayout'
+import {
+  SceneLayer,
+  composeInheritedAnim,
+  type InheritedAnim,
+} from '@/ui/Canvas'
+import { SelectionOverlay } from '@/ui/SelectionOverlay'
+import { evaluator } from '@/anim/easing'
+import type { AnimatedValue } from '@/ui/hooks/useAnimatedValues'
+import {
+  addComponentVariantInteraction,
+  applyComponentVariantState,
+  fitComponentToChildren,
+  measureComponentChildBounds,
+  upsertComponentVariant,
+} from '@/ui/actions'
+
+const EMPTY_INHERITED: Record<NodeId, InheritedAnim> = {}
+const EMPTY_ANIMATED: Record<NodeId, AnimatedValue> = {}
+
+type SurfacePoint = { x: number; y: number }
+type ConnectorDraft = SurfacePoint & {
+  fromState: string
+  x1: number
+  y1: number
+}
+type VariantDrag = {
+  state: string
+  startClientX: number
+  startClientY: number
+  originX: number
+  originY: number
+  moved: boolean
+}
+
+export function ComponentEditor() {
+  const sceneVersion = useSceneVersion()
+  const api = useSceneAPI()
+  const componentEditId = useUI((s) => s.componentEditId)
+  const setComponentEditId = useUI((s) => s.setComponentEditId)
+  const setSelection = useUI((s) => s.setSelection)
+  const view = useUI((s) => s.view)
+  const setView = useUI((s) => s.setView)
+  const zoomAt = useUI((s) => s.zoomAt)
+  const workspaceRef = useRef<HTMLElement>(null)
+  const surfaceRef = useRef<HTMLDivElement>(null)
+  const suppressVariantClickRef = useRef(false)
+  const [activeState, setActiveState] = useState<string | null>(null)
+  const [editingVariant, setEditingVariant] = useState<string | null>(null)
+  const [editingName, setEditingName] = useState('')
+  const [previewing, setPreviewing] = useState(false)
+  const [previewAnimated, setPreviewAnimated] = useState<Record<NodeId, AnimatedValue>>({})
+  const [connectorDraft, setConnectorDraft] = useState<ConnectorDraft | null>(null)
+  const [variantDrag, setVariantDrag] = useState<VariantDrag | null>(null)
+  const [liveVariantPositions, setLiveVariantPositions] = useState<
+    Record<string, SurfacePoint>
+  >({})
+  const seededDefaultRef = useRef<NodeId | null>(null)
+
+  const component = componentEditId
+    ? api.getNode(componentEditId)
+    : null
+  const master =
+    component && component.kind === 'component'
+      ? (component as ComponentNode)
+      : null
+
+  const container = useMemo(() => {
+    const bounds = master ? measureComponentChildBounds(api, master.id) : null
+    const hugWidth = bounds ? Math.ceil(bounds.maxX - bounds.minX) : 480
+    const hugHeight = bounds ? Math.ceil(bounds.maxY - bounds.minY) : 240
+    return {
+      width: Math.max(1, numericSize(master?.size.width, hugWidth)),
+      height: Math.max(1, numericSize(master?.size.height, hugHeight)),
+    }
+  }, [api, master, master?.id, master?.size.height, master?.size.width, sceneVersion])
+  const solved = useLayout(master?.id ?? null, container)
+  const order = useMemo<NodeId[]>(() => {
+    void sceneVersion
+    if (!master) return []
+    const out: NodeId[] = []
+    const visit = (id: NodeId) => {
+      out.push(id)
+      for (const child of api.getChildren(id)) visit(child.id)
+    }
+    visit(master.id)
+    return out
+  }, [api, master, sceneVersion])
+  const animated = previewing ? previewAnimated : EMPTY_ANIMATED
+  const inherited = useMemo(
+    () => (master ? composeInheritedAnim(api, master.id, animated, solved) : EMPTY_INHERITED),
+    [api, master, animated, solved],
+  )
+
+  const variants = master ? variantNames(master) : ['Default']
+  const baseVariants = baseVariantNames(variants)
+  const selectedState =
+    activeState && variants.includes(activeState) ? activeState : variants[0]!
+  const selectedParts = parseVariantState(selectedState)
+  const selectedBase = baseVariants.includes(selectedParts.base)
+    ? selectedParts.base
+    : baseVariants[0]!
+  const switchVariant = (nextState: string) => {
+    if (!master || nextState === selectedState) return
+    upsertComponentVariant(api, master.id, selectedState)
+    applyComponentVariantState(api, master.id, nextState)
+    setActiveState(nextState)
+    setSelection([master.id])
+  }
+  const beginRenameVariant = (name: string) => {
+    setEditingVariant(name)
+    setEditingName(name)
+  }
+  const commitRenameVariant = () => {
+    if (!master || !editingVariant) return
+    const next = editingName.trim()
+    if (!next || next === editingVariant || variants.includes(next)) {
+      setEditingVariant(null)
+      return
+    }
+    renameComponentVariant(api, master.id, editingVariant, next)
+    if (selectedState === editingVariant) setActiveState(next)
+    setEditingVariant(null)
+  }
+  const tileGap = 48
+  const tileLabelHeight = 28
+  const addTileWidth = Math.max(220, Math.min(320, container.width))
+  const tileOuterHeight = tileLabelHeight + container.height
+  const interactionSlotTop = tileOuterHeight + 54
+  const interactionSlotHeight = Math.max(180, container.height)
+  const variantPositions = useMemo(
+    () =>
+      resolveVariantPositions({
+        stored: master?.variantPositions ?? {},
+        live: liveVariantPositions,
+        baseVariants,
+        container,
+        tileGap,
+      }),
+    [
+      baseVariants,
+      container.height,
+      container.width,
+      liveVariantPositions,
+      master?.variantPositions,
+      tileGap,
+    ],
+  )
+  const selectedBasePosition = variantPositions[selectedBase] ?? { x: 0, y: 0 }
+  const surfaceWidth = Math.max(
+    620,
+    boardMaxX(variantPositions, container.width) + tileGap + addTileWidth,
+  )
+  const surfaceHeight = Math.max(
+    selectedBasePosition.y + interactionSlotTop + interactionSlotHeight,
+    Math.max(260, container.height),
+  )
+  const addVariant = () => {
+    if (!master) return
+    const name = nextVariantName(variants)
+    upsertComponentVariant(api, master.id, selectedState)
+    upsertComponentVariant(api, master.id, name)
+    applyComponentVariantState(api, master.id, name)
+    setActiveState(name)
+  }
+  const addInteractionState = (state: 'Hover' | 'Pressed') => {
+    if (!master) return
+    const name = `${selectedBase} / ${state}`
+    upsertComponentVariant(api, master.id, selectedState)
+    if (!variants.includes(name)) {
+      applyComponentVariantState(api, master.id, selectedBase)
+      upsertComponentVariant(api, master.id, name)
+      if (state === 'Hover') {
+        addComponentVariantInteraction(api, master.id, {
+          event: 'hoverIn',
+          targetState: name,
+        })
+        addComponentVariantInteraction(api, master.id, {
+          event: 'hoverOut',
+          targetState: selectedBase,
+        })
+      } else {
+        addComponentVariantInteraction(api, master.id, {
+          event: 'pointerDown',
+          targetState: name,
+        })
+        addComponentVariantInteraction(api, master.id, {
+          event: 'pointerUp',
+          targetState: selectedBase,
+        })
+      }
+    }
+    applyComponentVariantState(api, master.id, name)
+    setActiveState(name)
+    setSelection([master.id])
+  }
+  const screenToSurfacePoint = (clientX: number, clientY: number): SurfacePoint | null => {
+    const rect = surfaceRef.current?.getBoundingClientRect()
+    if (!rect) return null
+    return {
+      x: (clientX - rect.left) / view.zoom,
+      y: (clientY - rect.top) / view.zoom,
+    }
+  }
+  const startConnector = (
+    event: ReactPointerEvent,
+    fromState: string,
+    x1: number,
+    y1: number,
+  ) => {
+    event.preventDefault()
+    event.stopPropagation()
+    const point = screenToSurfacePoint(event.clientX, event.clientY) ?? { x: x1, y: y1 }
+    setConnectorDraft({ fromState, x1, y1, x: point.x, y: point.y })
+  }
+  const startVariantDrag = (
+    event: ReactPointerEvent,
+    state: string,
+    origin: SurfacePoint,
+  ) => {
+    if (editingVariant) return
+    setVariantDrag({
+      state,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      originX: origin.x,
+      originY: origin.y,
+      moved: false,
+    })
+  }
+  const finishConnector = (point: SurfacePoint) => {
+    if (!master || !connectorDraft) return
+    const target = findConnectorTarget(point, {
+      variants,
+      baseVariants,
+      selectedBase,
+      positions: variantPositions,
+      container,
+      tileGap,
+      tileLabelHeight,
+      interactionSlotTop,
+      interactionSlotHeight,
+      addTileWidth,
+    })
+    setConnectorDraft(null)
+    if (!target) return
+    if (target.kind === 'variant' && target.state === connectorDraft.fromState) return
+    if (target.kind === 'variant') {
+      addComponentVariantInteraction(api, master.id, {
+        event: 'click',
+        targetState: target.state,
+      })
+      return
+    }
+    addInteractionState(target.state)
+  }
+  const fitComponent = () => {
+    const el = workspaceRef.current
+    if (!el) {
+      setView({ zoom: 1, panX: 0, panY: 0 })
+      return
+    }
+    const rect = el.getBoundingClientRect()
+    const targetZoom = Math.min(
+      1.5,
+      Math.max(
+        0.25,
+        Math.min(
+          (rect.width - 160) / Math.max(surfaceWidth, 1),
+          (rect.height - 180) / Math.max(surfaceHeight, 1),
+        ),
+      ),
+    )
+    setView({ zoom: targetZoom, panX: 0, panY: 0 })
+  }
+
+  useEffect(() => {
+    if (!master) return
+    if (seededDefaultRef.current !== master.id) {
+      const hasDefaultSnapshot = master.variantOverrides.some(
+        (entry) => entry.match.State === 'Default',
+      )
+      if (!hasDefaultSnapshot) upsertComponentVariant(api, master.id, 'Default')
+      seededDefaultRef.current = master.id
+    }
+    if (fitComponentToChildren(api, master.id, { preserveHug: true })) return
+    requestAnimationFrame(fitComponent)
+  }, [api, master?.id, sceneVersion])
+
+  useEffect(() => {
+    const el = workspaceRef.current
+    if (!el) return
+    const onWheel = (e: WheelEvent) => {
+      if (!el.contains(e.target as Node)) return
+      e.preventDefault()
+      const rect = el.getBoundingClientRect()
+      const ox = e.clientX - rect.left - rect.width / 2
+      const oy = e.clientY - rect.top - rect.height / 2
+      if (e.ctrlKey || e.metaKey) {
+        const factor = Math.exp(-e.deltaY * 0.01)
+        zoomAt(view.zoom * factor, ox, oy)
+      } else {
+        setView({ panX: view.panX - e.deltaX, panY: view.panY - e.deltaY })
+      }
+    }
+    el.addEventListener('wheel', onWheel, { capture: true, passive: false })
+    return () => el.removeEventListener('wheel', onWheel, { capture: true })
+  }, [setView, view.panX, view.panY, view.zoom, zoomAt])
+
+  useEffect(() => {
+    if (!connectorDraft) return
+    const onMove = (event: PointerEvent) => {
+      const point = screenToSurfacePoint(event.clientX, event.clientY)
+      if (!point) return
+      setConnectorDraft((draft) =>
+        draft ? { ...draft, x: point.x, y: point.y } : draft,
+      )
+    }
+    const onUp = (event: PointerEvent) => {
+      const point = screenToSurfacePoint(event.clientX, event.clientY)
+      if (point) finishConnector(point)
+      else setConnectorDraft(null)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setConnectorDraft(null)
+      }
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp, { once: true })
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [connectorDraft, variantPositions, view.zoom])
+
+  useEffect(() => {
+    if (!variantDrag || !master) return
+    const onMove = (event: PointerEvent) => {
+      const dx = (event.clientX - variantDrag.startClientX) / view.zoom
+      const dy = (event.clientY - variantDrag.startClientY) / view.zoom
+      const moved = variantDrag.moved || Math.hypot(dx, dy) > 3
+      const next = {
+        x: Math.round(variantDrag.originX + dx),
+        y: Math.round(variantDrag.originY + dy),
+      }
+      setVariantDrag({ ...variantDrag, moved })
+      setLiveVariantPositions((positions) => ({
+        ...positions,
+        [variantDrag.state]: next,
+      }))
+    }
+    const onUp = () => {
+      const latest =
+        liveVariantPositions[variantDrag.state] ?? {
+          x: variantDrag.originX,
+          y: variantDrag.originY,
+        }
+      api.setNodeProperty(master.id, 'variantPositions', {
+        ...(master.variantPositions ?? {}),
+        [variantDrag.state]: latest,
+      } as never)
+      suppressVariantClickRef.current = variantDrag.moved
+      setVariantDrag(null)
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp, { once: true })
+    return () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+    }
+  }, [api, liveVariantPositions, master, variantDrag, view.zoom])
+
+  const playPrototype = () => {
+    if (!master) return
+    const variant = master.variantOverrides.find(
+      (entry) => entry.match.State === selectedState,
+    )
+    if (!variant) {
+      setPreviewing(false)
+      setPreviewAnimated({})
+      return
+    }
+    const duration = Math.max(0.01, master.variantTransition.duration || 0.3)
+    const ease = evaluator(master.variantTransition.easing)
+    const starts: Record<NodeId, AnimatedValue> = {}
+    const targets: Record<NodeId, AnimatedValue> = {}
+    for (const [nodeId, patch] of Object.entries(variant.overrides)) {
+      const node = api.getNode(nodeId)
+      if (!node) continue
+      starts[nodeId] = {
+        x: node.transform.x,
+        y: node.transform.y,
+        z: node.transform.z,
+        rotation: node.transform.rotation,
+        rotationX: node.transform.rotationX,
+        rotationY: node.transform.rotationY,
+        scaleX: node.transform.scaleX,
+        scaleY: node.transform.scaleY,
+        opacity: node.appearance.opacity,
+        cornerRadius: node.appearance.cornerRadius,
+      }
+      targets[nodeId] = previewTargetForPatch(starts[nodeId]!, patch)
+    }
+    setPreviewing(true)
+    const startedAt = performance.now()
+    let raf = 0
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - startedAt) / (duration * 1000))
+      const u = ease(t)
+      const next: Record<NodeId, AnimatedValue> = {}
+      for (const [nodeId, start] of Object.entries(starts)) {
+        const target = targets[nodeId]
+        if (!target) continue
+        next[nodeId] = interpolatePreviewValue(start, target, u)
+      }
+      setPreviewAnimated(next)
+      if (t < 1) {
+        raf = requestAnimationFrame(tick)
+      } else {
+        window.setTimeout(() => {
+          setPreviewing(false)
+          setPreviewAnimated({})
+        }, 180)
+      }
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }
+
+  if (!master) {
+    return (
+      <main className="flex min-w-0 flex-1 items-center justify-center bg-app-bg text-[13px] text-text-dim">
+        <button
+          type="button"
+          onClick={() => setComponentEditId(null)}
+          className="rounded-md border border-border px-3 py-2 text-text-muted hover:bg-panel-raised hover:text-text"
+        >
+          Back to canvas
+        </button>
+      </main>
+    )
+  }
+
+  return (
+    <main className="relative flex min-w-0 flex-1 flex-col overflow-hidden bg-app-bg">
+      <div className="z-10 flex h-12 shrink-0 items-center justify-between gap-4 border-b border-border bg-panel px-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setComponentEditId(null)
+              setSelection([master.id])
+            }}
+            className="rounded-md bg-panel-raised px-3 py-1.5 text-[12px] font-medium text-text-muted hover:text-text"
+          >
+            Home
+          </button>
+          <span className="text-text-dim">›</span>
+          <div className="flex min-w-0 items-center gap-2 rounded-md bg-[oklch(0.64_0.24_300_/_0.18)] px-3 py-1.5 text-[12px] font-semibold text-[oklch(0.76_0.22_300)]">
+            <span className="font-mono">◆</span>
+            <span className="max-w-[220px] truncate">{master.name}</span>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={playPrototype}
+            className="h-8 rounded-md bg-[oklch(0.64_0.24_300)] px-3 text-[12px] font-semibold text-white shadow-sm"
+          >
+            {previewing ? 'Playing' : 'Play'}
+          </button>
+          <div className="flex items-center gap-1 rounded-md border border-border bg-app-bg p-1">
+            <button
+              type="button"
+              onClick={fitComponent}
+              className="h-7 rounded px-2 text-[11px] font-semibold text-text-muted hover:bg-panel-raised hover:text-text"
+            >
+              Fit
+            </button>
+            <button
+              type="button"
+              onClick={() => setView({ zoom: 1, panX: 0, panY: 0 })}
+              className="h-7 rounded px-2 text-[11px] font-semibold text-text-muted hover:bg-panel-raised hover:text-text"
+            >
+              100%
+            </button>
+            <span className="px-2 font-mono text-[11px] text-text-dim">
+              {Math.round(view.zoom * 100)}%
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        ref={workspaceRef}
+        className="relative min-h-0 flex-1 overflow-hidden bg-app-bg"
+      >
+        <div className="absolute inset-0">
+          <div
+            ref={surfaceRef}
+            className="absolute left-1/2 top-1/2"
+            style={{
+              width: surfaceWidth,
+              height: surfaceHeight,
+              marginLeft: -surfaceWidth / 2,
+              marginTop: -surfaceHeight / 2,
+              transform: `translate(${view.panX}px, ${view.panY}px) scale(${view.zoom})`,
+              transformOrigin: 'center center',
+            }}
+          >
+            <ConnectorOverlay
+              master={master}
+              variants={variants}
+              baseVariants={baseVariants}
+              selectedBase={selectedBase}
+              selectedState={selectedState}
+              positions={variantPositions}
+              container={container}
+              tileGap={tileGap}
+              tileLabelHeight={tileLabelHeight}
+              interactionSlotTop={interactionSlotTop}
+              interactionSlotHeight={interactionSlotHeight}
+              surfaceWidth={surfaceWidth}
+              surfaceHeight={surfaceHeight}
+              draft={connectorDraft}
+            />
+            {baseVariants.map((name, index) => {
+              const isActive = name === selectedState
+              const isFamilyActive = name === selectedBase
+              const tilePosition = variantPositions[name] ?? {
+                x: index * (container.width + tileGap),
+                y: 0,
+              }
+              const tileAnimated = isActive
+                ? animated
+                : variantPreviewAnimated(master, name)
+              const tileInherited = isActive
+                ? inherited
+                : composeInheritedAnim(api, master.id, tileAnimated, solved)
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  onClick={() => {
+                    if (suppressVariantClickRef.current) {
+                      suppressVariantClickRef.current = false
+                      return
+                    }
+                    switchVariant(name)
+                  }}
+                  onPointerDown={(event) =>
+                    startVariantDrag(event, name, tilePosition)
+                  }
+                  onDoubleClick={(event) => {
+                    event.stopPropagation()
+                    beginRenameVariant(name)
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.preventDefault()
+                      beginRenameVariant(name)
+                    }
+                  }}
+                  className="absolute block text-left outline-none"
+                  style={{
+                    left: tilePosition.x,
+                    top: tilePosition.y,
+                    width: container.width,
+                    height: tileOuterHeight,
+                  }}
+                >
+                  <div
+                    className={[
+                      'mb-2 flex h-5 items-center gap-2 text-[11px] font-semibold',
+                      isFamilyActive
+                        ? 'text-[oklch(0.5_0.22_300)]'
+                        : 'text-text-muted',
+                    ].join(' ')}
+                  >
+                    <span
+                      className={[
+                        'grid h-4 w-4 place-items-center rounded',
+                        isFamilyActive
+                          ? 'bg-[oklch(0.64_0.24_300)] text-white'
+                          : 'bg-panel-raised text-[oklch(0.64_0.24_300)]',
+                      ].join(' ')}
+                    >
+                      {isFamilyActive ? '▶' : '◆'}
+                    </span>
+                    {editingVariant === name ? (
+                      <input
+                        value={editingName}
+                        onChange={(event) => setEditingName(event.target.value)}
+                        onBlur={commitRenameVariant}
+                        onClick={(event) => event.stopPropagation()}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') commitRenameVariant()
+                          if (event.key === 'Escape') setEditingVariant(null)
+                        }}
+                        autoFocus
+                        className="h-6 w-36 rounded border border-[oklch(0.64_0.24_300)] bg-panel px-1.5 text-[11px] text-text outline-none"
+                      />
+                    ) : (
+                      <span className="max-w-full truncate">{name}</span>
+                    )}
+                  </div>
+                  <div
+                    className={[
+                      'relative overflow-visible rounded-lg border bg-panel shadow-2xl',
+                      isActive
+                        ? 'border-[oklch(0.64_0.24_300)]'
+                        : 'border-border hover:border-[oklch(0.64_0.24_300_/_0.45)]',
+                    ].join(' ')}
+                    style={{
+                      width: container.width,
+                      height: container.height,
+                    }}
+                  >
+                    {!solved ? (
+                      <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 font-mono text-[11px] text-text-dim">
+                        preparing component…
+                      </span>
+                    ) : (
+                      <div className={isActive || isFamilyActive ? '' : 'pointer-events-none'}>
+                        <SceneLayer
+                          rootId={master.id}
+                          solved={solved}
+                          order={order}
+                          animated={tileAnimated}
+                          inherited={tileInherited}
+                        />
+                        {isActive ? (
+                          <div className="pointer-events-none absolute inset-0">
+                            <SelectionOverlay
+                              solved={solved}
+                              animated={tileAnimated}
+                              inherited={tileInherited}
+                              zoom={view.zoom}
+                              rootId={master.id}
+                            />
+                          </div>
+                        ) : null}
+                        {isFamilyActive ? (
+                          <>
+                            <span className="pointer-events-none absolute left-[-9px] top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border-2 border-[oklch(0.64_0.24_300)] bg-panel" />
+                            <span
+                              role="button"
+                              tabIndex={0}
+                              onPointerDown={(event) =>
+                                startConnector(
+                                  event,
+                                  name,
+                                  tilePosition.x + container.width + 14,
+                                  tilePosition.y + tileLabelHeight + container.height / 2,
+                                )
+                              }
+                              className="absolute right-[-17px] top-1/2 z-20 grid h-8 w-8 -translate-y-1/2 cursor-crosshair place-items-center rounded-full border-2 border-[oklch(0.64_0.24_300)] bg-panel text-[oklch(0.64_0.24_300)] shadow-sm hover:bg-[oklch(0.64_0.24_300)] hover:text-white"
+                              title="Drag to another variant"
+                            >
+                              ⚡
+                            </span>
+                          </>
+                        ) : null}
+                      </div>
+                    )}
+                  </div>
+                </button>
+              )
+            })}
+            <button
+              type="button"
+              onClick={addVariant}
+              className="absolute grid place-items-center rounded-lg border border-dashed border-border bg-panel text-center text-text-dim hover:border-[oklch(0.64_0.24_300_/_0.55)] hover:text-[oklch(0.5_0.22_300)]"
+              style={{
+                left: boardMaxX(variantPositions, container.width) + tileGap,
+                top: tileLabelHeight,
+                width: addTileWidth,
+                height: Math.max(140, container.height),
+              }}
+            >
+              <span className="flex flex-col items-center gap-3">
+                <span className="grid h-8 w-8 place-items-center rounded-full bg-panel-raised text-lg font-semibold">
+                  +
+                </span>
+                <span className="text-[13px] font-medium">
+                  {nextVariantName(variants)}
+                </span>
+              </span>
+            </button>
+            <InteractionStateSlot
+              master={master}
+              baseName={selectedBase}
+              selectedState={selectedState}
+              variants={variants}
+              left={selectedBasePosition.x}
+              top={selectedBasePosition.y + interactionSlotTop}
+              width={container.width}
+              height={interactionSlotHeight}
+              onSwitch={switchVariant}
+              onAdd={addInteractionState}
+            />
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}
+
+function variantNames(component: ComponentNode): string[] {
+  const axis = component.variants.find((variant) => variant.name === 'State')
+  const values = axis?.values.length ? axis.values : ['Default']
+  return values
+}
+
+function baseVariantNames(variants: string[]): string[] {
+  const base = variants.filter((name) => parseVariantState(name).state === 'Primary')
+  return base.length ? base : ['Default']
+}
+
+function parseVariantState(name: string): { base: string; state: string } {
+  const [base, state] = name.split(' / ')
+  return { base: base || name, state: state || 'Primary' }
+}
+
+function nextVariantName(variants: string[]): string {
+  let index = baseVariantNames(variants).length + 1
+  let name = `Variant ${index}`
+  while (variants.includes(name)) {
+    index += 1
+    name = `Variant ${index}`
+  }
+  return name
+}
+
+function resolveVariantPositions({
+  stored,
+  live,
+  baseVariants,
+  container,
+  tileGap,
+}: {
+  stored: Record<string, SurfacePoint>
+  live: Record<string, SurfacePoint>
+  baseVariants: string[]
+  container: { width: number; height: number }
+  tileGap: number
+}): Record<string, SurfacePoint> {
+  const out: Record<string, SurfacePoint> = {}
+  baseVariants.forEach((name, index) => {
+    out[name] = live[name] ?? stored[name] ?? {
+      x: index * (container.width + tileGap),
+      y: 0,
+    }
+  })
+  return out
+}
+
+function boardMaxX(
+  positions: Record<string, SurfacePoint>,
+  tileWidth: number,
+): number {
+  return Math.max(
+    tileWidth,
+    ...Object.values(positions).map((point) => point.x + tileWidth),
+  )
+}
+
+function renameComponentVariant(
+  api: ReturnType<typeof useSceneAPI>,
+  componentId: NodeId,
+  oldName: string,
+  newName: string,
+): void {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return
+  api.doc.transact(() => {
+    api.setNodeProperty(
+      component.id,
+      'variants',
+      component.variants.map((axis) =>
+        axis.name === 'State'
+          ? {
+              ...axis,
+              values: axis.values.map((value) => (value === oldName ? newName : value)),
+            }
+          : axis,
+      ) as never,
+    )
+    api.setNodeProperty(
+      component.id,
+      'defaultSelection',
+      component.defaultSelection.State === oldName
+        ? { ...component.defaultSelection, State: newName }
+        : component.defaultSelection,
+    )
+    api.setNodeProperty(
+      component.id,
+      'variantOverrides',
+      component.variantOverrides.map((variant) =>
+        variant.match.State === oldName
+          ? { ...variant, match: { ...variant.match, State: newName } }
+          : variant,
+      ) as never,
+    )
+    api.setNodeProperty(
+      component.id,
+      'interactions',
+      component.interactions.map((interaction) => ({
+        ...interaction,
+        actions: renameVariantActions(interaction.actions, oldName, newName),
+      })) as never,
+    )
+  })
+}
+
+function renameVariantActions(
+  actions: ComponentNode['interactions'][number]['actions'],
+  oldName: string,
+  newName: string,
+): ComponentNode['interactions'][number]['actions'] {
+  return actions.map((action) => {
+    if (action.type === 'setVariant' && action.selection.State === oldName) {
+      return { ...action, selection: { ...action.selection, State: newName } }
+    }
+    if (action.type === 'after') {
+      return {
+        ...action,
+        action:
+          action.action.type === 'setVariant' && action.action.selection.State === oldName
+            ? {
+                ...action.action,
+                selection: { ...action.action.selection, State: newName },
+              }
+            : action.action,
+      }
+    }
+    return action
+  })
+}
+
+function InteractionStateSlot({
+  master,
+  baseName,
+  selectedState,
+  variants,
+  left,
+  top,
+  width,
+  height,
+  onSwitch,
+  onAdd,
+}: {
+  master: ComponentNode
+  baseName: string
+  selectedState: string
+  variants: string[]
+  left: number
+  top: number
+  width: number
+  height: number
+  onSwitch: (state: string) => void
+  onAdd: (state: 'Hover' | 'Pressed') => void
+}) {
+  const hoverName = `${baseName} / Hover`
+  const pressedName = `${baseName} / Pressed`
+  const hoverExists = variants.includes(hoverName)
+  const pressedExists = variants.includes(pressedName)
+  const existing = [
+    hoverExists ? hoverName : null,
+    pressedExists ? pressedName : null,
+  ].filter(Boolean) as string[]
+  const showEmpty = existing.length === 0
+
+  return (
+    <div
+      className="absolute"
+      style={{ left, top, width, height }}
+    >
+      {existing.map((name, index) => (
+        <button
+          key={name}
+          type="button"
+          onClick={() => onSwitch(name)}
+          className={[
+            'absolute inset-x-0 rounded-lg border bg-panel text-left shadow-2xl outline-none',
+            selectedState === name
+              ? 'border-[oklch(0.64_0.24_300)]'
+              : 'border-border hover:border-[oklch(0.64_0.24_300_/_0.45)]',
+          ].join(' ')}
+          style={{
+            top: index * 48,
+            height: Math.max(44, height / 2 - 12),
+          }}
+        >
+          <span className="absolute left-4 top-3 text-[11px] font-semibold text-[oklch(0.5_0.22_300)]">
+            {parseVariantState(name).state}
+          </span>
+          <span className="absolute bottom-3 left-4 text-[11px] text-text-dim">
+            {interactionSummary(master, name)}
+          </span>
+        </button>
+      ))}
+      {showEmpty ? (
+        <div className="grid h-full place-items-center rounded-lg border border-dashed border-border bg-panel/70 text-center text-text-dim">
+          <div className="space-y-3">
+            <div className="mx-auto grid h-8 w-8 place-items-center rounded-full bg-panel-raised text-lg font-semibold">
+              +
+            </div>
+            <div className="text-[14px] font-medium">Hover / Pressed</div>
+            <div className="flex justify-center gap-2">
+              <button
+                type="button"
+                onClick={() => onAdd('Hover')}
+                className="h-8 rounded-md bg-[oklch(0.64_0.24_300)] px-3 text-[11px] font-semibold text-white"
+              >
+                Hover
+              </button>
+              <button
+                type="button"
+                onClick={() => onAdd('Pressed')}
+                className="h-8 rounded-md border border-border bg-panel px-3 text-[11px] font-semibold text-text-muted hover:text-text"
+              >
+                Pressed
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => onAdd(hoverExists ? 'Pressed' : 'Hover')}
+          className="absolute bottom-0 grid h-10 w-full place-items-center rounded-md border border-dashed border-border bg-panel/70 text-[11px] font-semibold text-text-dim hover:border-[oklch(0.64_0.24_300_/_0.55)] hover:text-[oklch(0.5_0.22_300)]"
+        >
+          + {hoverExists ? 'Pressed' : 'Hover'}
+        </button>
+      )}
+    </div>
+  )
+}
+
+function interactionSummary(component: ComponentNode, stateName: string): string {
+  const event = component.interactions.find((interaction) =>
+    interaction.actions.some((action) =>
+      action.type === 'setVariant'
+        ? action.selection.State === stateName
+        : action.type === 'after' &&
+          action.action.type === 'setVariant' &&
+          action.action.selection.State === stateName,
+    ),
+  )?.event
+  switch (event) {
+    case 'hoverIn':
+      return 'Mouse enter connector'
+    case 'pointerDown':
+      return 'Pressed connector'
+    case 'click':
+      return 'Click connector'
+    default:
+      return 'Variant connector'
+  }
+}
+
+function ConnectorOverlay({
+  master,
+  variants,
+  baseVariants,
+  selectedBase,
+  selectedState,
+  positions,
+  container,
+  tileGap,
+  tileLabelHeight,
+  interactionSlotTop,
+  interactionSlotHeight,
+  surfaceWidth,
+  surfaceHeight,
+  draft,
+}: {
+  master: ComponentNode
+  variants: string[]
+  baseVariants: string[]
+  selectedBase: string
+  selectedState: string
+  positions: Record<string, SurfacePoint>
+  container: { width: number; height: number }
+  tileGap: number
+  tileLabelHeight: number
+  interactionSlotTop: number
+  interactionSlotHeight: number
+  surfaceWidth: number
+  surfaceHeight: number
+  draft: ConnectorDraft | null
+}) {
+  const lines = connectorLinesForComponent(master, {
+    variants,
+    baseVariants,
+      selectedBase,
+      positions,
+      container,
+    tileGap,
+    tileLabelHeight,
+    interactionSlotTop,
+    interactionSlotHeight,
+  })
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 z-10 overflow-visible"
+      width={surfaceWidth}
+      height={surfaceHeight}
+      viewBox={`0 0 ${surfaceWidth} ${surfaceHeight}`}
+    >
+      <defs>
+        <marker
+          id="component-connector-arrow"
+          markerWidth="8"
+          markerHeight="8"
+          refX="6"
+          refY="4"
+          orient="auto"
+        >
+          <path d="M 0 0 L 8 4 L 0 8 z" fill="oklch(0.64 0.24 300)" />
+        </marker>
+      </defs>
+      {lines.map((line) => (
+        <ConnectorPath
+          key={`${line.fromState}-${line.toState}-${line.event}`}
+          line={line}
+          active={line.fromState === selectedState || line.fromState === selectedBase}
+        />
+      ))}
+      {draft ? (
+        <ConnectorPath
+          line={{
+            fromState: draft.fromState,
+            toState: 'draft',
+            event: 'drag',
+            x1: draft.x1,
+            y1: draft.y1,
+            x2: draft.x,
+            y2: draft.y,
+          }}
+          active
+          dashed
+        />
+      ) : null}
+    </svg>
+  )
+}
+
+function ConnectorPath({
+  line,
+  active,
+  dashed = false,
+}: {
+  line: ConnectorLine
+  active: boolean
+  dashed?: boolean
+}) {
+  const dx = Math.max(56, Math.abs(line.x2 - line.x1) * 0.45)
+  const path = `M ${line.x1} ${line.y1} C ${line.x1 + dx} ${line.y1}, ${line.x2 - dx} ${line.y2}, ${line.x2} ${line.y2}`
+  return (
+    <g opacity={active ? 1 : 0.45}>
+      <path
+        d={path}
+        fill="none"
+        stroke="oklch(0.64 0.24 300 / 0.18)"
+        strokeWidth={7}
+        strokeLinecap="round"
+      />
+      <path
+        d={path}
+        fill="none"
+        stroke="oklch(0.64 0.24 300)"
+        strokeWidth={2.25}
+        strokeLinecap="round"
+        strokeDasharray={dashed ? '8 7' : undefined}
+        markerEnd="url(#component-connector-arrow)"
+      />
+      {!dashed ? (
+        <text
+          x={(line.x1 + line.x2) / 2}
+          y={(line.y1 + line.y2) / 2 - 8}
+          textAnchor="middle"
+          className="fill-[oklch(0.5_0.22_300)] text-[10px] font-semibold"
+        >
+          {connectorEventLabel(line.event)}
+        </text>
+      ) : null}
+    </g>
+  )
+}
+
+type ConnectorLine = {
+  fromState: string
+  toState: string
+  event: string
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+}
+
+type ConnectorLayout = {
+  variants: string[]
+  baseVariants: string[]
+  selectedBase: string
+  positions: Record<string, SurfacePoint>
+  container: { width: number; height: number }
+  tileGap: number
+  tileLabelHeight: number
+  interactionSlotTop: number
+  interactionSlotHeight: number
+}
+
+function connectorLinesForComponent(
+  component: ComponentNode,
+  layout: ConnectorLayout,
+): ConnectorLine[] {
+  const lines: ConnectorLine[] = []
+  for (const interaction of component.interactions) {
+    const targetState = interactionTargetState(interaction)
+    if (!targetState || !layout.variants.includes(targetState)) continue
+    const target = connectorPointForState(targetState, layout, 'in')
+    const source = connectorPointForState(layout.selectedBase, layout, 'out')
+    if (!target || !source) continue
+    if (targetState === layout.selectedBase) continue
+    lines.push({
+      fromState: layout.selectedBase,
+      toState: targetState,
+      event: interaction.event,
+      x1: source.x,
+      y1: source.y,
+      x2: target.x,
+      y2: target.y,
+    })
+  }
+  return lines
+}
+
+function interactionTargetState(
+  interaction: ComponentNode['interactions'][number],
+): string | null {
+  const action = interaction.actions[0]
+  if (!action) return null
+  if (action.type === 'setVariant') return action.selection.State ?? null
+  if (action.type === 'after' && action.action.type === 'setVariant') {
+    return action.action.selection.State ?? null
+  }
+  return null
+}
+
+function connectorPointForState(
+  stateName: string,
+  layout: ConnectorLayout,
+  side: 'in' | 'out',
+): SurfacePoint | null {
+  const parsed = parseVariantState(stateName)
+  const baseIndex = layout.baseVariants.indexOf(parsed.base)
+  if (baseIndex < 0) return null
+  const position =
+    layout.positions[parsed.base] ?? {
+      x: baseIndex * (layout.container.width + layout.tileGap),
+      y: 0,
+    }
+  const left = position.x
+  const top = position.y
+  if (parsed.state === 'Primary') {
+    return {
+      x: side === 'out' ? left + layout.container.width + 14 : left - 8,
+      y: top + layout.tileLabelHeight + layout.container.height / 2,
+    }
+  }
+  const stateIndex = parsed.state === 'Pressed' ? 1 : 0
+  return {
+    x: side === 'out' ? left + layout.container.width + 14 : left - 8,
+    y:
+      top +
+      layout.interactionSlotTop +
+      stateIndex * 48 +
+      Math.max(44, layout.interactionSlotHeight / 2 - 12) / 2,
+  }
+}
+
+function findConnectorTarget(
+  point: SurfacePoint,
+  layout: ConnectorLayout & { addTileWidth: number },
+):
+  | { kind: 'variant'; state: string }
+  | { kind: 'interaction'; state: 'Hover' | 'Pressed' }
+  | null {
+  for (const [index, name] of layout.baseVariants.entries()) {
+    const position =
+      layout.positions[name] ?? {
+        x: index * (layout.container.width + layout.tileGap),
+        y: 0,
+      }
+    const left = position.x
+    const top = position.y
+    if (
+      point.x >= left &&
+      point.x <= left + layout.container.width &&
+      point.y >= top + layout.tileLabelHeight &&
+      point.y <= top + layout.tileLabelHeight + layout.container.height
+    ) {
+      return { kind: 'variant', state: name }
+    }
+  }
+  const selectedIndex = layout.baseVariants.indexOf(layout.selectedBase)
+  const selectedPosition =
+    layout.positions[layout.selectedBase] ?? {
+      x: selectedIndex * (layout.container.width + layout.tileGap),
+      y: 0,
+    }
+  const selectedLeft = selectedPosition.x
+  const selectedTop = selectedPosition.y
+  if (
+    point.x >= selectedLeft &&
+    point.x <= selectedLeft + layout.container.width &&
+    point.y >= selectedTop + layout.interactionSlotTop &&
+    point.y <= selectedTop + layout.interactionSlotTop + layout.interactionSlotHeight
+  ) {
+    const midpoint =
+      selectedTop + layout.interactionSlotTop + layout.interactionSlotHeight / 2
+    return { kind: 'interaction', state: point.y < midpoint ? 'Hover' : 'Pressed' }
+  }
+  return null
+}
+
+function connectorEventLabel(event: string): string {
+  switch (event) {
+    case 'hoverIn':
+      return 'Hover'
+    case 'hoverOut':
+      return 'Leave'
+    case 'pointerDown':
+      return 'Press'
+    case 'pointerUp':
+      return 'Release'
+    default:
+      return 'Click'
+  }
+}
+
+function numericSize(value: ComponentNode['size']['width'], fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function variantPreviewAnimated(
+  component: ComponentNode,
+  stateName: string,
+): Record<NodeId, AnimatedValue> {
+  const variant = component.variantOverrides.find(
+    (entry) => entry.match.State === stateName,
+  )
+  if (!variant) return EMPTY_ANIMATED
+  const out: Record<NodeId, AnimatedValue> = {}
+  for (const [nodeId, patch] of Object.entries(variant.overrides)) {
+    const value: AnimatedValue = {}
+    if (patch.transform && typeof patch.transform === 'object') {
+      const transform = patch.transform as Record<string, unknown>
+      for (const key of [
+        'x',
+        'y',
+        'z',
+        'rotation',
+        'rotationX',
+        'rotationY',
+        'scaleX',
+        'scaleY',
+      ] as const) {
+        if (typeof transform[key] === 'number') value[key] = transform[key]
+      }
+    }
+    if (patch.appearance && typeof patch.appearance === 'object') {
+      const appearance = patch.appearance as Record<string, unknown>
+      if (typeof appearance.opacity === 'number') value.opacity = appearance.opacity
+      if (typeof appearance.cornerRadius === 'number') {
+        value.cornerRadius = appearance.cornerRadius
+      }
+    }
+    out[nodeId as NodeId] = value
+  }
+  return out
+}
+
+function previewTargetForPatch(
+  start: AnimatedValue,
+  patch: Record<string, unknown>,
+): AnimatedValue {
+  const target: AnimatedValue = { ...start }
+  if (patch.transform && typeof patch.transform === 'object') {
+    const transform = patch.transform as Record<string, unknown>
+    for (const key of [
+      'x',
+      'y',
+      'z',
+      'rotation',
+      'rotationX',
+      'rotationY',
+      'scaleX',
+      'scaleY',
+    ] as const) {
+      if (typeof transform[key] === 'number') target[key] = transform[key]
+    }
+  }
+  if (patch.appearance && typeof patch.appearance === 'object') {
+    const appearance = patch.appearance as Record<string, unknown>
+    if (typeof appearance.opacity === 'number') target.opacity = appearance.opacity
+    if (typeof appearance.cornerRadius === 'number') {
+      target.cornerRadius = appearance.cornerRadius
+    }
+  }
+  return target
+}
+
+function interpolatePreviewValue(
+  start: AnimatedValue,
+  target: AnimatedValue,
+  u: number,
+): AnimatedValue {
+  const out: AnimatedValue = {}
+  for (const key of [
+    'x',
+    'y',
+    'z',
+    'rotation',
+    'rotationX',
+    'rotationY',
+    'scaleX',
+    'scaleY',
+    'opacity',
+    'cornerRadius',
+  ] as const) {
+    const a = start[key]
+    const b = target[key]
+    if (typeof a === 'number' && typeof b === 'number') {
+      out[key] = a + (b - a) * u
+    }
+  }
+  return out
+}

--- a/src/ui/Inspector.tsx
+++ b/src/ui/Inspector.tsx
@@ -13,6 +13,7 @@ import { useSceneAPI, useSceneVersion } from '@/scene'
 import type {
   Appearance,
   CameraNode,
+  ComponentPropertyDefinition,
   CornerRadii,
   Effect,
   FlexAlign,
@@ -30,6 +31,9 @@ import type {
   Stroke,
   TextNode,
   Transform,
+  Interaction,
+  InteractionEventKind,
+  VariantTransition,
 } from '@/scene'
 import { isImageFile } from '@/ui/importImage'
 import { getLastSolvedLayout } from '@/ui/hooks/lastSolvedLayout'
@@ -50,7 +54,27 @@ import {
 } from '@/ui/fields'
 import { PresetsPanel } from '@/ui/PresetsPanel'
 import { AlignTools } from '@/ui/AlignTools'
-import { setLockedRecursive, wrapInAutoLayout } from '@/ui/actions'
+import { EasingPicker } from '@/ui/EasingPicker'
+import type { EasingPresetId } from '@/anim'
+import {
+  addComponentVariantInteraction,
+  applyComponentVariantState,
+  applyInstanceVariantTransition,
+  ensureComponentStateAxis,
+  exposeComponentProperty,
+  fitComponentToChildren,
+  removeComponentProperty,
+  removeComponentInteraction,
+  removeComponentVariant,
+  resetInstanceComponentProperty,
+  setComponentSourceProperty,
+  setInstanceComponentProperty,
+  setLockedRecursive,
+  updateComponentInteraction,
+  updateComponentPropertyDefinition,
+  upsertComponentVariant,
+  wrapInAutoLayout,
+} from '@/ui/actions'
 import {
   findKeyframeAt,
   findTrack,
@@ -478,6 +502,12 @@ function MultiNodeDetails({ nodes, api }: { nodes: Node[]; api: SceneAPI }) {
     for (const n of nodes) {
       if ('size' in n) {
         api.setNodeProperty(n.id, 'size', { ...n.size, ...patch })
+        if (
+          n.kind === 'component' &&
+          (patch.width === 'hug' || patch.height === 'hug')
+        ) {
+          fitComponentToChildren(api, n.id, { preserveHug: true })
+        }
         if (recording) {
           recordKeyframesForPatch(api, n.id, playhead, 'size', patch)
         } else {
@@ -1048,6 +1078,59 @@ function stableKey(v: unknown): string {
 // Per-node details
 // ---------------------------------------------------------------------------
 
+type PivotPreset =
+  | 'custom'
+  | 'center'
+  | 'left'
+  | 'right'
+  | 'top'
+  | 'bottom'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right'
+
+function pivotPresetPatch(preset: Exclude<PivotPreset, 'custom'>): Pick<Transform, 'anchorX' | 'anchorY' | 'anchorZ'> {
+  switch (preset) {
+    case 'left':
+      return { anchorX: 0, anchorY: 0.5, anchorZ: 0 }
+    case 'right':
+      return { anchorX: 1, anchorY: 0.5, anchorZ: 0 }
+    case 'top':
+      return { anchorX: 0.5, anchorY: 0, anchorZ: 0 }
+    case 'bottom':
+      return { anchorX: 0.5, anchorY: 1, anchorZ: 0 }
+    case 'top-left':
+      return { anchorX: 0, anchorY: 0, anchorZ: 0 }
+    case 'top-right':
+      return { anchorX: 1, anchorY: 0, anchorZ: 0 }
+    case 'bottom-left':
+      return { anchorX: 0, anchorY: 1, anchorZ: 0 }
+    case 'bottom-right':
+      return { anchorX: 1, anchorY: 1, anchorZ: 0 }
+    default:
+      return { anchorX: 0.5, anchorY: 0.5, anchorZ: 0 }
+  }
+}
+
+function pivotPresetForTransform(transform: Transform): PivotPreset {
+  const x = transform.anchorX ?? 0.5
+  const y = transform.anchorY ?? 0.5
+  const z = transform.anchorZ ?? 0
+  if (Math.abs(z) > 0.001) return 'custom'
+  const close = (a: number, b: number) => Math.abs(a - b) < 0.001
+  if (close(x, 0.5) && close(y, 0.5)) return 'center'
+  if (close(x, 0) && close(y, 0.5)) return 'left'
+  if (close(x, 1) && close(y, 0.5)) return 'right'
+  if (close(x, 0.5) && close(y, 0)) return 'top'
+  if (close(x, 0.5) && close(y, 1)) return 'bottom'
+  if (close(x, 0) && close(y, 0)) return 'top-left'
+  if (close(x, 1) && close(y, 0)) return 'top-right'
+  if (close(x, 0) && close(y, 1)) return 'bottom-left'
+  if (close(x, 1) && close(y, 1)) return 'bottom-right'
+  return 'custom'
+}
+
 function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
   // Whether this node's parent is a frame with fill explicitly set to
   // null. When that's the case, a child fill would paint on top of a
@@ -1081,6 +1164,14 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
     node.kind === 'camera'
       ? anim?.focusDistance ?? node.focusDistance ?? 0
       : 0
+  const liveFocusX =
+    node.kind === 'camera'
+      ? anim?.focusX ?? node.focusX ?? node.transform.x
+      : 0
+  const liveFocusY =
+    node.kind === 'camera'
+      ? anim?.focusY ?? node.focusY ?? node.transform.y
+      : 0
   const liveFocusWorldX =
     node.kind === 'camera'
       ? anim?.focusWorldX ?? node.focusWorldX ?? node.focusX ?? node.transform.x
@@ -1093,6 +1184,10 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
     node.kind === 'camera'
       ? anim?.focusWorldZ ?? node.focusWorldZ ?? node.focusDistance ?? 0
       : 0
+  const liveFocusRadius =
+    node.kind === 'camera' ? anim?.focusRadius ?? node.focusRadius ?? 160 : 160
+  const liveFocusFalloff =
+    node.kind === 'camera' ? anim?.focusFalloff ?? node.focusFalloff ?? 180 : 180
   const liveAperture =
     node.kind === 'camera' ? anim?.aperture ?? node.aperture ?? 0 : 0
   const liveIso = node.kind === 'camera' ? node.iso ?? 100 : 100
@@ -1165,6 +1260,12 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
   const patchSize = (patch: Partial<Size>) => {
     if (!('size' in node)) return
     api.setNodeProperty(node.id, 'size', { ...node.size, ...patch })
+    if (
+      node.kind === 'component' &&
+      (patch.width === 'hug' || patch.height === 'hug')
+    ) {
+      fitComponentToChildren(api, node.id, { preserveHug: true })
+    }
     stampForPatch('size', patch)
   }
   const patchCamera = (
@@ -1178,6 +1279,8 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
         | 'focusWorldX'
         | 'focusWorldY'
         | 'focusWorldZ'
+        | 'focusRadius'
+        | 'focusFalloff'
         | 'focusTargetNodeId'
         | 'focalLength'
         | 'aperture'
@@ -1215,6 +1318,12 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
     }
     if (patch.focusWorldZ !== undefined) {
       api.setNodeProperty(node.id, 'focusWorldZ', patch.focusWorldZ)
+    }
+    if (patch.focusRadius !== undefined) {
+      api.setNodeProperty(node.id, 'focusRadius', patch.focusRadius)
+    }
+    if (patch.focusFalloff !== undefined) {
+      api.setNodeProperty(node.id, 'focusFalloff', patch.focusFalloff)
     }
     if (patch.focusTargetNodeId !== undefined) {
       api.setNodeProperty(node.id, 'focusTargetNodeId', patch.focusTargetNodeId)
@@ -1276,6 +1385,7 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
       })
     })
   }
+  const pivotPreset = node.kind === 'camera' ? 'center' : pivotPresetForTransform(node.transform)
   const patchLayout = (patch: Partial<Layout>) => {
     if (!('layout' in node)) return
     api.setNodeProperty(node.id, 'layout', { ...node.layout, ...patch })
@@ -1352,6 +1462,16 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
           />
         </FieldRow>
       </Section>
+
+      {(node.kind === 'component' || node.kind === 'instance') ? (
+        <>
+          <ComponentVariablesSection node={node} api={api} />
+          <VariantsSection node={node} api={api} />
+          <PrototypeSection node={node} api={api} />
+        </>
+      ) : (
+        <ExposeComponentPropertiesSection node={node} api={api} />
+      )}
 
       <PositionSection node={node} api={api} />
 
@@ -1656,6 +1776,28 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
             onCommitY={(v) => patchTransform({ scaleY: v })}
           />
         </FieldRow>
+        <FieldRow label="Pivot">
+          <SelectField<PivotPreset>
+            value={pivotPreset}
+            options={[
+              { value: 'center', label: 'Center' },
+              { value: 'left', label: 'Left edge' },
+              { value: 'right', label: 'Right edge' },
+              { value: 'top', label: 'Top edge' },
+              { value: 'bottom', label: 'Bottom edge' },
+              { value: 'top-left', label: 'Top left' },
+              { value: 'top-right', label: 'Top right' },
+              { value: 'bottom-left', label: 'Bottom left' },
+              { value: 'bottom-right', label: 'Bottom right' },
+              { value: 'custom', label: 'Custom' },
+            ]}
+            onCommit={(preset) => {
+              if (preset === 'custom') return
+              patchTransform(pivotPresetPatch(preset))
+            }}
+            width="w-full"
+          />
+        </FieldRow>
         <FieldRow label="Anchor X">
           <NumberField
             value={node.transform.anchorX ?? 0.5}
@@ -1845,42 +1987,6 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
               />
             </FieldRow>
             <FieldRow
-              label="Near Clip"
-              keyframe={
-                <KeyframeButton
-                  nodeId={node.id}
-                  propertyId="camera.nearClip"
-                  currentValue={liveNearClip}
-                />
-              }
-            >
-              <NumberField
-                value={liveNearClip}
-                onCommit={(v) => patchCamera({ nearClip: Math.max(0.001, v) })}
-                min={0.001}
-                step={1}
-                suffix="px"
-              />
-            </FieldRow>
-            <FieldRow
-              label="Far Clip"
-              keyframe={
-                <KeyframeButton
-                  nodeId={node.id}
-                  propertyId="camera.farClip"
-                  currentValue={liveFarClip}
-                />
-              }
-            >
-              <NumberField
-                value={liveFarClip}
-                onCommit={(v) => patchCamera({ farClip: Math.max(1, v) })}
-                min={1}
-                step={100}
-                suffix="px"
-              />
-            </FieldRow>
-            <FieldRow
               label="Aperture"
               keyframe={
                 <KeyframeButton
@@ -1899,41 +2005,126 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
               />
             </FieldRow>
             <FieldRow
-              label="Focus distance"
+              label="Focus radius"
               keyframe={
                 <KeyframeButton
                   nodeId={node.id}
-                  propertyId="camera.focusDistance"
-                  currentValue={liveFocusDistance}
+                  propertyId="camera.focusRadius"
+                  currentValue={liveFocusRadius}
                 />
               }
             >
               <NumberField
-                value={liveFocusDistance / 100}
-                onCommit={(v) =>
-                  patchCamera({
-                    focusDistance: v * 100,
-                    focusWorldZ: v * 100,
-                  })
-                }
-                min={0}
-                step={0.05}
-                suffix="m"
+                value={liveFocusRadius}
+                onCommit={(v) => patchCamera({ focusRadius: Math.max(4, v) })}
+                min={4}
+                max={2000}
+                step={5}
+                suffix="px"
               />
+            </FieldRow>
+            <FieldRow
+              label="Focus falloff"
+              keyframe={
+                <KeyframeButton
+                  nodeId={node.id}
+                  propertyId="camera.focusFalloff"
+                  currentValue={liveFocusFalloff}
+                />
+              }
+            >
+              <NumberField
+                value={liveFocusFalloff}
+                onCommit={(v) => patchCamera({ focusFalloff: Math.max(1, v) })}
+                min={1}
+                max={4000}
+                step={5}
+                suffix="px"
+              />
+            </FieldRow>
+            <FieldRow label="Focus point">
+              <div className="grid w-full grid-cols-3 gap-1">
+                <button
+                  type="button"
+                  className="h-7 rounded border border-border bg-panel px-2 text-[11px] font-medium text-text-muted transition-colors hover:border-border-strong hover:text-text"
+                  onClick={() => {
+                    const canvas = api.getMeta().canvas
+                    patchCamera({
+                      focusMode: 'screen',
+                      focusX: canvas.width / 2,
+                      focusY: canvas.height / 2,
+                      focusTargetNodeId: null,
+                    })
+                  }}
+                >
+                  Center
+                </button>
+                <button
+                  type="button"
+                  className={[
+                    'h-7 rounded border px-2 text-[11px] font-medium transition-colors',
+                    focusPickingCameraId === node.id
+                      ? 'border-accent bg-accent/15 text-text'
+                      : 'border-border bg-panel text-text-muted hover:border-border-strong hover:text-text',
+                  ].join(' ')}
+                  onClick={() =>
+                    setFocusPickingCameraId(
+                      focusPickingCameraId === node.id ? null : node.id,
+                    )
+                  }
+                >
+                  {focusPickingCameraId === node.id ? 'Click canvas' : 'Pick'}
+                </button>
+                <button
+                  type="button"
+                  className="h-7 rounded border border-border bg-panel px-2 text-[11px] font-medium text-text-muted transition-colors hover:border-border-strong hover:text-danger"
+                  onClick={() => {
+                    const focusProps = new Set([
+                      'camera.focusX',
+                      'camera.focusY',
+                      'camera.focusWorldX',
+                      'camera.focusWorldY',
+                      'camera.focusWorldZ',
+                      'camera.focusDistance',
+                    ])
+                    for (const track of api.getTracksForNode(node.id)) {
+                      if (focusProps.has(track.propertyId)) {
+                        removeTrack(api, track.id)
+                      }
+                    }
+                    const canvas = api.getMeta().canvas
+                    patchCamera({
+                      focusMode: 'screen',
+                      focusX: canvas.width / 2,
+                      focusY: canvas.height / 2,
+                      focusTargetNodeId: null,
+                    })
+                  }}
+                >
+                  Clear
+                </button>
+              </div>
             </FieldRow>
             <FieldRow
               label="Focus X"
               keyframe={
                 <KeyframeButton
                   nodeId={node.id}
-                  propertyId="camera.focusWorldX"
-                  currentValue={liveFocusWorldX}
+                  propertyId="camera.focusX"
+                  currentValue={liveFocusX}
                 />
               }
             >
               <NumberField
-                value={liveFocusWorldX}
-                onCommit={(v) => patchPreciseFocusPoint({ focusWorldX: v })}
+                value={liveFocusX}
+                onCommit={(v) =>
+                  patchCamera({
+                    focusMode: 'screen',
+                    focusX: v,
+                    focusWorldX: v,
+                    focusTargetNodeId: null,
+                  })
+                }
                 step={1}
                 suffix="px"
               />
@@ -1943,20 +2134,27 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
               keyframe={
                 <KeyframeButton
                   nodeId={node.id}
-                  propertyId="camera.focusWorldY"
-                  currentValue={liveFocusWorldY}
+                  propertyId="camera.focusY"
+                  currentValue={liveFocusY}
                 />
               }
             >
               <NumberField
-                value={liveFocusWorldY}
-                onCommit={(v) => patchPreciseFocusPoint({ focusWorldY: v })}
+                value={liveFocusY}
+                onCommit={(v) =>
+                  patchCamera({
+                    focusMode: 'screen',
+                    focusY: v,
+                    focusWorldY: v,
+                    focusTargetNodeId: null,
+                  })
+                }
                 step={1}
                 suffix="px"
               />
             </FieldRow>
             <FieldRow
-              label="Focus Z"
+              label="Focus Z depth"
               keyframe={
                 <KeyframeButton
                   nodeId={node.id}
@@ -1967,37 +2165,16 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
             >
               <NumberField
                 value={liveFocusWorldZ}
-                onCommit={(v) => patchPreciseFocusPoint({ focusWorldZ: v })}
+                onCommit={(v) =>
+                  patchCamera({
+                    focusWorldZ: v,
+                    focusDistance: v,
+                    focusTargetNodeId: null,
+                  })
+                }
                 step={5}
                 suffix="px"
               />
-            </FieldRow>
-            <FieldRow label="ISO">
-              <NumberField
-                value={liveIso}
-                onCommit={(v) => patchCamera({ iso: Math.max(50, Math.round(v)) })}
-                min={50}
-                max={12800}
-                step={50}
-              />
-            </FieldRow>
-            <FieldRow label="Focus point">
-              <button
-                type="button"
-                className={[
-                  'h-7 w-full rounded border px-2 text-[11px] font-medium transition-colors',
-                  focusPickingCameraId === node.id
-                    ? 'border-accent bg-accent/15 text-text'
-                    : 'border-border bg-panel text-text-muted hover:border-border-strong hover:text-text',
-                ].join(' ')}
-                onClick={() =>
-                  setFocusPickingCameraId(
-                    focusPickingCameraId === node.id ? null : node.id,
-                  )
-                }
-              >
-                {focusPickingCameraId === node.id ? 'Click canvas to set' : 'Pick on canvas'}
-              </button>
             </FieldRow>
             <FieldRow label="Depth of field">
               <CheckboxField
@@ -2005,14 +2182,8 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
                 onCommit={(v) => api.setNodeProperty(node.id, 'depthOfField', v)}
               />
             </FieldRow>
-            <FieldRow label="Show focus plane">
-              <CheckboxField
-                value={node.showFocusPlane ?? false}
-                onCommit={(v) => patchCamera({ showFocusPlane: v })}
-              />
-            </FieldRow>
             <FieldRow
-              label="Blur"
+              label="Blur amount"
               keyframe={
                 <KeyframeButton
                   nodeId={node.id}
@@ -2022,32 +2193,14 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
               }
             >
               <NumberField
-                value={Math.max(0, Math.min(64, liveBlurLevel))}
+                value={Math.max(0, Math.min(128, liveBlurLevel))}
                 onCommit={(v) =>
-                  patchCamera({ blurLevel: Math.max(0, Math.min(64, v)) })
+                  patchCamera({ blurLevel: Math.max(0, Math.min(128, v)) })
                 }
                 min={0}
-                max={64}
-                step={0.25}
-                suffix="px"
-              />
-            </FieldRow>
-            <FieldRow
-              label="Blur quality"
-              keyframe={
-                <KeyframeButton
-                  nodeId={node.id}
-                  propertyId="camera.blurQuality"
-                  currentValue={node.blurQuality ?? 8}
-                />
-              }
-            >
-              <NumberField
-                value={node.blurQuality ?? 8}
-                onCommit={(v) => patchCamera({ blurQuality: Math.max(1, Math.round(v)) })}
-                min={1}
-                max={64}
+                max={128}
                 step={1}
+                suffix="px"
               />
             </FieldRow>
             <FillField
@@ -2568,6 +2721,965 @@ function ShadowFields({
 
 function clamp01(n: number): number {
   return Math.max(0, Math.min(1, n))
+}
+
+function ExposeComponentPropertiesSection({
+  node,
+  api,
+}: {
+  node: Node
+  api: SceneAPI
+}) {
+  const component = findOwningComponent(api, node.id)
+  if (!component || node.id === component.id) return null
+  const exposed = new Set(
+    component.componentProperties
+      .filter((prop) => prop.nodeId === node.id)
+      .map((prop) => prop.path),
+  )
+  const options = exposeOptionsForNode(node)
+  if (options.length === 0) return null
+  return (
+    <Section title="Expose">
+      <p className="mb-2 text-[11px] leading-4 text-text-dim">
+        Make selected layer properties editable on instances.
+      </p>
+      <div className="grid grid-cols-2 gap-1.5">
+        {options.map((option) => {
+          const active = exposed.has(option.path)
+          const existing = component.componentProperties.find(
+            (prop) => prop.nodeId === node.id && prop.path === option.path,
+          )
+          return (
+            <button
+              key={option.path}
+              type="button"
+              onClick={() =>
+                active && existing
+                  ? removeComponentProperty(api, component.id, existing.id)
+                  : exposeComponentProperty(
+                      api,
+                      node.id,
+                      option.path,
+                      option.type,
+                      `${node.name} ${option.name}`,
+                    )
+              }
+              className={[
+                'h-7 rounded-md border px-2 text-left text-[11px] font-medium',
+                active
+                  ? 'border-[oklch(0.64_0.24_300)] bg-[oklch(0.64_0.24_300_/_0.14)] text-[oklch(0.5_0.22_300)]'
+                  : 'border-border bg-panel-raised text-text-muted hover:border-border-strong hover:text-text',
+              ].join(' ')}
+            >
+              {option.name}
+            </button>
+          )
+        })}
+      </div>
+    </Section>
+  )
+}
+
+function InstanceComponentPropertiesSection({
+  node,
+  api,
+}: {
+  node: Extract<Node, { kind: 'instance' }>
+  api: SceneAPI
+}) {
+  const component = api.getNode(node.componentId)
+  if (!component || component.kind !== 'component') return null
+  if (component.componentProperties.length === 0) return null
+  return (
+    <Section title="Properties">
+      <div className="space-y-2">
+        {component.componentProperties.map((property) => {
+          const source = api.getNode(property.nodeId)
+          if (!source) return null
+          const value = componentPropertyValue(node, source, property)
+          const overridden = hasPathValue(
+            node.overrides[property.nodeId] ?? {},
+            property.path,
+          )
+          return (
+            <div key={property.id} className="rounded-md border border-border bg-panel-raised p-2">
+              <div className="mb-1.5 flex items-center justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="truncate text-[11px] font-semibold text-text">
+                    {property.name}
+                  </div>
+                  <div className="truncate text-[10px] text-text-dim">
+                    {source.name}
+                  </div>
+                </div>
+                {overridden ? (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      resetInstanceComponentProperty(api, node.id, property.id)
+                    }
+                    className="h-6 rounded border border-border px-1.5 text-[10px] text-text-muted hover:text-text"
+                  >
+                    Reset
+                  </button>
+                ) : null}
+              </div>
+              <ComponentPropertyControl
+                property={property}
+                value={value}
+                onCommit={(next) =>
+                  setInstanceComponentProperty(api, node.id, property.id, next)
+                }
+              />
+            </div>
+          )
+        })}
+      </div>
+    </Section>
+  )
+}
+
+function ComponentVariablesSection({
+  node,
+  api,
+}: {
+  node: Extract<Node, { kind: 'component' | 'instance' }>
+  api: SceneAPI
+}) {
+  const [propertyMenuOpen, setPropertyMenuOpen] = useState(false)
+  const playhead = useUI((s) => s.playhead)
+  const component =
+    node.kind === 'component' ? node : api.getNode(node.componentId)
+  if (!component || component.kind !== 'component') return null
+  const stateAxis = component.variants.find((axis) => axis.name === 'State')
+  const values = stateAxis?.values.length ? stateAxis.values : ['Default']
+  const currentState =
+    node.kind === 'instance'
+      ? node.selection.State ?? component.defaultSelection.State ?? values[0]!
+      : component.defaultSelection.State ?? values[0]!
+
+  return (
+    <Section title={component.name}>
+      <div className="space-y-3">
+        <div className="relative">
+          <div className="mb-2 flex items-center justify-between">
+            <div className="text-[12px] font-semibold text-text-dim">
+              Properties
+            </div>
+            <button
+              type="button"
+              onClick={() => setPropertyMenuOpen((open) => !open)}
+              className="grid h-7 w-7 place-items-center rounded-md text-[18px] leading-none text-text-muted hover:bg-panel-raised hover:text-text"
+              aria-label="Create property"
+            >
+              +
+            </button>
+          </div>
+          {propertyMenuOpen ? (
+            <div className="absolute right-0 top-8 z-20 w-44 rounded-lg bg-neutral-950 p-2 text-white shadow-2xl">
+              <div className="px-2 pb-1.5 text-[11px] text-white/55">
+                Create property
+              </div>
+              {[
+                ['◇', 'Variant'],
+                ['T', 'Text'],
+                ['◉', 'Boolean'],
+                ['◇', 'Instance swap'],
+                ['⊞', 'Slot'],
+              ].map(([icon, label]) => (
+                <button
+                  key={label}
+                  type="button"
+                  onClick={() => setPropertyMenuOpen(false)}
+                  className="flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[12px] text-white/90 hover:bg-white/10"
+                >
+                  <span className="grid h-4 w-4 place-items-center font-mono text-[13px]">
+                    {icon}
+                  </span>
+                  <span>{label}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+
+          <div className="space-y-1">
+            <ComponentPropertyRow
+              icon="◇"
+              name="State"
+              value={currentState}
+              control={
+                <SelectField<string>
+                  value={currentState}
+                  options={values}
+                  width="w-full"
+                  onCommit={(value) => {
+                    if (node.kind === 'instance') {
+                      applyInstanceVariantTransition(
+                        api,
+                        node.id,
+                        { State: value },
+                        { playhead },
+                      )
+                    } else {
+                      api.setNodeProperty(component.id, 'defaultSelection', {
+                        ...component.defaultSelection,
+                        State: value,
+                      } as never)
+                    }
+                  }}
+                />
+              }
+            />
+
+            {component.componentProperties.map((property) => {
+              const source = api.getNode(property.nodeId)
+              if (!source) return null
+              const value =
+                node.kind === 'instance'
+                  ? componentPropertyValue(node, source, property)
+                  : getPathValue(
+                      source as unknown as Record<string, unknown>,
+                      property.path,
+                    )
+              const overridden =
+                node.kind === 'instance' &&
+                hasPathValue(node.overrides[property.nodeId] ?? {}, property.path)
+              return (
+                <ComponentPropertyRow
+                  key={property.id}
+                  icon={componentPropertyIcon(property.type)}
+                  name={property.name}
+                  value={formatComponentPropertyValue(value, property)}
+                  control={
+                    <div className="space-y-1.5">
+                      {node.kind === 'component' ? (
+                        <TextField
+                          value={property.name}
+                          onCommit={(name) =>
+                            updateComponentPropertyDefinition(
+                              api,
+                              component.id,
+                              property.id,
+                              { name: name.trim() || property.name },
+                            )
+                          }
+                          allowEmpty={false}
+                        />
+                      ) : null}
+                      <ComponentPropertyControl
+                        property={property}
+                        value={value}
+                        onCommit={(next) =>
+                          node.kind === 'instance'
+                            ? setInstanceComponentProperty(api, node.id, property.id, next)
+                            : setComponentSourceProperty(api, component.id, property.id, next)
+                        }
+                      />
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="truncate text-[10px] text-text-dim">
+                          {source.name} · {variablePathLabel(property.path)}
+                        </div>
+                        <div className="flex shrink-0 gap-1">
+                          {overridden ? (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                resetInstanceComponentProperty(api, node.id, property.id)
+                              }
+                              className="h-6 rounded px-1.5 text-[10px] text-text-muted hover:bg-panel-raised hover:text-text"
+                            >
+                              Reset
+                            </button>
+                          ) : null}
+                          {node.kind === 'component' ? (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                removeComponentProperty(api, component.id, property.id)
+                              }
+                              className="h-6 rounded px-1.5 text-[10px] text-text-muted hover:bg-panel-raised hover:text-danger"
+                            >
+                              Remove
+                            </button>
+                          ) : null}
+                        </div>
+                      </div>
+                    </div>
+                  }
+                />
+              )
+            })}
+          </div>
+        </div>
+      </div>
+    </Section>
+  )
+}
+
+function ComponentPropertyRow({
+  icon,
+  name,
+  value,
+  control,
+}: {
+  icon: string
+  name: string
+  value: string
+  control: ReactNode
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="rounded-md bg-panel-raised">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex min-h-8 w-full items-center gap-2 px-2 text-left"
+      >
+        <span className="grid h-5 w-5 shrink-0 place-items-center rounded border border-border bg-panel font-mono text-[11px] text-text-muted">
+          {icon}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-text">
+          {name}
+          <span className="font-normal text-text-dim"> · {value}</span>
+        </span>
+      </button>
+      {open ? <div className="border-t border-border px-2 py-2">{control}</div> : null}
+    </div>
+  )
+}
+
+function ComponentPropertyControl({
+  property,
+  value,
+  onCommit,
+}: {
+  property: ComponentPropertyDefinition
+  value: unknown
+  onCommit: (value: unknown) => void
+}) {
+  if (property.type === 'text') {
+    return (
+      <TextField
+        value={typeof value === 'string' ? value : ''}
+        onCommit={onCommit}
+        allowEmpty
+      />
+    )
+  }
+  if (property.type === 'fill') {
+    return (
+      <FillField
+        label=""
+        value={(value as Node['appearance']['fill']) ?? null}
+        onCommit={onCommit}
+      />
+    )
+  }
+  if (property.type === 'color') {
+    return (
+      <ColorField
+        value={typeof value === 'string' ? value : '#0a0a0c'}
+        onCommit={(color) => {
+          if (color) onCommit(color)
+        }}
+      />
+    )
+  }
+  if (property.type === 'stroke') {
+    return (
+      <StrokeControls
+        value={(value as Stroke | null) ?? null}
+        onCommit={onCommit}
+      />
+    )
+  }
+  if (property.type === 'size') {
+    const size = value as Size | undefined
+    return (
+      <div className="space-y-1">
+        <SizeAxisField
+          value={size?.width ?? 'hug'}
+          onCommit={(width) => onCommit({ ...(size ?? {}), width })}
+        />
+        <SizeAxisField
+          value={size?.height ?? 'hug'}
+          onCommit={(height) => onCommit({ ...(size ?? {}), height })}
+        />
+      </div>
+    )
+  }
+  if (property.type === 'boolean') {
+    return (
+      <CheckboxField
+        value={typeof value === 'boolean' ? value : false}
+        onCommit={onCommit}
+      />
+    )
+  }
+  return (
+    <NumberField
+      value={typeof value === 'number' ? value : 0}
+      onCommit={onCommit}
+      step={property.path.includes('opacity') ? 0.05 : 1}
+      min={property.path.includes('opacity') ? 0 : undefined}
+      max={property.path.includes('opacity') ? 1 : undefined}
+    />
+  )
+}
+
+function exposeOptionsForNode(node: Node): ComponentPropertyDefinition[] {
+  const options: ComponentPropertyDefinition[] = []
+  if (node.kind === 'text') {
+    options.push(
+      exposeOption('Text', node.id, 'text', 'text'),
+      exposeOption('Text color', node.id, 'color', 'color'),
+    )
+  }
+  if ('size' in node) {
+    options.push(exposeOption('Size', node.id, 'size', 'size'))
+  }
+  if (node.kind !== 'camera') {
+    options.push(
+      exposeOption('Fill', node.id, 'appearance.fill', 'fill'),
+      exposeOption('Stroke', node.id, 'appearance.stroke', 'stroke'),
+      exposeOption('Border width', node.id, 'appearance.stroke.width', 'number'),
+      exposeOption('Radius', node.id, 'appearance.cornerRadius', 'number'),
+      exposeOption('Opacity', node.id, 'appearance.opacity', 'number'),
+    )
+  }
+  if (node.kind === 'frame') {
+    options.push(exposeOption('Clip content', node.id, 'clipsContent', 'boolean'))
+  }
+  return options
+}
+
+function exposeOption(
+  name: string,
+  nodeId: NodeId,
+  path: string,
+  type: ComponentPropertyDefinition['type'],
+): ComponentPropertyDefinition {
+  return { id: path, name, nodeId, path, type }
+}
+
+function componentPropertyValue(
+  instance: Extract<Node, { kind: 'instance' }>,
+  source: Node,
+  property: ComponentPropertyDefinition,
+): unknown {
+  const override = getPathValue(instance.overrides[property.nodeId] ?? {}, property.path)
+  if (override !== undefined) return override
+  return getPathValue(source as unknown as Record<string, unknown>, property.path)
+}
+
+function componentPropertyIcon(type: ComponentPropertyDefinition['type']): string {
+  switch (type) {
+    case 'text':
+      return 'T'
+    case 'boolean':
+      return 'O'
+    case 'fill':
+    case 'color':
+    case 'stroke':
+      return 'C'
+    case 'size':
+      return 'W'
+    case 'number':
+      return '#'
+    default:
+      return 'P'
+  }
+}
+
+function formatComponentPropertyValue(
+  value: unknown,
+  property: ComponentPropertyDefinition,
+): string {
+  if (property.type === 'boolean') return value ? 'True' : 'False'
+  if (property.type === 'text') {
+    return truncatePropertyValue(typeof value === 'string' ? value : '')
+  }
+  if (property.type === 'number') {
+    return typeof value === 'number' ? String(Number(value.toFixed(2))) : '0'
+  }
+  if (property.type === 'size') {
+    const size = value as Partial<Size> | undefined
+    return `${formatSizeAxis(size?.width)} x ${formatSizeAxis(size?.height)}`
+  }
+  if (property.type === 'color') return typeof value === 'string' ? value : 'Color'
+  if (property.type === 'fill') return value ? 'Fill' : 'None'
+  if (property.type === 'stroke') return value ? 'Stroke' : 'None'
+  return truncatePropertyValue(value == null ? 'None' : String(value))
+}
+
+function truncatePropertyValue(value: string): string {
+  return value.length > 34 ? `${value.slice(0, 31)}...` : value
+}
+
+function formatSizeAxis(value: unknown): string {
+  if (typeof value === 'number') return String(Math.round(value))
+  if (typeof value === 'string') return value
+  return '-'
+}
+
+function getPathValue(source: Record<string, unknown>, path: string): unknown {
+  let cur: unknown = source
+  for (const key of path.split('.')) {
+    if (!cur || typeof cur !== 'object') return undefined
+    cur = (cur as Record<string, unknown>)[key]
+  }
+  return cur
+}
+
+function hasPathValue(source: Record<string, unknown>, path: string): boolean {
+  return getPathValue(source, path) !== undefined
+}
+
+function variablePathLabel(path: string): string {
+  switch (path) {
+    case 'text':
+      return 'Text'
+    case 'color':
+      return 'Text color'
+    case 'appearance.fill':
+      return 'Fill'
+    case 'appearance.stroke':
+      return 'Stroke'
+    case 'appearance.stroke.width':
+      return 'Border width'
+    case 'appearance.cornerRadius':
+      return 'Radius'
+    case 'appearance.opacity':
+      return 'Opacity'
+    case 'size':
+      return 'Size'
+    case 'clipsContent':
+      return 'Clip content'
+    default:
+      return path
+  }
+}
+
+function isInsideNode(api: SceneAPI, nodeId: NodeId, ancestorId: NodeId): boolean {
+  let current = api.getNode(nodeId)
+  while (current?.parent) {
+    if (current.parent === ancestorId) return true
+    current = api.getNode(current.parent)
+  }
+  return false
+}
+
+function prototypeEventLabel(event: InteractionEventKind): string {
+  switch (event) {
+    case 'hoverIn':
+      return 'Hover'
+    case 'hoverOut':
+      return 'Hover out'
+    case 'pointerDown':
+      return 'Press'
+    case 'pointerUp':
+      return 'Release'
+    default:
+      return 'Click'
+  }
+}
+
+function interactionTargetState(interaction: Interaction): string | null {
+  const action = interaction.actions[0]
+  if (!action) return null
+  if (action.type === 'setVariant') return action.selection.State ?? null
+  if (action.type === 'after' && action.action.type === 'setVariant') {
+    return action.action.selection.State ?? null
+  }
+  return null
+}
+
+function setInteractionTargetState(
+  interaction: Interaction,
+  state: string,
+): Interaction['actions'] {
+  return interaction.actions.map((action) => {
+    if (action.type === 'setVariant') {
+      return { ...action, selection: { ...action.selection, State: state } }
+    }
+    if (action.type === 'after' && action.action.type === 'setVariant') {
+      return {
+        ...action,
+        action: {
+          ...action.action,
+          selection: { ...action.action.selection, State: state },
+        },
+      }
+    }
+    return action
+  })
+}
+
+function findOwningComponent(
+  api: SceneAPI,
+  nodeId: NodeId,
+): Extract<Node, { kind: 'component' }> | null {
+  let current = api.getNode(nodeId)
+  while (current?.parent) {
+    const parent = api.getNode(current.parent)
+    if (parent?.kind === 'component') return parent
+    current = parent
+  }
+  return current?.kind === 'component' ? current : null
+}
+
+function VariantsSection({
+  node,
+  api,
+}: {
+  node: Extract<Node, { kind: 'component' | 'instance' }>
+  api: SceneAPI
+}) {
+  const [draftName, setDraftName] = useState('')
+  const [activeState, setActiveState] = useState<string | null>(null)
+  const playhead = useUI((s) => s.playhead)
+  const component =
+    node.kind === 'component' ? node : api.getNode(node.componentId)
+  if (!component || component.kind !== 'component') return null
+  const stateAxis = component.variants.find((axis) => axis.name === 'State')
+  const values = stateAxis?.values ?? ['Default']
+  const currentState =
+    node.kind === 'instance'
+      ? node.selection.State ?? component.defaultSelection.State ?? values[0]!
+      : component.defaultSelection.State ?? values[0]!
+  const selectedState =
+    activeState && values.includes(activeState) ? activeState : currentState
+  const transition = component.variantTransition ?? DEFAULT_VARIANT_TRANSITION
+
+  const patchTransition = (patch: Partial<VariantTransition>) => {
+    api.setNodeProperty(component.id, 'variantTransition', {
+      ...transition,
+      ...patch,
+    } as never)
+  }
+  const switchComponentState = (value: string) => {
+    if (value === selectedState) return
+    upsertComponentVariant(api, component.id, selectedState)
+    applyComponentVariantState(api, component.id, value)
+    setActiveState(value)
+  }
+
+  return (
+    <Section title="Component states">
+      {node.kind === 'component' ? (
+        <>
+          <FieldRow label="Axis">
+            <button
+              type="button"
+              onClick={() => ensureComponentStateAxis(api, component.id)}
+              className="h-7 rounded-md bg-app-bg px-2 text-[12px] font-medium text-text hover:ring-1 hover:ring-border"
+            >
+              State
+            </button>
+          </FieldRow>
+          <div className="flex flex-wrap gap-1.5">
+            {values.map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => switchComponentState(value)}
+                className={[
+                  'h-7 rounded-md border px-2.5 text-[11px] font-semibold',
+                  value === selectedState
+                    ? 'border-[oklch(0.64_0.24_300)] bg-[oklch(0.64_0.24_300_/_0.16)] text-[oklch(0.5_0.22_300)]'
+                    : 'border-border bg-panel-raised text-text-muted hover:text-text',
+                ].join(' ')}
+              >
+                {value}
+              </button>
+            ))}
+          </div>
+          <FieldRow label="New">
+            <div className="flex w-full gap-1">
+              <input
+                value={draftName}
+                onChange={(e) => setDraftName(e.currentTarget.value)}
+                placeholder={`Variant ${values.length + 1}`}
+                className="h-7 min-w-0 flex-1 rounded-md bg-app-bg px-2 text-[12px] text-text outline-none ring-1 ring-transparent placeholder:text-text-dim focus:ring-accent/45"
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  const nextName = draftName.trim() || `Variant ${values.length + 1}`
+                  upsertComponentVariant(api, component.id, selectedState)
+                  upsertComponentVariant(api, component.id, nextName)
+                  applyComponentVariantState(api, component.id, nextName)
+                  setActiveState(nextName)
+                  setDraftName('')
+                }}
+                className="h-7 rounded-md bg-[oklch(0.64_0.24_300)] px-2 text-[11px] font-semibold text-white"
+              >
+                Add
+              </button>
+            </div>
+          </FieldRow>
+          <div className="grid grid-cols-2 gap-1.5">
+            <button
+              type="button"
+              onClick={() => upsertComponentVariant(api, component.id, selectedState)}
+              className="h-7 rounded-md border border-border bg-panel-raised px-2 text-[11px] font-semibold text-text-muted hover:text-text"
+            >
+              Update selected
+            </button>
+            <button
+              type="button"
+              disabled={selectedState === 'Default'}
+              onClick={() => {
+                removeComponentVariant(api, component.id, selectedState)
+                applyComponentVariantState(api, component.id, 'Default')
+                setActiveState('Default')
+              }}
+              className="h-7 rounded-md border border-border bg-panel-raised px-2 text-[11px] font-semibold text-text-muted hover:text-danger disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Delete selected
+            </button>
+          </div>
+          <p className="text-[11px] leading-4 text-text-dim">
+            Edit the master to the target look, then add a new state or update
+            the selected state. Instances animate between these states.
+          </p>
+        </>
+      ) : (
+        <p className="text-[11px] leading-4 text-text-dim">
+          Select an instance state in Variables. Transition settings below
+          control how that instance animates between component states.
+        </p>
+      )}
+
+      <div className="border-t border-border pt-4">
+        <FieldRow label="Duration">
+          <NumberField
+            value={transition.duration}
+            onCommit={(duration) => patchTransition({ duration: Math.max(0, duration) })}
+            min={0}
+            step={0.05}
+            suffix="s"
+          />
+        </FieldRow>
+        <EasingPicker
+          title="Transition"
+          presetId={(transition.presetId as EasingPresetId | undefined) ?? 'smooth'}
+          strength={transition.strength ?? 50}
+          onChange={({ presetId, strength, easing }) =>
+            patchTransition({ presetId, strength, easing })
+          }
+        />
+        <SpringControls transition={transition} onPatch={patchTransition} />
+      </div>
+    </Section>
+  )
+}
+
+function PrototypeSection({
+  node,
+  api,
+}: {
+  node: Extract<Node, { kind: 'component' | 'instance' }>
+  api: SceneAPI
+}) {
+  const [event, setEvent] = useState<InteractionEventKind>('click')
+  const [targetState, setTargetState] = useState('Default')
+  const [delay, setDelay] = useState(0)
+  const component =
+    node.kind === 'component' ? node : api.getNode(node.componentId)
+  if (!component || component.kind !== 'component') return null
+  const stateAxis = component.variants.find((axis) => axis.name === 'State')
+  const values = stateAxis?.values.length ? stateAxis.values : ['Default']
+  const selectedInnerNode =
+    useUI.getState().selection.find((id) => id !== component.id && isInsideNode(api, id, component.id)) ??
+    undefined
+  const sourceNode = selectedInnerNode ? api.getNode(selectedInnerNode) : null
+  const currentTargetState = values.includes(targetState) ? targetState : values[0]!
+  const interactions = component.interactions
+
+  return (
+    <Section title="Prototype">
+      <div className="space-y-3">
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-text-dim">
+              Trigger
+            </div>
+            <SelectField<InteractionEventKind>
+              value={event}
+              options={['click', 'hoverIn', 'hoverOut', 'pointerDown', 'pointerUp']}
+              width="w-full"
+              onCommit={setEvent}
+            />
+          </div>
+          <div>
+            <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-text-dim">
+              To state
+            </div>
+            <SelectField<string>
+              value={currentTargetState}
+              options={values}
+              width="w-full"
+              onCommit={setTargetState}
+            />
+          </div>
+        </div>
+        <FieldRow label="Delay">
+          <NumberField
+            value={delay}
+            onCommit={(value) => setDelay(Math.max(0, value))}
+            min={0}
+            step={0.05}
+            suffix="s"
+          />
+        </FieldRow>
+        <button
+          type="button"
+          onClick={() =>
+            addComponentVariantInteraction(api, component.id, {
+              event,
+              targetState: currentTargetState,
+              delay,
+              sourceNodeId: sourceNode?.id,
+            })
+          }
+          className="h-8 w-full rounded-md bg-[oklch(0.64_0.24_300)] text-[12px] font-semibold text-white"
+        >
+          Add variant connector
+        </button>
+        <p className="text-[11px] leading-4 text-text-dim">
+          Source is {sourceNode ? sourceNode.name : 'the component root'}. Select
+          a child layer inside the master to attach the trigger to that layer.
+        </p>
+
+        {interactions.length > 0 ? (
+          <div className="space-y-2 border-t border-border pt-3">
+            {interactions.map((interaction) => {
+              const target = interactionTargetState(interaction) ?? values[0]!
+              const triggerLabel = prototypeEventLabel(interaction.event)
+              return (
+                <div
+                  key={interaction.id}
+                  className="rounded-md border border-border bg-panel-raised p-2"
+                >
+                  <div className="mb-2 flex items-center gap-2 text-[11px]">
+                    <span className="rounded bg-app-bg px-1.5 py-0.5 font-semibold text-text">
+                      {triggerLabel}
+                    </span>
+                    <span className="h-px flex-1 bg-[oklch(0.64_0.24_300_/_0.55)]" />
+                    <span className="rounded bg-[oklch(0.64_0.24_300_/_0.16)] px-1.5 py-0.5 font-semibold text-[oklch(0.5_0.22_300)]">
+                      {target}
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-[1fr_auto] gap-2">
+                    <SelectField<string>
+                      value={target}
+                      options={values}
+                      width="w-full"
+                      onCommit={(value) =>
+                        updateComponentInteraction(
+                          api,
+                          component.id,
+                          interaction.id,
+                          {
+                            actions: setInteractionTargetState(
+                              interaction,
+                              value,
+                            ),
+                          },
+                        )
+                      }
+                    />
+                    <button
+                      type="button"
+                      onClick={() =>
+                        removeComponentInteraction(api, component.id, interaction.id)
+                      }
+                      className="h-7 rounded border border-border px-2 text-[11px] text-text-muted hover:text-danger"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        ) : null}
+      </div>
+    </Section>
+  )
+}
+
+const DEFAULT_VARIANT_TRANSITION: VariantTransition = {
+  duration: 0.3,
+  easing: 'ease-in-out',
+  presetId: 'smooth',
+  strength: 50,
+}
+
+function SpringControls({
+  transition,
+  onPatch,
+}: {
+  transition: VariantTransition
+  onPatch: (patch: Partial<VariantTransition>) => void
+}) {
+  const spring =
+    typeof transition.easing === 'object' && 'spring' in transition.easing
+      ? transition.easing.spring
+      : { stiffness: 240, damping: 22, mass: 1 }
+  return (
+    <div className="mt-3 rounded border border-border bg-panel-raised p-2.5">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[10px] font-medium uppercase tracking-wider text-text-dim">
+          Spring
+        </span>
+        <button
+          type="button"
+          onClick={() =>
+            onPatch({
+              presetId: 'elastic',
+              easing: { spring },
+            })
+          }
+          className="rounded bg-app-bg px-2 py-1 text-[10px] font-medium text-text-muted hover:text-text"
+        >
+          Use spring
+        </button>
+      </div>
+      <FieldRow label="Stiffness">
+        <NumberField
+          value={spring.stiffness}
+          onCommit={(stiffness) =>
+            onPatch({ easing: { spring: { ...spring, stiffness } } })
+          }
+          min={1}
+          step={10}
+        />
+      </FieldRow>
+      <FieldRow label="Damping">
+        <NumberField
+          value={spring.damping}
+          onCommit={(damping) =>
+            onPatch({ easing: { spring: { ...spring, damping } } })
+          }
+          min={0.1}
+          step={1}
+        />
+      </FieldRow>
+      <FieldRow label="Mass">
+        <NumberField
+          value={spring.mass}
+          onCommit={(mass) =>
+            onPatch({ easing: { spring: { ...spring, mass } } })
+          }
+          min={0.1}
+          step={0.1}
+        />
+      </FieldRow>
+    </div>
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -3189,6 +4301,12 @@ function ImageSection({ node, api }: { node: ImageNode; api: SceneAPI }) {
 
   return (
     <Section title="Image">
+      {node.importWarning ? (
+        <div className="mb-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-[11px] leading-4 text-amber-900">
+          <div className="mb-1 font-semibold">Imported as image fallback</div>
+          <div>{node.importWarning}</div>
+        </div>
+      ) : null}
       <FieldRow label="Preview">
         <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
           {node.src ? (

--- a/src/ui/LayersPanel.tsx
+++ b/src/ui/LayersPanel.tsx
@@ -12,7 +12,7 @@ import type { Node, NodeId, NodeKind } from '@/scene'
 import type { SceneAPI } from '@/scene/doc'
 import { useUI } from '@/state/ui'
 import { buildNodeContextMenu } from '@/ui/contextMenuActions'
-import { setLockedRecursive } from '@/ui/actions'
+import { instantiateComponent, setLockedRecursive } from '@/ui/actions'
 import { getLastSolvedLayout } from '@/ui/hooks/lastSolvedLayout'
 
 /**
@@ -43,13 +43,21 @@ export function LayersPanel() {
   const api = useSceneAPI()
   const rootId = api.getRoot()
   const root = rootId ? api.getNode(rootId) : null
+  const componentEditId = useUI((s) => s.componentEditId)
+  const editMaster = componentEditId ? api.getNode(componentEditId) : null
   const camera = api.getActiveCamera()
+  const pasteboardNodes = api
+    .getAllNodeIds()
+    .map((id) => api.getNode(id))
+    .filter((node): node is Node => !!node && !!node.workspaceOnly && node.parent === null)
   const selection = useUI((s) => s.selection)
   const layersCollapsed = useUI((s) => s.layersCollapsed)
   const toggleLayerCollapsed = useUI((s) => s.toggleLayerCollapsed)
   const scrollerRef = useRef<HTMLDivElement>(null)
   const width = useUI((s) => s.layersWidth)
   const setWidth = useUI((s) => s.setLayersWidth)
+  const [tab, setTab] = useState<'layers' | 'components'>('layers')
+  const [componentsModalOpen, setComponentsModalOpen] = useState(false)
 
   // When the canvas (or any other surface) commits a new selection,
   // make sure the Layers panel reveals the row:
@@ -125,30 +133,64 @@ export function LayersPanel() {
       className="relative flex shrink-0 flex-col border-r border-border bg-panel"
       style={{ width }}
     >
-      <div className="flex h-9 shrink-0 items-center border-b border-border px-4">
-        {/* Apple HIG: section headers are title-style, not uppercase. */}
-        <span className="text-[11px] font-medium text-text-muted">
-          Layers
-        </span>
+      <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border px-2">
+        <SidebarTab
+          active={tab === 'layers'}
+          label="Layers"
+          onClick={() => setTab('layers')}
+        />
+        <SidebarTab
+          active={tab === 'components'}
+          label="Assets"
+          onClick={() => setTab('components')}
+        />
       </div>
-      <div ref={scrollerRef} className="flex-1 overflow-auto py-2">
-        {/* Camera sits above the artboard tree as its own section. It's a
-            scene-level node (parent: null, not a child of root) so it
-            would otherwise not appear in the walk. Surfacing it here
-            makes it selectable and keyframeable via the same flow as
-            any other layer — click to select, then edit in Inspector,
-            or animate via the Animate tab. */}
-        {camera ? <CameraRow node={camera} /> : <AddCameraRow />}
-        {root ? (
-          <Row node={root} depth={0} />
-        ) : (
-          <p className="px-3 py-4 text-text-dim">
-            Empty scene.
-            <br />
-            <span className="text-[11px]">Press R to draw a rectangle.</span>
-          </p>
-        )}
-      </div>
+      {tab === 'layers' ? (
+        <div ref={scrollerRef} className="flex-1 overflow-auto py-2">
+          {editMaster && editMaster.kind === 'component' ? (
+            <>
+              <div className="px-3 pb-2 text-[10px] font-medium uppercase tracking-wider text-[oklch(0.64_0.24_300)]">
+                Master component
+              </div>
+              <Row node={editMaster} depth={0} rootId={editMaster.id} />
+            </>
+          ) : (
+            <>
+          {/* Camera sits above the artboard tree as its own section. It's a
+              scene-level node (parent: null, not a child of root) so it
+              would otherwise not appear in the walk. Surfacing it here
+              makes it selectable and keyframeable via the same flow as
+              any other layer — click to select, then edit in Inspector,
+              or animate via the Animate tab. */}
+          {camera ? <CameraRow node={camera} /> : <AddCameraRow />}
+          {root ? (
+            <Row node={root} depth={0} rootId={rootId} />
+          ) : (
+            <p className="px-3 py-4 text-text-dim">
+              Empty scene.
+              <br />
+              <span className="text-[11px]">Press R to draw a rectangle.</span>
+            </p>
+          )}
+          {pasteboardNodes.length > 0 ? (
+            <div className="mt-3 border-t border-border pt-2">
+              <div className="px-3 pb-1 text-[10px] font-medium uppercase tracking-wider text-text-dim">
+                Pasteboard
+              </div>
+              {pasteboardNodes.map((node) => (
+                <Row key={node.id} node={node} depth={0} rootId={rootId} />
+              ))}
+            </div>
+          ) : null}
+            </>
+          )}
+        </div>
+      ) : (
+        <ComponentsPanel onViewAll={() => setComponentsModalOpen(true)} />
+      )}
+      {componentsModalOpen ? (
+        <ComponentsModal onClose={() => setComponentsModalOpen(false)} />
+      ) : null}
       {/* Right-edge drag handle. 4px wide, sits half-outside the panel
           so the handle hit area straddles the border line — easier to
           grab than a 1px border. */}
@@ -159,6 +201,274 @@ export function LayersPanel() {
       />
     </aside>
   )
+}
+
+function SidebarTab({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        'h-6 rounded px-2 text-[11px] font-medium transition-colors',
+        active
+          ? 'bg-panel-raised text-text'
+          : 'text-text-muted hover:bg-panel-raised/70 hover:text-text',
+      ].join(' ')}
+    >
+      {label}
+    </button>
+  )
+}
+
+function ComponentsPanel({ onViewAll }: { onViewAll: () => void }) {
+  useSceneVersion()
+  const api = useSceneAPI()
+  const components = listComponents(api)
+  const setSelection = useUI((s) => s.setSelection)
+  const setComponentEditId = useUI((s) => s.setComponentEditId)
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex h-9 shrink-0 items-center justify-between border-b border-border px-3">
+        <span className="text-[11px] font-medium text-text-muted">
+          Assets
+        </span>
+        <button
+          type="button"
+          onClick={onViewAll}
+          className="rounded px-2 py-1 text-[11px] font-medium text-[oklch(0.7_0.24_300)] hover:bg-panel-raised"
+        >
+          View all
+        </button>
+      </div>
+      <div className="flex-1 overflow-auto py-2">
+        {components.length === 0 ? (
+          <p className="px-3 py-4 text-[12px] text-text-dim">
+            No components yet.
+            <br />
+            <span className="text-[11px]">Select layers and press ⌥⌘K.</span>
+          </p>
+        ) : (
+          components.map((component) => (
+            <button
+              key={component.id}
+              type="button"
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.setData('text/hyper-motion-component', component.id)
+                e.dataTransfer.effectAllowed = 'copy'
+              }}
+              onClick={() => setSelection([component.id])}
+              onDoubleClick={() => {
+                setComponentEditId(component.id)
+                setSelection([component.id])
+              }}
+              className="group flex w-full items-center gap-2 px-3 py-2 text-left text-[12px] text-text-muted hover:bg-panel-raised hover:text-text"
+            >
+              <span className="font-mono text-[11px] text-[oklch(0.7_0.24_300)]">
+                ◆
+              </span>
+              <span className="min-w-0 flex-1 truncate">{component.name}</span>
+              <span className="text-[10px] text-text-dim">
+                {api.getChildren(component.id).length}
+              </span>
+            </button>
+          ))
+        )}
+      </div>
+      <div className="border-t border-border px-3 py-3">
+        <div className="text-[10px] font-medium uppercase tracking-wider text-text-dim">
+          Imported assets
+        </div>
+        <div className="mt-2 rounded-md border border-dashed border-border px-3 py-2 text-[11px] text-text-dim">
+          Images and media can be dropped directly onto the scene canvas.
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ComponentsModal({ onClose }: { onClose: () => void }) {
+  useSceneVersion()
+  const api = useSceneAPI()
+  const rootId = api.getRoot()
+  const components = listComponents(api)
+  const [query, setQuery] = useState('')
+  const [activeId, setActiveId] = useState<string | null>(
+    components[0]?.id ?? null,
+  )
+  const setSelection = useUI((s) => s.setSelection)
+  const filtered = components.filter((component) =>
+    component.name.toLowerCase().includes(query.trim().toLowerCase()),
+  )
+  const active =
+    filtered.find((component) => component.id === activeId) ??
+    filtered[0] ??
+    null
+
+  const insert = () => {
+    if (!active || !rootId) return
+    const meta = api.getMeta()
+    const id = instantiateComponent(api, active.id, rootId, {
+      absolute: true,
+      position: {
+        x: Math.round(meta.canvas.width / 2 - 80),
+        y: Math.round(meta.canvas.height / 2 - 60),
+      },
+    })
+    if (id) setSelection([id])
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45">
+      <div className="flex h-[620px] w-[860px] flex-col overflow-hidden rounded-lg border border-border-strong bg-panel shadow-2xl">
+        <div className="border-b border-border px-5 py-4">
+          <h2 className="text-[15px] font-semibold text-text">
+            Components
+          </h2>
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search components"
+            className="mt-3 h-9 w-full rounded-md border border-border bg-app-bg px-3 text-[13px] text-text outline-none ring-0 placeholder:text-text-dim focus:border-[oklch(0.64_0.24_300)]"
+          />
+        </div>
+        <div className="grid min-h-0 flex-1 grid-cols-[220px_1fr]">
+          <div className="border-r border-border bg-app-bg/40 p-2">
+            {filtered.length === 0 ? (
+              <p className="px-2 py-3 text-[12px] text-text-dim">
+                No matches.
+              </p>
+            ) : (
+              filtered.map((component) => {
+                const selected = component.id === active?.id
+                return (
+                  <button
+                    key={component.id}
+                    type="button"
+                    onClick={() => setActiveId(component.id)}
+                    className={[
+                      'flex w-full items-center gap-2 rounded px-2 py-2 text-left text-[12px]',
+                      selected
+                        ? 'text-text'
+                        : 'text-text-muted hover:bg-panel-raised hover:text-text',
+                    ].join(' ')}
+                    style={
+                      selected
+                        ? { backgroundColor: 'oklch(0.64 0.24 300 / 0.16)' }
+                        : undefined
+                    }
+                  >
+                    <span className="font-mono text-[oklch(0.7_0.24_300)]">
+                      ◆
+                    </span>
+                    <span className="min-w-0 flex-1 truncate">
+                      {component.name}
+                    </span>
+                  </button>
+                )
+              })
+            )}
+          </div>
+          <div className="flex min-h-0 flex-col p-5">
+            {active ? (
+              <>
+                <div className="flex flex-1 items-center justify-center rounded-md border border-border bg-app-bg">
+                  <div className="rounded-md border border-[oklch(0.64_0.24_300_/_0.55)] bg-panel px-8 py-6 text-center shadow-lg">
+                    <div className="text-[28px] text-[oklch(0.7_0.24_300)]">
+                      ◆
+                    </div>
+                    <div className="mt-2 text-[14px] font-semibold text-text">
+                      {active.name}
+                    </div>
+                    <div className="mt-1 text-[11px] text-text-dim">
+                      Master component
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-4 grid grid-cols-3 gap-3 text-[12px]">
+                  <ComponentFact label="Name" value={active.name} />
+                  <ComponentFact
+                    label="Children"
+                    value={String(api.getChildren(active.id).length)}
+                  />
+                  <ComponentFact
+                    label="Instances"
+                    value={String(countInstances(api, active.id))}
+                  />
+                </div>
+              </>
+            ) : (
+              <div className="flex flex-1 items-center justify-center text-[13px] text-text-dim">
+                No component selected.
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 border-t border-border px-5 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-9 rounded-md border border-border px-4 text-[13px] font-medium text-text-muted hover:bg-panel-raised hover:text-text"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={insert}
+            disabled={!active}
+            className="h-9 rounded-md bg-[oklch(0.64_0.24_300)] px-4 text-[13px] font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Insert
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ComponentFact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-panel-raised px-3 py-2">
+      <div className="text-[10px] uppercase tracking-wide text-text-dim">
+        {label}
+      </div>
+      <div className="mt-1 truncate text-[12px] font-medium text-text">
+        {value}
+      </div>
+    </div>
+  )
+}
+
+function listComponents(api: SceneAPI): Extract<Node, { kind: 'component' }>[] {
+  return api
+    .getAllNodeIds()
+    .map((id) => api.getNode(id))
+    .filter(
+      (node): node is Extract<Node, { kind: 'component' }> =>
+        !!node && node.kind === 'component',
+    )
+}
+
+function countInstances(api: SceneAPI, componentId: NodeId): number {
+  let count = 0
+  for (const id of api.getAllNodeIds()) {
+    const node = api.getNode(id)
+    if (node?.kind === 'instance' && node.componentId === componentId) {
+      count++
+    }
+  }
+  return count
 }
 
 /**
@@ -316,17 +626,27 @@ function AddCameraRow() {
   )
 }
 
-function Row({ node, depth }: { node: Node; depth: number }) {
+function Row({
+  node,
+  depth,
+  rootId,
+}: {
+  node: Node
+  depth: number
+  rootId: NodeId
+}) {
   const api = useSceneAPI()
   const selection = useUI((s) => s.selection)
   const toggleInSelection = useUI((s) => s.toggleInSelection)
   const setSelection = useUI((s) => s.setSelection)
+  const setComponentEditId = useUI((s) => s.setComponentEditId)
   const extendSelectionTo = useUI((s) => s.extendSelectionTo)
   const openContextMenu = useUI((s) => s.openContextMenu)
   const collapsed = useUI((s) => s.layersCollapsed.has(node.id))
   const layersCollapsed = useUI((s) => s.layersCollapsed)
   const toggleLayerCollapsed = useUI((s) => s.toggleLayerCollapsed)
   const selected = selection.includes(node.id)
+  const isComponentNode = node.kind === 'component' || node.kind === 'instance'
   const children = api.getChildren(node.id)
   const hasChildren = children.length > 0
   const [editing, setEditing] = useState(false)
@@ -334,7 +654,7 @@ function Row({ node, depth }: { node: Node; depth: number }) {
   const [dropEdge, setDropEdge] = useState<'above' | 'into' | 'below' | null>(
     null,
   )
-  const isRoot = node.parent === null
+  const isRoot = node.id === rootId
   // Which nodes accept "drop into" as a new child. Frames and components
   // are the real containers. Instances technically expose children
   // through their component definition — dropping a foreign node inside
@@ -462,13 +782,21 @@ function Row({ node, depth }: { node: Node; depth: number }) {
           }
         }}
         onDoubleClick={() => {
+          if (node.kind === 'component' || node.kind === 'instance') {
+            const masterId = node.kind === 'instance' ? node.componentId : node.id
+            setComponentEditId(masterId)
+            setSelection([masterId])
+            return
+          }
           setDraftName(node.name)
           setEditing(true)
         }}
         className={[
           'group relative flex w-full items-center gap-1 py-1 pr-2 text-left text-[12px] transition-colors',
           selected
-            ? 'bg-accent-soft text-text'
+            ? isComponentNode
+              ? 'text-text'
+              : 'bg-accent-soft text-text'
             : 'text-text-muted hover:bg-panel-raised hover:text-text',
           dropEdge === 'above' ? 'border-t-2 border-t-accent' : '',
           dropEdge === 'below' ? 'border-b-2 border-b-accent' : '',
@@ -479,7 +807,12 @@ function Row({ node, depth }: { node: Node; depth: number }) {
             ? 'ring-2 ring-inset ring-accent bg-accent-soft/40'
             : '',
         ].join(' ')}
-        style={{ paddingLeft: 8 + depth * 12 }}
+        style={{
+          paddingLeft: 8 + depth * 12,
+          ...(selected && isComponentNode
+            ? { backgroundColor: 'oklch(0.64 0.24 300 / 0.16)' }
+            : {}),
+        }}
       >
         {hasChildren ? (
           <button
@@ -556,7 +889,7 @@ function Row({ node, depth }: { node: Node; depth: number }) {
       </div>
       {!collapsed &&
         children.map((c) => (
-          <Row key={c.id} node={c} depth={depth + 1} />
+          <Row key={c.id} node={c} depth={depth + 1} rootId={rootId} />
         ))}
     </>
   )
@@ -695,8 +1028,14 @@ function glyphFor(node: Node): string {
 }
 
 function KindGlyph({ node }: { node: Node }) {
+  const isComponentNode = node.kind === 'component' || node.kind === 'instance'
   return (
-    <span className="w-3 shrink-0 text-center font-mono text-[10px] text-text-dim">
+    <span
+      className="w-3 shrink-0 text-center font-mono text-[10px] text-text-dim"
+      style={{
+        color: isComponentNode ? 'oklch(0.7 0.24 300)' : undefined,
+      }}
+    >
       {glyphFor(node)}
     </span>
   )

--- a/src/ui/SelectionOverlay.tsx
+++ b/src/ui/SelectionOverlay.tsx
@@ -25,16 +25,18 @@ export function SelectionOverlay({
   animated,
   inherited,
   zoom,
+  rootId: rootIdOverride,
 }: {
   solved: SolvedLayout
   animated: Record<NodeId, AnimatedValue>
   inherited: Record<NodeId, InheritedAnim>
   zoom: number
+  rootId?: NodeId | null
 }) {
   useSceneVersion()
   const api = useSceneAPI()
   const selection = useUI((s) => s.selection)
-  const rootId = api.getRoot()
+  const rootId = rootIdOverride ?? api.getRoot()
 
   if (selection.length === 0) return null
 
@@ -72,6 +74,9 @@ export function SelectionOverlay({
         const ownRot = anim?.rotation ?? node.transform.rotation
         const ownSX = anim?.scaleX ?? node.transform.scaleX
         const ownSY = anim?.scaleY ?? node.transform.scaleY
+        const anchorX = isRoot ? 0.5 : anim?.anchorX ?? node.transform.anchorX ?? 0.5
+        const anchorY = isRoot ? 0.5 : anim?.anchorY ?? node.transform.anchorY ?? 0.5
+        const anchorZ = isRoot ? 0 : anim?.anchorZ ?? node.transform.anchorZ ?? 0
         const tx = isRoot ? 0 : ownX + (inh?.x ?? 0)
         const ty = isRoot ? 0 : ownY + (inh?.y ?? 0)
         const rotation = isRoot ? 0 : ownRot + (inh?.rotation ?? 0)
@@ -85,6 +90,14 @@ export function SelectionOverlay({
         const transform = parts.length > 0 ? parts.join(' ') : undefined
 
         const isSingle = singleSelection === id
+        const isComponentNode =
+          node.kind === 'component' || node.kind === 'instance'
+        const outlineColor = isComponentNode
+          ? 'oklch(0.64 0.24 300)'
+          : 'var(--color-accent)'
+        const outlineSoft = isComponentNode
+          ? 'oklch(0.64 0.24 300 / 0.18)'
+          : 'var(--color-accent-soft)'
 
         return (
           <div
@@ -99,12 +112,12 @@ export function SelectionOverlay({
               width: rect.width,
               height: rect.height,
               transform,
-              transformOrigin: 'center center',
-              outline: `${strokeWidth}px solid var(--color-accent)`,
+              transformOrigin: `${Number((anchorX * 100).toFixed(3))}% ${Number((anchorY * 100).toFixed(3))}% ${Number(anchorZ.toFixed(3))}px`,
+              outline: `${strokeWidth}px solid ${outlineColor}`,
               outlineOffset: `${0.5 / Math.max(zoom, 0.001)}px`,
               // Subtle corner ticks make the selection read at a glance
               // even on tiny nodes at high zoom. 6px at 1x, scaled.
-              boxShadow: `0 0 0 ${strokeWidth / 3}px var(--color-accent-soft) inset`,
+              boxShadow: `0 0 0 ${strokeWidth / 3}px ${outlineSoft} inset`,
             }}
           >
             {isSingle && showHandles ? (

--- a/src/ui/TopBar.tsx
+++ b/src/ui/TopBar.tsx
@@ -139,6 +139,7 @@ export function TopBar() {
         <span className="mx-1 h-4 w-px bg-border" />
 
         <ThemeToggle />
+        <PreviewButton />
         <PanelTogglePopover panels={panels} togglePanel={togglePanel} />
 
         <span className="mx-1 h-4 w-px bg-border" />
@@ -408,6 +409,30 @@ function ThemeToggle() {
   )
 }
 
+function PreviewButton() {
+  const openPreview = () => {
+    const url = new URL(window.location.href)
+    url.searchParams.set('preview', '1')
+    url.searchParams.delete('render-window')
+    url.searchParams.delete('requestId')
+    window.history.pushState(null, '', url.toString())
+    window.dispatchEvent(new Event('popstate'))
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={openPreview}
+      title="Preview (Cmd P)"
+      aria-label="Preview (Cmd P)"
+      className="flex h-8 items-center gap-1.5 rounded-md px-2.5 text-[12px] font-medium text-text-muted hover:bg-panel-raised hover:text-text"
+    >
+      <PlayIcon />
+      <span>Preview</span>
+    </button>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Icon glyphs. 16×16 base, currentColor stroke, hand-drawn so they fit
 // the rest of the app's icon language. Mode tabs use slightly smaller
@@ -481,6 +506,14 @@ function SystemIcon() {
     <svg {...svgProps()}>
       <rect x="2" y="3" width="12" height="9" rx="1" />
       <path d="M5.5 14.5h5M8 12.5v2" />
+    </svg>
+  )
+}
+
+function PlayIcon() {
+  return (
+    <svg {...svgProps(14)} fill="currentColor" stroke="none">
+      <path d="M5 3.25v7.5c0 .45.5.72.88.48l5.75-3.75a.56.56 0 000-.96L5.88 2.77A.57.57 0 005 3.25z" />
     </svg>
   )
 }

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -1,7 +1,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Layout, Node as SceneNode, NodeId } from '@/scene'
+import type {
+  ComponentPropertyDefinition,
+  ComponentPropertyType,
+  EasingKind,
+  Interaction,
+  InteractionEventKind,
+  Layout,
+  Node as SceneNode,
+  NodeId,
+  SizeAxis,
+  Stroke,
+  Track,
+  VariantSelection,
+} from '@/scene'
 import type { SceneAPI } from '@/scene/doc'
+import { addKeyframe } from '@/anim'
+import { getLastSolvedLayout } from '@/ui/hooks/lastSolvedLayout'
+
+const DEFAULT_COMPONENT_STROKE: Stroke = {
+  color: 'oklch(0.6 0 0)',
+  width: 1,
+  align: 'inside',
+  style: 'solid',
+  dashLength: 6,
+  dashGap: 4,
+}
 
 /**
  * High-level scene actions that are reused across keyboard shortcuts,
@@ -77,6 +101,1072 @@ export function wrapInAutoLayout(
  */
 export function wrapInGrid(api: SceneAPI, ids: NodeId[]): NodeId | null {
   return wrapInContainer(api, ids, { name: 'Grid', layout: DEFAULT_GRID_LAYOUT })
+}
+
+/**
+ * Create a master component from the current selection.
+ *
+ * MVP behavior intentionally mirrors the existing wrap action: the
+ * selected layers become children of a new Component node under their
+ * parent. That keeps the master visible/editable on canvas while giving
+ * instances a stable `componentId` to reference.
+ */
+export function createComponentFromSelection(
+  api: SceneAPI,
+  ids: NodeId[],
+): NodeId | null {
+  if (ids.length === 0) return null
+  const nodes = ids
+    .map((id) => api.getNode(id))
+    .filter((n): n is SceneNode => !!n)
+    .filter((n) => n.parent != null && n.kind !== 'camera')
+  if (nodes.length === 0) return null
+
+  if (nodes.length === 1 && nodes[0]!.kind === 'component') {
+    return nodes[0]!.id
+  }
+
+  const firstParent = nodes[0]!.parent as NodeId
+  const allSameParent = nodes.every((n) => n.parent === firstParent)
+  const siblings = allSameParent
+    ? api.getChildren(firstParent).map((c) => c.id)
+    : []
+  const sortedIds = allSameParent
+    ? nodes
+        .map((n) => n.id)
+        .sort((a, b) => siblings.indexOf(a) - siblings.indexOf(b))
+    : nodes.map((n) => n.id)
+  const selectedSiblingIndexes = sortedIds
+    .map((id) => siblings.indexOf(id))
+    .filter((index) => index >= 0)
+  const insertionIndex =
+    allSameParent && selectedSiblingIndexes.length > 0
+      ? Math.min(...selectedSiblingIndexes)
+      : -1
+  const parentNode = api.getNode(firstParent)
+  const parentLayoutMode =
+    parentNode && 'layout' in parentNode ? parentNode.layout.mode : 'none'
+  const shouldStayInLayout =
+    allSameParent &&
+    parentLayoutMode !== 'none' &&
+    nodes.every((node) => node.position !== 'absolute')
+
+  const bounds = getSelectionBounds(nodes, firstParent)
+  const componentId = api.createNode('component', firstParent, {
+    name: nodes.length === 1 ? `${nodes[0]!.name} component` : 'Component',
+    size: { width: bounds.width, height: bounds.height },
+    layout: {
+      mode: 'none',
+      direction: 'row',
+      justify: 'start',
+      align: 'start',
+      gap: 0,
+      padding: { top: 0, right: 0, bottom: 0, left: 0 },
+      wrap: false,
+      columns: 3,
+      rowGap: 0,
+      columnGap: 0,
+    },
+    appearance: {
+      opacity: 1,
+      fill: null,
+      stroke: null,
+      cornerRadius: 0,
+      effects: [],
+    },
+    position: shouldStayInLayout ? 'flow' : 'absolute',
+    transform: {
+      x: shouldStayInLayout ? 0 : bounds.x,
+      y: shouldStayInLayout ? 0 : bounds.y,
+      z: 0,
+      rotation: 0,
+      rotationX: 0,
+      rotationY: 0,
+      scaleX: 1,
+      scaleY: 1,
+    },
+    variants: [{ name: 'State', values: ['Default'] }],
+    defaultSelection: { State: 'Default' },
+    variantOverrides: [],
+    componentProperties: [],
+    variantTransition: {
+      duration: 0.3,
+      easing: 'ease-in-out',
+      presetId: 'smooth',
+      strength: 50,
+    },
+    timelines: {},
+    interactions: [],
+  })
+  if (insertionIndex >= 0) {
+    api.moveChild(firstParent, componentId, insertionIndex)
+  }
+
+  for (const id of sortedIds) {
+    const child = api.getNode(id)
+    if (!child) continue
+    const childRect = bounds.rects[id]
+    api.appendChild(componentId, id)
+    api.setNodeProperty(id, 'position', 'absolute')
+    api.setNodeProperty(id, 'transform', {
+      ...child.transform,
+      x: Math.round((childRect?.x ?? child.transform.x) - bounds.x),
+      y: Math.round((childRect?.y ?? child.transform.y) - bounds.y),
+    })
+  }
+  return componentId
+}
+
+export function fitComponentToChildren(
+  api: SceneAPI,
+  componentId: NodeId,
+  opts: { preserveHug?: boolean } = {},
+): boolean {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return false
+  const bounds = measureComponentChildBounds(api, componentId)
+  if (!bounds) return false
+  const width = Math.max(1, Math.ceil(bounds.maxX - bounds.minX))
+  const height = Math.max(1, Math.ceil(bounds.maxY - bounds.minY))
+  const currentWidth =
+    typeof component.size.width === 'number' ? component.size.width : 0
+  const currentHeight =
+    typeof component.size.height === 'number' ? component.size.height : 0
+  const shouldNormalize =
+    Math.abs(bounds.minX) >= 0.5 || Math.abs(bounds.minY) >= 0.5
+  if (
+    !shouldNormalize &&
+    Math.abs(currentWidth - width) < 0.5 &&
+    Math.abs(currentHeight - height) < 0.5
+  ) {
+    return false
+  }
+  api.doc.transact(() => {
+    if (shouldNormalize) {
+      for (const child of api.getChildren(component.id)) {
+        api.setNodeProperty(child.id, 'transform', {
+          ...child.transform,
+          x: child.transform.x - bounds.minX,
+          y: child.transform.y - bounds.minY,
+        })
+      }
+    }
+    api.setNodeProperty(component.id, 'size', {
+      width:
+        opts.preserveHug && component.size.width === 'hug'
+          ? 'hug'
+          : width,
+      height:
+        opts.preserveHug && component.size.height === 'hug'
+          ? 'hug'
+          : height,
+    })
+  })
+  syncComponentInstances(api, component.id)
+  return true
+}
+
+export function exposeComponentProperty(
+  api: SceneAPI,
+  nodeId: NodeId,
+  path: string,
+  type: ComponentPropertyType,
+  name?: string,
+): string | null {
+  const component = findOwningComponent(api, nodeId)
+  if (!component) return null
+  const existing = component.componentProperties.find(
+    (prop) => prop.nodeId === nodeId && prop.path === path,
+  )
+  if (existing) return existing.id
+  const node = api.getNode(nodeId)
+  const prop: ComponentPropertyDefinition = {
+    id: genActionId(),
+    nodeId,
+    path,
+    type,
+    name: name ?? defaultComponentPropertyName(node?.name ?? 'Layer', path),
+  }
+  api.setNodeProperty(component.id, 'componentProperties', [
+    ...component.componentProperties,
+    prop,
+  ] as never)
+  return prop.id
+}
+
+export function removeComponentProperty(
+  api: SceneAPI,
+  componentId: NodeId,
+  propertyId: string,
+): void {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return
+  api.setNodeProperty(
+    component.id,
+    'componentProperties',
+    component.componentProperties.filter((prop) => prop.id !== propertyId) as never,
+  )
+}
+
+export function updateComponentPropertyDefinition(
+  api: SceneAPI,
+  componentId: NodeId,
+  propertyId: string,
+  patch: Partial<ComponentPropertyDefinition>,
+): void {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return
+  api.setNodeProperty(
+    component.id,
+    'componentProperties',
+    component.componentProperties.map((prop) =>
+      prop.id === propertyId ? { ...prop, ...patch, id: prop.id } : prop,
+    ) as never,
+  )
+}
+
+export function setComponentSourceProperty(
+  api: SceneAPI,
+  componentId: NodeId,
+  propertyId: string,
+  value: unknown,
+): void {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return
+  const prop = component.componentProperties.find((p) => p.id === propertyId)
+  if (!prop) return
+  const source = api.getNode(prop.nodeId)
+  if (!source) return
+  const patch =
+    prop.path === 'appearance.stroke.width'
+      ? setPathValue(source as unknown as Record<string, unknown>, 'appearance.stroke', {
+          ...DEFAULT_COMPONENT_STROKE,
+          ...(source.appearance.stroke ?? {}),
+          width: value,
+        })
+      : setPathValue({}, prop.path, value)
+  applyPatchStatic(api, source.id, patch)
+  syncComponentInstances(api, component.id)
+}
+
+export function setInstanceComponentProperty(
+  api: SceneAPI,
+  instanceId: NodeId,
+  propertyId: string,
+  value: unknown,
+): void {
+  const instance = api.getNode(instanceId)
+  if (!instance || instance.kind !== 'instance') return
+  const component = api.getNode(instance.componentId)
+  if (!component || component.kind !== 'component') return
+  const prop = component.componentProperties.find((p) => p.id === propertyId)
+  if (!prop) return
+  const currentNodeOverrides = instance.overrides[prop.nodeId] ?? {}
+  const source = api.getNode(prop.nodeId)
+  const nextNodeOverrides =
+    prop.path === 'appearance.stroke.width' && source
+      ? setPathValue(currentNodeOverrides, 'appearance.stroke', {
+          ...DEFAULT_COMPONENT_STROKE,
+          ...(source.appearance.stroke ?? {}),
+          ...((getPathValue(
+            currentNodeOverrides,
+            'appearance.stroke',
+          ) as object | undefined) ?? {}),
+          width: value,
+        })
+      : setPathValue(currentNodeOverrides, prop.path, value)
+  const nextOverrides = {
+    ...instance.overrides,
+    [prop.nodeId]: nextNodeOverrides,
+  }
+  api.setNodeProperty(instance.id, 'overrides', nextOverrides)
+  const targetId = mapInstanceChildrenBySource(api, instanceId).get(prop.nodeId)
+  if (targetId) applyPatchStatic(api, targetId, nextNodeOverrides)
+}
+
+export function resetInstanceComponentProperty(
+  api: SceneAPI,
+  instanceId: NodeId,
+  propertyId: string,
+): void {
+  const instance = api.getNode(instanceId)
+  if (!instance || instance.kind !== 'instance') return
+  const component = api.getNode(instance.componentId)
+  if (!component || component.kind !== 'component') return
+  const prop = component.componentProperties.find((p) => p.id === propertyId)
+  if (!prop) return
+  const currentNodeOverrides = instance.overrides[prop.nodeId] ?? {}
+  const nextNodeOverrides = unsetPathValue(currentNodeOverrides, prop.path)
+  const nextOverrides = { ...instance.overrides }
+  if (Object.keys(nextNodeOverrides).length === 0) {
+    delete nextOverrides[prop.nodeId]
+  } else {
+    nextOverrides[prop.nodeId] = nextNodeOverrides
+  }
+  api.setNodeProperty(instance.id, 'overrides', nextOverrides)
+  materializeComponentChildren(api, component.id, instance.id)
+  applyVariantSelectionStatic(api, instance.id, instance.selection)
+  applyInstanceOverridesStatic(api, instance.id)
+}
+
+/**
+ * Create a linked instance of a master component.
+ *
+ * The current renderer cannot yet draw virtual repeated children with
+ * duplicate ids, so instances are materialized as children whose
+ * `componentSourceId` points back to the corresponding master node.
+ * `syncComponentInstances` refreshes those materialized children from
+ * the master definition.
+ */
+export function instantiateComponent(
+  api: SceneAPI,
+  componentId: NodeId,
+  parentId?: NodeId | null,
+  opts?: {
+    position?: { x: number; y: number }
+    absolute?: boolean
+    workspaceOnly?: boolean
+  },
+): NodeId | null {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return null
+  const parent = parentId === undefined ? component.parent : parentId
+  if (!parent && !opts?.workspaceOnly) return null
+
+  const instanceId = api.createNode('instance', parent, {
+    name: `${component.name} instance`,
+    componentId,
+    size: component.size,
+    layout: component.layout,
+    appearance: component.appearance,
+    selection: component.defaultSelection,
+    overrides: {},
+    interactions: [],
+    position: opts?.absolute ? 'absolute' : 'flow',
+    workspaceOnly: opts?.workspaceOnly ?? false,
+    transform: {
+      ...component.transform,
+      x: opts?.position?.x ?? component.transform.x + 24,
+      y: opts?.position?.y ?? component.transform.y + 24,
+    },
+  })
+  materializeComponentChildren(api, componentId, instanceId)
+  const instance = api.getNode(instanceId)
+  if (instance?.kind === 'instance') {
+    applyVariantSelectionStatic(api, instanceId, instance.selection)
+    applyInstanceOverridesStatic(api, instanceId)
+  }
+  return instanceId
+}
+
+export function ensureComponentStateAxis(api: SceneAPI, componentId: NodeId): void {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return
+  if (component.variants.some((axis) => axis.name === 'State')) return
+  api.doc.transact(() => {
+    api.setNodeProperty(component.id, 'variants', [
+      ...component.variants,
+      { name: 'State', values: ['Default'] },
+    ])
+    api.setNodeProperty(component.id, 'defaultSelection', {
+      ...component.defaultSelection,
+      State: 'Default',
+    })
+  })
+}
+
+export function captureComponentVariant(
+  api: SceneAPI,
+  componentId: NodeId,
+  variantName: string,
+): void {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return
+  const cleanName = variantName.trim() || `Variant ${component.variantOverrides.length + 1}`
+  const axes = component.variants.some((axis) => axis.name === 'State')
+    ? component.variants.map((axis) =>
+        axis.name === 'State' && !axis.values.includes(cleanName)
+          ? { ...axis, values: [...axis.values, cleanName] }
+          : axis,
+      )
+    : [...component.variants, { name: 'State', values: ['Default', cleanName] }]
+  const overrides = captureComponentSubtree(api, componentId)
+  const nextOverrides = [
+    ...component.variantOverrides.filter(
+      (variant) => variant.match.State !== cleanName,
+    ),
+    { match: { State: cleanName }, overrides },
+  ]
+  api.doc.transact(() => {
+    api.setNodeProperty(component.id, 'variants', axes)
+    api.setNodeProperty(component.id, 'defaultSelection', {
+      ...component.defaultSelection,
+      State: component.defaultSelection.State ?? 'Default',
+    })
+    api.setNodeProperty(component.id, 'variantOverrides', nextOverrides)
+  })
+}
+
+export const upsertComponentVariant = captureComponentVariant
+
+export function applyComponentVariantState(
+  api: SceneAPI,
+  componentId: NodeId,
+  variantName: string,
+): void {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return
+  const variant = component.variantOverrides.find(
+    (entry) => entry.match.State === variantName,
+  )
+  if (!variant) return
+  api.doc.transact(() => {
+    for (const [nodeId, patch] of Object.entries(variant.overrides)) {
+      applyPatchStatic(api, nodeId, patch)
+    }
+  })
+  fitComponentToChildren(api, component.id)
+}
+
+export function removeComponentVariant(
+  api: SceneAPI,
+  componentId: NodeId,
+  variantName: string,
+): void {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return
+  if (variantName === 'Default') return
+  api.doc.transact(() => {
+    api.setNodeProperty(
+      component.id,
+      'variants',
+      component.variants.map((axis) =>
+        axis.name === 'State'
+          ? { ...axis, values: axis.values.filter((value) => value !== variantName) }
+          : axis,
+      ) as never,
+    )
+    api.setNodeProperty(
+      component.id,
+      'variantOverrides',
+      component.variantOverrides.filter(
+        (variant) => variant.match.State !== variantName,
+      ) as never,
+    )
+    if (component.defaultSelection.State === variantName) {
+      api.setNodeProperty(component.id, 'defaultSelection', {
+        ...component.defaultSelection,
+        State: 'Default',
+      } as never)
+    }
+  })
+}
+
+export function addComponentVariantInteraction(
+  api: SceneAPI,
+  componentId: NodeId,
+  opts: {
+    event: InteractionEventKind
+    targetState: string
+    sourceNodeId?: NodeId
+    delay?: number
+  },
+): string | null {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return null
+  const action = {
+    type: 'setVariant' as const,
+    selection: { State: opts.targetState },
+  }
+  const interaction: Interaction = {
+    id: genActionId(),
+    sourceNodeId: opts.sourceNodeId,
+    event: opts.event,
+    actions:
+      opts.delay && opts.delay > 0
+        ? [{ type: 'after', delay: opts.delay, action }]
+        : [action],
+  }
+  api.setNodeProperty(component.id, 'interactions', [
+    ...component.interactions,
+    interaction,
+  ] as never)
+  return interaction.id
+}
+
+export function updateComponentInteraction(
+  api: SceneAPI,
+  componentId: NodeId,
+  interactionId: string,
+  patch: Partial<Interaction>,
+): void {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return
+  api.setNodeProperty(
+    component.id,
+    'interactions',
+    component.interactions.map((interaction) =>
+      interaction.id === interactionId
+        ? { ...interaction, ...patch, id: interaction.id }
+        : interaction,
+    ) as never,
+  )
+}
+
+export function removeComponentInteraction(
+  api: SceneAPI,
+  componentId: NodeId,
+  interactionId: string,
+): void {
+  const component = api.getNode(componentId)
+  if (!component || component.kind !== 'component') return
+  api.setNodeProperty(
+    component.id,
+    'interactions',
+    component.interactions.filter((interaction) => interaction.id !== interactionId) as never,
+  )
+}
+
+export function applyInstanceVariantTransition(
+  api: SceneAPI,
+  instanceId: NodeId,
+  selection: VariantSelection,
+  opts: { playhead: number },
+): void {
+  const instance = api.getNode(instanceId)
+  if (!instance || instance.kind !== 'instance') return
+  const component = api.getNode(instance.componentId)
+  if (!component || component.kind !== 'component') return
+  const overrides = resolveVariantOverrideForSelection(component, selection)
+  const sourceToMaterialized = mapInstanceChildrenBySource(api, instanceId)
+  const duration = Math.max(0, component.variantTransition.duration)
+  const easing = component.variantTransition.easing
+
+  api.doc.transact(() => {
+    api.setNodeProperty(instance.id, 'selection', {
+      ...instance.selection,
+      ...selection,
+    })
+    for (const [sourceId, patch] of Object.entries(overrides)) {
+      const targetId = sourceToMaterialized.get(sourceId)
+      if (!targetId) continue
+      animatePatch(api, targetId, patch, opts.playhead, duration, easing)
+    }
+  })
+}
+
+function resolveVariantOverrideForSelection(
+  component: Extract<SceneNode, { kind: 'component' }>,
+  selection: VariantSelection,
+): Record<NodeId, Record<string, unknown>> {
+  const out: Record<NodeId, Record<string, unknown>> = {}
+  for (const variant of component.variantOverrides) {
+    let matches = true
+    for (const [axis, value] of Object.entries(variant.match)) {
+      if (selection[axis] !== value) {
+        matches = false
+        break
+      }
+    }
+    if (!matches) continue
+    for (const [nodeId, patch] of Object.entries(variant.overrides)) {
+      out[nodeId] = { ...(out[nodeId] ?? {}), ...patch }
+    }
+  }
+  return out
+}
+
+function captureComponentSubtree(
+  api: SceneAPI,
+  componentId: NodeId,
+): Record<NodeId, Record<string, unknown>> {
+  const out: Record<NodeId, Record<string, unknown>> = {}
+  const visit = (id: NodeId) => {
+    const node = api.getNode(id)
+    if (!node || node.id === componentId) {
+      for (const child of api.getChildren(id)) visit(child.id)
+      return
+    }
+    out[node.id] = captureVariantProps(node)
+    for (const child of api.getChildren(id)) visit(child.id)
+  }
+  visit(componentId)
+  return out
+}
+
+function captureVariantProps(node: SceneNode): Record<string, unknown> {
+  const props: Record<string, unknown> = {
+    transform: node.transform,
+    appearance: node.appearance,
+    visible: node.visible,
+  }
+  if ('size' in node) props.size = node.size
+  if ('layout' in node) props.layout = node.layout
+  if (node.kind === 'text') {
+    props.text = node.text
+    props.color = node.color
+    props.fontSize = node.fontSize
+    props.fontWeight = node.fontWeight
+    props.lineHeight = node.lineHeight
+    props.letterSpacing = node.letterSpacing
+    props.textAlign = node.textAlign
+  }
+  return props
+}
+
+function mapInstanceChildrenBySource(
+  api: SceneAPI,
+  instanceId: NodeId,
+): Map<NodeId, NodeId> {
+  const out = new Map<NodeId, NodeId>()
+  const visit = (id: NodeId) => {
+    const node = api.getNode(id)
+    if (!node) return
+    if (node.componentSourceId) out.set(node.componentSourceId, node.id)
+    for (const child of api.getChildren(id)) visit(child.id)
+  }
+  visit(instanceId)
+  return out
+}
+
+function animatePatch(
+  api: SceneAPI,
+  nodeId: NodeId,
+  patch: Record<string, unknown>,
+  playhead: number,
+  duration: number,
+  easing: EasingKind,
+): void {
+  const node = api.getNode(nodeId)
+  if (!node) return
+  if (patch.transform && typeof patch.transform === 'object') {
+    const target = patch.transform as Partial<SceneNode['transform']>
+    for (const key of ['x', 'y', 'z', 'rotation', 'rotationX', 'rotationY', 'scaleX', 'scaleY'] as const) {
+      const value = target[key]
+      if (typeof value !== 'number') continue
+      addKeyframe(api, nodeId, `transform.${key}` as never, playhead, node.transform[key], easing)
+      addKeyframe(api, nodeId, `transform.${key}` as never, playhead + duration, value, easing)
+    }
+    api.setNodeProperty(nodeId, 'transform', { ...node.transform, ...target })
+  }
+  if (patch.appearance && typeof patch.appearance === 'object') {
+    const target = patch.appearance as Partial<SceneNode['appearance']>
+    if (typeof target.opacity === 'number') {
+      addKeyframe(api, nodeId, 'appearance.opacity', playhead, node.appearance.opacity, easing)
+      addKeyframe(api, nodeId, 'appearance.opacity', playhead + duration, target.opacity, easing)
+    }
+    if (typeof target.cornerRadius === 'number') {
+      addKeyframe(api, nodeId, 'appearance.cornerRadius', playhead, node.appearance.cornerRadius, easing)
+      addKeyframe(api, nodeId, 'appearance.cornerRadius', playhead + duration, target.cornerRadius, easing)
+    }
+    api.setNodeProperty(nodeId, 'appearance', deepMerge(node.appearance, target))
+  }
+  if (patch.size && typeof patch.size === 'object' && 'size' in node) {
+    api.setNodeProperty(nodeId, 'size', { ...node.size, ...(patch.size as object) })
+  }
+  if (patch.layout && typeof patch.layout === 'object' && 'layout' in node) {
+    api.setNodeProperty(nodeId, 'layout', { ...node.layout, ...(patch.layout as object) })
+  }
+  for (const [key, value] of Object.entries(patch)) {
+    if (
+      [
+        'id',
+        'kind',
+        'parent',
+        'children',
+        'transform',
+        'appearance',
+        'size',
+        'layout',
+      ].includes(key)
+    ) continue
+    api.setNodeProperty(nodeId, key as never, value as never)
+  }
+}
+
+export function syncComponentInstances(api: SceneAPI, componentId: NodeId): void {
+  for (const id of api.getAllNodeIds()) {
+    const node = api.getNode(id)
+    if (!node || node.kind !== 'instance' || node.componentId !== componentId) {
+      continue
+    }
+    const component = api.getNode(componentId)
+    if (!component || component.kind !== 'component') continue
+    api.setNodeProperty(node.id, 'size', component.size)
+    api.setNodeProperty(node.id, 'layout', component.layout)
+    materializeComponentChildren(api, componentId, node.id)
+    applyVariantSelectionStatic(api, node.id, node.selection)
+    applyInstanceOverridesStatic(api, node.id)
+  }
+}
+
+function applyVariantSelectionStatic(
+  api: SceneAPI,
+  instanceId: NodeId,
+  selection: VariantSelection,
+): void {
+  const instance = api.getNode(instanceId)
+  if (!instance || instance.kind !== 'instance') return
+  const component = api.getNode(instance.componentId)
+  if (!component || component.kind !== 'component') return
+  const overrides = resolveVariantOverrideForSelection(component, selection)
+  const sourceToMaterialized = mapInstanceChildrenBySource(api, instanceId)
+  for (const [sourceId, patch] of Object.entries(overrides)) {
+    const targetId = sourceToMaterialized.get(sourceId)
+    if (!targetId) continue
+    applyPatchStatic(api, targetId, patch)
+  }
+}
+
+function applyInstanceOverridesStatic(api: SceneAPI, instanceId: NodeId): void {
+  const instance = api.getNode(instanceId)
+  if (!instance || instance.kind !== 'instance') return
+  const sourceToMaterialized = mapInstanceChildrenBySource(api, instanceId)
+  for (const [sourceId, patch] of Object.entries(instance.overrides)) {
+    const targetId = sourceToMaterialized.get(sourceId)
+    if (!targetId) continue
+    applyPatchStatic(api, targetId, patch)
+  }
+}
+
+function applyPatchStatic(
+  api: SceneAPI,
+  nodeId: NodeId,
+  patch: Record<string, unknown>,
+): void {
+  const node = api.getNode(nodeId)
+  if (!node) return
+  if (patch.transform && typeof patch.transform === 'object') {
+    api.setNodeProperty(nodeId, 'transform', {
+      ...node.transform,
+      ...(patch.transform as object),
+    })
+  }
+  if (patch.appearance && typeof patch.appearance === 'object') {
+    api.setNodeProperty(nodeId, 'appearance', {
+      ...deepMerge(node.appearance, patch.appearance as Record<string, unknown>),
+    })
+  }
+  if (patch.size && typeof patch.size === 'object' && 'size' in node) {
+    api.setNodeProperty(nodeId, 'size', { ...node.size, ...(patch.size as object) })
+  }
+  if (patch.layout && typeof patch.layout === 'object' && 'layout' in node) {
+    api.setNodeProperty(nodeId, 'layout', { ...node.layout, ...(patch.layout as object) })
+  }
+  for (const [key, value] of Object.entries(patch)) {
+    if (
+      [
+        'id',
+        'kind',
+        'parent',
+        'children',
+        'componentSourceId',
+        'workspaceOnly',
+        'transform',
+        'appearance',
+        'size',
+        'layout',
+      ].includes(key)
+    ) continue
+    api.setNodeProperty(nodeId, key as never, value as never)
+  }
+}
+
+function findOwningComponent(
+  api: SceneAPI,
+  nodeId: NodeId,
+): Extract<SceneNode, { kind: 'component' }> | null {
+  let current = api.getNode(nodeId)
+  while (current?.parent) {
+    const parent = api.getNode(current.parent)
+    if (parent?.kind === 'component') return parent
+    current = parent
+  }
+  return current?.kind === 'component' ? current : null
+}
+
+function defaultComponentPropertyName(layerName: string, path: string): string {
+  const label =
+    path === 'text'
+      ? 'Text'
+      : path === 'color'
+        ? 'Text color'
+        : path === 'appearance.fill'
+          ? 'Fill'
+          : path === 'appearance.stroke'
+            ? 'Stroke'
+            : path === 'appearance.stroke.width'
+              ? 'Stroke width'
+              : path === 'appearance.cornerRadius'
+                ? 'Radius'
+                : path === 'appearance.opacity'
+                  ? 'Opacity'
+                  : path === 'size'
+                    ? 'Size'
+                    : path
+  return `${layerName} ${label}`
+}
+
+function setPathValue(
+  source: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): Record<string, unknown> {
+  const keys = path.split('.')
+  if (keys.length === 1) return { ...source, [path]: value }
+  const [head, ...rest] = keys
+  const current =
+    source[head!] && typeof source[head!] === 'object'
+      ? (source[head!] as Record<string, unknown>)
+      : {}
+  return {
+    ...source,
+    [head!]: setPathValue(current, rest.join('.'), value),
+  }
+}
+
+function getPathValue(source: Record<string, unknown>, path: string): unknown {
+  let cur: unknown = source
+  for (const key of path.split('.')) {
+    if (!cur || typeof cur !== 'object') return undefined
+    cur = (cur as Record<string, unknown>)[key]
+  }
+  return cur
+}
+
+function unsetPathValue(
+  source: Record<string, unknown>,
+  path: string,
+): Record<string, unknown> {
+  const keys = path.split('.')
+  const [head, ...rest] = keys
+  if (!head) return source
+  if (rest.length === 0) {
+    const { [head]: _removed, ...remaining } = source
+    void _removed
+    return remaining
+  }
+  const current = source[head]
+  if (!current || typeof current !== 'object') return source
+  const nextChild = unsetPathValue(current as Record<string, unknown>, rest.join('.'))
+  const next = { ...source }
+  if (Object.keys(nextChild).length === 0) {
+    delete next[head]
+  } else {
+    next[head] = nextChild
+  }
+  return next
+}
+
+function deepMerge<T extends Record<string, unknown>>(
+  base: T,
+  patch: Record<string, unknown>,
+): T {
+  const out: Record<string, unknown> = { ...base }
+  for (const [key, value] of Object.entries(patch)) {
+    const current = out[key]
+    if (
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      current &&
+      typeof current === 'object' &&
+      !Array.isArray(current)
+    ) {
+      out[key] = deepMerge(
+        current as Record<string, unknown>,
+        value as Record<string, unknown>,
+      )
+    } else {
+      out[key] = value
+    }
+  }
+  return out as T
+}
+
+function materializeComponentChildren(
+  api: SceneAPI,
+  componentId: NodeId,
+  instanceId: NodeId,
+): void {
+  const existing = api.getChildren(instanceId).map((child) => child.id)
+  for (const childId of existing) deleteNodeWithTracks(api, childId)
+  for (const child of api.getChildren(componentId)) {
+    cloneFromComponentSource(api, child.id, instanceId)
+  }
+}
+
+function deleteNodeWithTracks(api: SceneAPI, nodeId: NodeId): void {
+  for (const child of api.getChildren(nodeId)) {
+    deleteNodeWithTracks(api, child.id)
+  }
+  for (const track of api.getTracksForNode(nodeId)) {
+    api.deleteTrack(track.id)
+  }
+  api.deleteNode(nodeId)
+}
+
+function cloneFromComponentSource(
+  api: SceneAPI,
+  sourceId: NodeId,
+  parentId: NodeId,
+): NodeId | null {
+  const source = api.getNode(sourceId)
+  if (!source || source.kind === 'camera') return null
+  const cloneId = api.createNode(source.kind, parentId, {
+    ...stripNodeLinks(source),
+    name: source.name,
+    componentSourceId: source.id,
+  } as Partial<SceneNode>)
+  for (const track of api.getTracksForNode(sourceId)) {
+    cloneTrack(api, track, cloneId)
+  }
+  for (const child of api.getChildren(sourceId)) {
+    cloneFromComponentSource(api, child.id, cloneId)
+  }
+  return cloneId
+}
+
+function cloneTrack(api: SceneAPI, track: Track, nodeId: NodeId): void {
+  api.setTrack({
+    id: genActionId(),
+    nodeId,
+    propertyId: track.propertyId,
+    defaultEasing: track.defaultEasing,
+    keyframes: track.keyframes.map((kf) => ({ ...kf, id: genActionId() })),
+  })
+}
+
+export function measureComponentChildBounds(
+  api: SceneAPI,
+  componentId: NodeId,
+): { minX: number; minY: number; maxX: number; maxY: number } | null {
+  const children = api.getChildren(componentId)
+  if (children.length === 0) return null
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = 0
+  let maxY = 0
+  const visit = (node: SceneNode, parentX: number, parentY: number) => {
+    const x = parentX + node.transform.x
+    const y = parentY + node.transform.y
+    const size = measureStaticNodeSize(api, node)
+    minX = Math.min(minX, x)
+    minY = Math.min(minY, y)
+    maxX = Math.max(maxX, x + size.width)
+    maxY = Math.max(maxY, y + size.height)
+    for (const child of api.getChildren(node.id)) {
+      visit(child, x, y)
+    }
+  }
+  for (const child of children) visit(child, 0, 0)
+  if (!Number.isFinite(minX) || !Number.isFinite(minY)) return null
+  return { minX, minY, maxX, maxY }
+}
+
+function measureStaticNodeSize(
+  api: SceneAPI,
+  node: SceneNode,
+): { width: number; height: number } {
+  if (node.kind === 'text') {
+    const textWidth = Math.max(1, node.text.length * node.fontSize * 0.58)
+    const textHeight = Math.max(1, node.fontSize * node.lineHeight)
+    return {
+      width: measureSizeAxis(node.size.width, textWidth),
+      height: measureSizeAxis(node.size.height, textHeight),
+    }
+  }
+  if ('size' in node) {
+    const nested =
+      'layout' in node && node.layout.mode === 'none'
+        ? measureComponentChildBounds(api, node.id)
+        : null
+    return {
+      width: measureSizeAxis(
+        node.size.width,
+        nested ? nested.maxX - nested.minX : 100,
+      ),
+      height: measureSizeAxis(
+        node.size.height,
+        nested ? nested.maxY - nested.minY : 100,
+      ),
+    }
+  }
+  return { width: 100, height: 100 }
+}
+
+function measureSizeAxis(value: SizeAxis, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function getSelectionBounds(nodes: SceneNode[], parentId: NodeId): {
+  x: number
+  y: number
+  width: number
+  height: number
+  rects: Record<NodeId, { x: number; y: number; width: number; height: number }>
+} {
+  const solved = getLastSolvedLayout()
+  const parentRect = solved?.[parentId] ?? { x: 0, y: 0, width: 0, height: 0 }
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  const rects: Record<
+    NodeId,
+    { x: number; y: number; width: number; height: number }
+  > = {}
+  for (const node of nodes) {
+    const solvedRect = solved?.[node.id]
+    const width =
+      solvedRect?.width ??
+      ('size' in node && typeof node.size.width === 'number'
+        ? node.size.width
+        : 100)
+    const height =
+      solvedRect?.height ??
+      ('size' in node && typeof node.size.height === 'number'
+        ? node.size.height
+        : 100)
+    const rect = {
+      x: (solvedRect?.x ?? 0) + node.transform.x - parentRect.x,
+      y: (solvedRect?.y ?? 0) + node.transform.y - parentRect.y,
+      width,
+      height,
+    }
+    rects[node.id] = rect
+    minX = Math.min(minX, rect.x)
+    minY = Math.min(minY, rect.y)
+    maxX = Math.max(maxX, rect.x + rect.width)
+    maxY = Math.max(maxY, rect.y + rect.height)
+  }
+  const x = Number.isFinite(minX) ? Math.round(minX) : 0
+  const y = Number.isFinite(minY) ? Math.round(minY) : 0
+  const width = Number.isFinite(maxX) ? Math.max(1, Math.round(maxX - minX)) : 1
+  const height = Number.isFinite(maxY) ? Math.max(1, Math.round(maxY - minY)) : 1
+  return {
+    x,
+    y,
+    width,
+    height,
+    rects,
+  }
+}
+
+function stripNodeLinks<T extends object>(node: T): Partial<T> {
+  const { id: _id, parent: _parent, children: _children, ...rest } =
+    node as unknown as { id: unknown; parent: unknown; children: unknown }
+  void _id
+  void _parent
+  void _children
+  return rest as Partial<T>
+}
+
+function genActionId(): string {
+  return (
+    Math.random().toString(36).slice(2, 10) +
+    Math.random().toString(36).slice(2, 10)
+  )
 }
 
 function wrapInContainer(

--- a/src/ui/contextMenuActions.ts
+++ b/src/ui/contextMenuActions.ts
@@ -4,7 +4,13 @@ import type { NodeId } from '@/scene'
 import type { SceneAPI } from '@/scene/doc'
 import type { ContextMenuItem } from '@/state/ui'
 import { useUI } from '@/state/ui'
-import { ungroupFrame, wrapInAutoLayout, wrapInGrid } from '@/ui/actions'
+import {
+  createComponentFromSelection,
+  instantiateComponent,
+  ungroupFrame,
+  wrapInAutoLayout,
+  wrapInGrid,
+} from '@/ui/actions'
 
 /**
  * Build the right-click context menu for the given selection.
@@ -117,6 +123,30 @@ export function buildNodeContextMenu(
     items.push({ kind: 'separator' })
   }
 
+  items.push({
+    label: 'Create component',
+    shortcut: '⌥⌘K',
+    disabled: allRoots,
+    onClick: () => {
+      const componentId = createComponentFromSelection(api, ids)
+      if (componentId) useUI.getState().setSelection([componentId])
+    },
+  })
+
+  const singleComponent =
+    ids.length === 1 && nodes[0]?.kind === 'component' ? nodes[0] : null
+  if (singleComponent) {
+    items.push({
+      label: 'Create instance',
+      onClick: () => {
+        const instanceId = instantiateComponent(api, singleComponent.id)
+        if (instanceId) useUI.getState().setSelection([instanceId])
+      },
+    })
+  }
+
+  items.push({ kind: 'separator' })
+
   // Rename — opens the multi-select rename dialog. Available for any
   // selection (1+); single-layer rename via the dialog is still useful
   // because the dialog lets users insert ascending numbers and run a
@@ -167,6 +197,7 @@ export function buildNodeContextMenu(
 function duplicateForContextMenu(api: SceneAPI, id: NodeId): NodeId | null {
   const original = api.getNode(id)
   if (!original || !original.parent) return null
+  if (original.kind === 'component') return instantiateComponent(api, original.id)
 
   const cloneSubtree = (srcId: NodeId, parent: NodeId): NodeId => {
     const src = api.getNode(srcId)

--- a/src/ui/hooks/useAnimatedValues.ts
+++ b/src/ui/hooks/useAnimatedValues.ts
@@ -40,6 +40,8 @@ export interface AnimatedValue {
   focusWorldX?: number
   focusWorldY?: number
   focusWorldZ?: number
+  focusRadius?: number
+  focusFalloff?: number
   pointOfInterestX?: number
   pointOfInterestY?: number
   pointOfInterestZ?: number

--- a/src/ui/hooks/useDragToMove.ts
+++ b/src/ui/hooks/useDragToMove.ts
@@ -55,6 +55,7 @@ export function useDragToMove(nodeId: NodeId, isRoot: boolean) {
       if (isRoot) return
       const node = api.getNode(nodeId)
       if (!node || node.locked) return
+      e.stopPropagation()
       // Selecting on pointerdown (not click) matches Figma's feel —
       // the selection frame appears before you've released the mouse.
       //

--- a/src/ui/hooks/useFileMenu.ts
+++ b/src/ui/hooks/useFileMenu.ts
@@ -40,7 +40,18 @@ export function useFileMenu(): void {
 
   useEffect(() => {
     const bridge = window.hypermotion
-    if (!bridge || !bridge.on) return
+    if (!bridge || !bridge.on) {
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 's') {
+          return
+        }
+        event.preventDefault()
+        downloadSceneFile(api.getMeta()?.name || 'Untitled')
+        useUI.getState().setCurrentFile(null, Date.now())
+      }
+      window.addEventListener('keydown', onKeyDown)
+      return () => window.removeEventListener('keydown', onKeyDown)
+    }
 
     // Read currentFilePath from the store at the moment of each event —
     // not via useUI()/useState so we don't tear the closure or remount
@@ -76,6 +87,18 @@ export function useFileMenu(): void {
         // saved timestamp so the TopBar reads "Saved just now" instead
         // of "Unsaved" right after a fresh open.
         setFile(result.path, Date.now())
+      })()
+    })
+
+    const offOpenPath = bridge.on('file:open-path', (path) => {
+      void (async () => {
+        if (typeof path !== 'string') return
+        const bytes = (await bridge.invoke('file:read', path)) as
+          | Uint8Array
+          | null
+        if (!bytes) return
+        loadSceneIntoDoc(sceneDoc, new Uint8Array(bytes))
+        setFile(path, Date.now())
       })()
     })
 
@@ -118,8 +141,31 @@ export function useFileMenu(): void {
     return () => {
       offNew?.()
       offOpen?.()
+      offOpenPath?.()
       offSave?.()
       offSaveAs?.()
     }
   }, [api])
+}
+
+function downloadSceneFile(name: string): void {
+  const bytes = sceneToBytes(sceneDoc)
+  const copy = new Uint8Array(bytes)
+  const arrayBuffer = copy.buffer.slice(
+    copy.byteOffset,
+    copy.byteOffset + copy.byteLength,
+  )
+  const blob = new Blob([arrayBuffer], { type: 'application/x-hypermotion' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${safeFilename(name)}.hype`
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+function safeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9-_ ]/g, '').trim() || 'Untitled'
 }

--- a/src/ui/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/hooks/useKeyboardShortcuts.ts
@@ -11,7 +11,11 @@ import type {
   PropertyId,
 } from '@/scene'
 import { useUI, type Tool } from '@/state/ui'
-import { wrapInAutoLayout } from '@/ui/actions'
+import {
+  createComponentFromSelection,
+  instantiateComponent,
+  wrapInAutoLayout,
+} from '@/ui/actions'
 import { addKeyframe, removeTrack } from '@/anim'
 
 /**
@@ -173,6 +177,17 @@ export function useKeyboardShortcuts() {
         return
       }
 
+      // Create component — Cmd/Ctrl + Alt/Opt + K.
+      // Converts the selection into a master component and keeps it
+      // selected so the next Cmd+C / Cmd+V can instantiate it.
+      if (meta && e.altKey && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        const sel = useUI.getState().selection
+        const componentId = createComponentFromSelection(api, sel)
+        if (componentId) setSelection([componentId])
+        return
+      }
+
       // Copy — serialize each selected subtree into our module-scoped
       // clipboard. Skip when no selection so Cmd+C inside a focused
       // input still works for ordinary text copy (events from text
@@ -224,9 +239,15 @@ export function useKeyboardShortcuts() {
       //     you have a frame selected and hit Cmd+V).
       //   - Otherwise the scene root (paste at the top level).
       if (meta && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'v') {
-        e.preventDefault()
-        if (pasteKeyframesAtPlayhead(api)) return
+        if (pasteKeyframesAtPlayhead(api)) {
+          e.preventDefault()
+          return
+        }
+        // If Hyper Motion's in-app clipboard is empty, do not consume
+        // Cmd+V. Let the browser/Electron paste event fire so external
+        // payloads from the Figma plugin can be read by useFigmaPaste().
         if (clipboard.length === 0) return
+        e.preventDefault()
         const sel = useUI.getState().selection
         const root = api.getRoot()
         let targetParent: NodeId | null = root || null
@@ -237,7 +258,7 @@ export function useKeyboardShortcuts() {
           }
         }
         const newIds = clipboard
-          .map((item) => pasteSubtree(api, item, targetParent))
+          .map((item) => pasteClipboardItem(api, item, targetParent))
           .filter((id): id is NodeId => id !== null)
         if (newIds.length > 0) setSelection(newIds)
         return
@@ -508,7 +529,10 @@ export function useKeyboardShortcuts() {
         }
         for (const id of ui.selection) {
           const n = api.getNode(id)
-          if (n && n.parent) api.deleteNode(id) // never delete root via keyboard
+          if (!n) continue
+          if (id === api.getRoot()) continue // never delete the scene root
+          if (n.kind === 'camera') continue
+          if (n.parent || n.workspaceOnly) api.deleteNode(id)
         }
         clearSelection()
         return
@@ -579,6 +603,7 @@ function duplicateNode(
   const original = api.getNode(id)
   if (!original || !original.parent) return null
   if (original.kind === 'camera') return null
+  if (original.kind === 'component') return instantiateComponent(api, original.id)
 
   const cloneSubtree = (src: SceneNode, parent: NodeId): NodeId => {
     const newId = api.createNode(src.kind, parent, {
@@ -671,6 +696,8 @@ interface ClipboardNode {
     defaultEasing: unknown
     keyframes: unknown[]
   }>
+  /** When set, paste creates a linked instance instead of a detached clone. */
+  componentId?: NodeId
 }
 
 let clipboard: ClipboardNode[] = []
@@ -710,7 +737,19 @@ function serializeSubtree(
     kind: node.kind,
     children,
     tracks,
+    ...(node.kind === 'component' ? { componentId: node.id } : {}),
   }
+}
+
+function pasteClipboardItem(
+  api: ReturnType<typeof useSceneAPI>,
+  item: ClipboardNode,
+  parentId: NodeId | null,
+): NodeId | null {
+  if (item.componentId) {
+    return instantiateComponent(api, item.componentId, parentId)
+  }
+  return pasteSubtree(api, item, parentId)
 }
 
 /**

--- a/src/ui/importImage.ts
+++ b/src/ui/importImage.ts
@@ -33,8 +33,8 @@ import type { NodeId, Transform } from '@/scene'
 export async function importImageFile(
   file: File,
   api: SceneAPI,
-  parent: NodeId,
-  opts?: { dropPos?: { x: number; y: number } },
+  parent: NodeId | null,
+  opts?: { dropPos?: { x: number; y: number }; workspaceOnly?: boolean },
 ): Promise<NodeId> {
   const dataUrl = await readFileAsDataUrl(file)
   const { width: natW, height: natH } = await decodeNaturalSize(dataUrl)
@@ -74,6 +74,7 @@ export async function importImageFile(
     transform,
     src: dataUrl,
     fit: 'cover',
+    workspaceOnly: opts?.workspaceOnly ?? false,
   } as Parameters<SceneAPI['createNode']>[2])
 
   return id
@@ -88,8 +89,8 @@ export async function importImageFile(
 export async function importImageFiles(
   files: FileList | File[],
   api: SceneAPI,
-  parent: NodeId,
-  opts?: { dropPos?: { x: number; y: number } },
+  parent: NodeId | null,
+  opts?: { dropPos?: { x: number; y: number }; workspaceOnly?: boolean },
 ): Promise<NodeId[]> {
   const ids: NodeId[] = []
   const list = Array.from(files).filter(isImageFile)

--- a/src/ui/importMedia.ts
+++ b/src/ui/importMedia.ts
@@ -25,8 +25,8 @@ const DATA_URL_SOFT_CEILING_MB = 25
 export async function importVideoFile(
   file: File,
   api: SceneAPI,
-  parent: NodeId,
-  opts?: { dropPos?: { x: number; y: number } },
+  parent: NodeId | null,
+  opts?: { dropPos?: { x: number; y: number }; workspaceOnly?: boolean },
 ): Promise<NodeId> {
   const dataUrl = await readFileAsDataUrl(file)
   const { width: natW, height: natH, duration } = await decodeVideoMeta(dataUrl)
@@ -72,6 +72,7 @@ export async function importVideoFile(
     startTime: 0,
     trimStart: 0,
     loop: false,
+    workspaceOnly: opts?.workspaceOnly ?? false,
   } as Parameters<SceneAPI['createNode']>[2])
 
   return id
@@ -80,8 +81,8 @@ export async function importVideoFile(
 export async function importAudioFile(
   file: File,
   api: SceneAPI,
-  parent: NodeId,
-  opts?: { dropPos?: { x: number; y: number } },
+  parent: NodeId | null,
+  opts?: { dropPos?: { x: number; y: number }; workspaceOnly?: boolean },
 ): Promise<NodeId> {
   const dataUrl = await readFileAsDataUrl(file)
   const { duration } = await decodeAudioMeta(dataUrl)
@@ -119,6 +120,7 @@ export async function importAudioFile(
     startTime: 0,
     trimStart: 0,
     loop: false,
+    workspaceOnly: opts?.workspaceOnly ?? false,
   } as Parameters<SceneAPI['createNode']>[2])
 
   return id
@@ -132,8 +134,8 @@ export async function importAudioFile(
 export async function importMediaFiles(
   files: FileList | File[],
   api: SceneAPI,
-  parent: NodeId,
-  opts?: { dropPos?: { x: number; y: number } },
+  parent: NodeId | null,
+  opts?: { dropPos?: { x: number; y: number }; workspaceOnly?: boolean },
 ): Promise<NodeId[]> {
   const ids: NodeId[] = []
   for (const file of Array.from(files)) {


### PR DESCRIPTION
## Summary
- Add 3D-aware autolayout/group behavior, pivot controls, and component editing support
- Rework camera focus/blur preview and export handling, including edge-safe blur compositing
- Add in-app preview mode with Cmd+P, looping work-area controls, and recent projects menu support

## Verification
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD