### PR TITLE
Add audio timeline and export support

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -312,9 +312,9 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
       y.set('trimStart', node.trimStart ?? 0)
       y.set('trimEnd', node.trimEnd ?? node.duration ?? 0)
       y.set('loop', node.loop ?? false)
+      y.set('muted', node.muted ?? node.kind === 'video')
       if (node.kind === 'video') {
         y.set('fit', node.fit ?? 'cover')
-        y.set('muted', node.muted ?? true)
       }
     }
     if (node.kind === 'text') {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type PointerEvent as ReactPointerEvent,
@@ -20,6 +21,7 @@ import { ErrorBoundary } from '@/ui/ErrorBoundary'
 import { UpdateNotice } from '@/ui/UpdateNotice'
 import { useUI } from '@/state/ui'
 import { SceneProvider, useSceneAPI, useSceneVersion } from '@/scene'
+import type { SceneNode } from '@/scene'
 import { useKeyboardShortcuts } from '@/ui/hooks/useKeyboardShortcuts'
 import { useAnim } from '@/ui/hooks/useAnim'
 import { useFigmaPaste } from '@/ui/hooks/useFigmaPaste'
@@ -235,12 +237,82 @@ function Shell() {
         {showInspector && <Inspector />}
       </div>
       {showTimeline && !componentEditId && <Timeline />}
+      <AudioPlaybackHost />
       <ContextMenu />
       <RenameDialog />
       <ExportRecordingIndicator />
       <UpdateNotice />
     </div>
   )
+}
+
+function AudioPlaybackHost() {
+  const api = useSceneAPI()
+  const version = useSceneVersion()
+  const clips = useMemo(() => {
+    const out: Array<Extract<SceneNode, { kind: 'audio' }>> = []
+    for (const id of api.getAllNodeIds()) {
+      const node = api.getNode(id)
+      if (node?.kind === 'audio') out.push(node)
+    }
+    return out
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api, version])
+
+  return (
+    <div hidden aria-hidden="true">
+      {clips.map((clip) => (
+        <AudioPlaybackElement key={clip.id} node={clip} />
+      ))}
+    </div>
+  )
+}
+
+function AudioPlaybackElement({
+  node,
+}: {
+  node: Extract<SceneNode, { kind: 'audio' }>
+}) {
+  const ref = useRef<HTMLAudioElement | null>(null)
+  const playing = useUI((s) => s.playing)
+  const playhead = useUI((s) => s.playhead)
+  const clipLen = Math.max(0, (node.trimEnd || node.duration) - node.trimStart)
+  const local = clampAudioLocal(playhead - node.startTime + node.trimStart, node)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    el.muted = node.muted
+    el.volume = Math.max(0, Math.min(1, node.volume))
+  }, [node.muted, node.volume])
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const inRange = playhead >= node.startTime && playhead < node.startTime + clipLen
+    if (playing && inRange && !node.muted) {
+      if (el.paused) {
+        if (Math.abs(el.currentTime - local) > 0.2) el.currentTime = local
+        el.play().catch(() => {})
+      }
+    } else {
+      if (!el.paused) el.pause()
+      if (Math.abs(el.currentTime - local) > 0.05) el.currentTime = local
+    }
+  }, [playing, playhead, local, clipLen, node.startTime, node.muted])
+
+  if (!node.src) return null
+  return <audio ref={ref} src={node.src} preload="auto" />
+}
+
+function clampAudioLocal(
+  t: number,
+  node: Extract<SceneNode, { kind: 'audio' }>,
+): number {
+  const trimEnd = node.trimEnd || node.duration || 0
+  if (t < node.trimStart) return node.trimStart
+  if (t > trimEnd) return trimEnd
+  return t
 }
 
 function PreviewShell() {
@@ -253,19 +325,21 @@ function PreviewShell() {
   const playing = useUI((s) => s.playing)
   const playhead = useUI((s) => s.playhead)
   const setIsolatedRange = useUI((s) => s.setIsolatedRange)
+  const storedWorkArea = useUI((s) => s.workAreaRange)
+  const setStoredWorkArea = useUI((s) => s.setWorkAreaRange)
   const trackRef = useRef<HTMLDivElement>(null)
   const dragRef = useRef<PreviewDragState | null>(null)
-  const [workArea, setWorkArea] = useState<PreviewWorkArea>(() => ({
-    start: 0,
-    end: 1,
-  }))
+  const [dragTooltip, setDragTooltip] = useState<{
+    mode: 'start' | 'end'
+    time: number
+  } | null>(null)
   useSceneVersion()
   const meta = api.getMeta()
   const duration = Math.max(0.1, meta.duration)
   const frameStep = 1 / Math.max(1, meta.frameRate)
   const minWorkArea = Math.max(frameStep, 0.05)
   const normalizedWorkArea = normalizePreviewWorkArea(
-    workArea,
+    storedWorkArea ?? { start: 0, end: duration },
     duration,
     minWorkArea,
   )
@@ -356,8 +430,14 @@ function PreviewShell() {
   }
 
   useEffect(() => {
-    setWorkArea((range) => normalizePreviewWorkArea(range, duration, minWorkArea))
-  }, [duration, minWorkArea])
+    setStoredWorkArea(normalizePreviewWorkArea(normalizedWorkArea, duration, minWorkArea))
+  }, [
+    duration,
+    minWorkArea,
+    normalizedWorkArea.start,
+    normalizedWorkArea.end,
+    setStoredWorkArea,
+  ])
 
   useEffect(() => {
     getAnimEngine().setLoopRange(normalizedWorkArea)
@@ -385,6 +465,7 @@ function PreviewShell() {
     const t = timeFromPreviewPointer(clientX)
     if (drag.mode === 'scrub') {
       setPlayhead(t)
+      setDragTooltip(null)
       return
     }
     if (drag.mode === 'start') {
@@ -393,8 +474,9 @@ function PreviewShell() {
         0,
         normalizedWorkArea.end - minWorkArea,
       )
-      setWorkArea({ start: nextStart, end: normalizedWorkArea.end })
+      setStoredWorkArea({ start: nextStart, end: normalizedWorkArea.end })
       setPlayhead(nextStart)
+      setDragTooltip({ mode: 'start', time: nextStart })
       return
     }
     if (drag.mode === 'end') {
@@ -403,15 +485,17 @@ function PreviewShell() {
         normalizedWorkArea.start + minWorkArea,
         duration,
       )
-      setWorkArea({ start: normalizedWorkArea.start, end: nextEnd })
+      setStoredWorkArea({ start: normalizedWorkArea.start, end: nextEnd })
       setPlayhead(Math.min(playhead, nextEnd))
+      setDragTooltip({ mode: 'end', time: nextEnd })
       return
     }
     const delta = t - drag.anchorTime
     const span = drag.startArea.end - drag.startArea.start
     const nextStart = clamp(drag.startArea.start + delta, 0, duration - span)
-    setWorkArea({ start: nextStart, end: nextStart + span })
+    setStoredWorkArea({ start: nextStart, end: nextStart + span })
     setPlayhead(clamp(drag.startPlayhead + delta, nextStart, nextStart + span))
+    setDragTooltip(null)
   }
 
   const beginPreviewDrag = (
@@ -429,6 +513,14 @@ function PreviewShell() {
       startPlayhead: playhead,
     }
     if (mode === 'scrub') setPlayhead(anchorTime)
+    if (mode === 'start' || mode === 'end') {
+      setDragTooltip({
+        mode,
+        time: mode === 'start' ? normalizedWorkArea.start : normalizedWorkArea.end,
+      })
+    } else {
+      setDragTooltip(null)
+    }
     trackRef.current?.setPointerCapture(event.pointerId)
   }
 
@@ -444,6 +536,7 @@ function PreviewShell() {
     if (trackRef.current?.hasPointerCapture(event.pointerId)) {
       trackRef.current.releasePointerCapture(event.pointerId)
     }
+    setDragTooltip(null)
   }
 
   const restartPreview = () => {
@@ -482,6 +575,7 @@ function PreviewShell() {
       <div className="flex min-h-0 flex-1">
         <Canvas />
       </div>
+      <AudioPlaybackHost />
       <div className="flex h-16 shrink-0 items-center gap-3 border-t border-white/10 bg-black px-4 text-white">
         <button
           type="button"
@@ -539,6 +633,23 @@ function PreviewShell() {
               onPointerDown={(event) => beginPreviewDrag(event, 'end')}
             />
           </div>
+          {dragTooltip ? (
+            <div
+              className="pointer-events-none absolute -top-9 z-20 -translate-x-1/2 rounded-full border border-white/30 bg-white px-2.5 py-1 font-mono text-[11px] tabular-nums text-black shadow-lg"
+              style={{
+                left: `${
+                  ((dragTooltip.mode === 'start'
+                    ? normalizedWorkArea.start
+                    : normalizedWorkArea.end) /
+                    duration) *
+                  100
+                }%`,
+              }}
+            >
+              {formatPreviewTimePrecise(dragTooltip.time)}
+              <span className="absolute left-1/2 top-full h-2 w-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-b border-r border-white/30 bg-white" />
+            </div>
+          ) : null}
         </div>
         <span className="w-14 font-mono text-[11px] tabular-nums text-white/45">
           {formatPreviewTime(duration)}
@@ -583,6 +694,16 @@ function formatPreviewTime(seconds: number): string {
   const minutes = Math.floor(whole / 60)
   const secs = whole % 60
   return `${minutes}:${String(secs).padStart(2, '0')}.${tenths}`
+}
+
+function formatPreviewTimePrecise(seconds: number): string {
+  const safe = Math.max(0, seconds)
+  const minutes = Math.floor(safe / 60)
+  const secs = Math.floor(safe % 60)
+  const hundredths = Math.floor((safe - Math.floor(safe)) * 100)
+  return `${minutes.toString().padStart(2, '0')}:${secs
+    .toString()
+    .padStart(2, '0')}.${hundredths.toString().padStart(2, '0')}`
 }
 
 function PreviewStartIcon() {

--- a/src/anim/engine.ts
+++ b/src/anim/engine.ts
@@ -112,6 +112,9 @@ export interface AnimEngine {
    * user exits isolation.
    */
   setLoopRange(range: { start: number; end: number } | null): void
+  setPlaybackRange(
+    range: { start: number; end: number; mode?: 'loop' | 'stop' } | null,
+  ): void
   /** Subscribe via the `useSyncExternalStore` convention. */
   subscribe: (cb: () => void) => () => void
   getSnapshot: () => Record<NodeId, AnimatedValue>
@@ -135,7 +138,7 @@ function createAnimEngine(): AnimEngine {
   // Restrict play looping to a sub-range of the comp. Null = full
   // duration (the default). Set by useAnim to mirror UI-side
   // isolation. tick() wraps modulo this range when set.
-  let loopRange: { start: number; end: number } | null = null
+  let playbackRange: { start: number; end: number; mode: 'loop' | 'stop' } | null = null
   // Snapshot is a fresh object each update (React sees identity change).
   let snapshot: Record<NodeId, AnimatedValue> = {}
   const listeners = new Set<() => void>()
@@ -154,16 +157,22 @@ function createAnimEngine(): AnimEngine {
     lastTick = now
     const meta = api.getMeta()
     const next = playhead + dt
-    if (loopRange) {
-      // Loop within [start, end]. Wrap modulo the span; if the
-      // playhead drifted out of the range from a prior seek, clamp
-      // back into it on the first tick.
-      const span = Math.max(0.0001, loopRange.end - loopRange.start)
+    if (playbackRange) {
+      // Restrict playback within [start, end]. In loop mode, wrap
+      // modulo the span. In stop mode, park exactly at end and pause.
+      const span = Math.max(0.0001, playbackRange.end - playbackRange.start)
       let p = next
-      if (p < loopRange.start) p = loopRange.start
-      else if (p > loopRange.end) {
-        const over = (p - loopRange.start) % span
-        p = loopRange.start + over
+      if (p < playbackRange.start) p = playbackRange.start
+      else if (p > playbackRange.end) {
+        if (playbackRange.mode === 'stop') {
+          p = playbackRange.end
+          playing = false
+          if (rafHandle) cancelAnimationFrame(rafHandle)
+          rafHandle = 0
+        } else {
+          const over = (p - playbackRange.start) % span
+          p = playbackRange.start + over
+        }
       }
       playhead = p
     } else {
@@ -213,13 +222,13 @@ function createAnimEngine(): AnimEngine {
     },
     play() {
       if (playing || !api) return
-      // If the playhead is sitting outside the active loop range
+      // If the playhead is sitting outside the active playback range
       // when the user hits Play, snap it to the start of the range
       // so playback begins at the right place rather than near the
       // boundary the user already left.
-      if (loopRange) {
-        if (playhead < loopRange.start || playhead >= loopRange.end) {
-          playhead = loopRange.start
+      if (playbackRange) {
+        if (playhead < playbackRange.start || playhead >= playbackRange.end) {
+          playhead = playbackRange.start
         }
       }
       playing = true
@@ -238,7 +247,12 @@ function createAnimEngine(): AnimEngine {
       recompute()
     },
     setLoopRange(range) {
-      loopRange = range
+      playbackRange = range ? { ...range, mode: 'loop' } : null
+    },
+    setPlaybackRange(range) {
+      playbackRange = range
+        ? { start: range.start, end: range.end, mode: range.mode ?? 'loop' }
+        : null
     },
     getPlayhead: () => playhead,
     subscribe: (cb) => {

--- a/src/export/audioMix.ts
+++ b/src/export/audioMix.ts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SceneAPI } from '@/scene/doc'
+import type { SceneNode } from '@/scene'
+
+interface FrameSegment {
+  firstFrame: number
+  lastFrame: number
+}
+
+export interface PcmAudioTrack {
+  sampleRate: number
+  numberOfChannels: number
+  samples: Float32Array[]
+}
+
+interface MediaAudioNode {
+  id: string
+  src: string
+  duration: number
+  volume: number
+  muted: boolean
+  startTime: number
+  trimStart: number
+  trimEnd: number
+  loop: boolean
+}
+
+export async function mixSceneAudioTrack(opts: {
+  api: SceneAPI
+  segments: FrameSegment[]
+  fps: number
+  sampleRate?: number
+  numberOfChannels?: number
+}): Promise<PcmAudioTrack | null> {
+  if (typeof window === 'undefined' || typeof AudioContext === 'undefined') {
+    return null
+  }
+
+  const mediaNodes = collectAudibleMediaNodes(opts.api)
+  if (mediaNodes.length === 0) return null
+
+  const sampleRate = opts.sampleRate ?? 48_000
+  const numberOfChannels = opts.numberOfChannels ?? 2
+  const totalFrames = opts.segments.reduce(
+    (acc, seg) => acc + (seg.lastFrame - seg.firstFrame + 1),
+    0,
+  )
+  const totalSamples = Math.max(1, Math.ceil((totalFrames / opts.fps) * sampleRate))
+  const output = Array.from(
+    { length: numberOfChannels },
+    () => new Float32Array(totalSamples),
+  )
+
+  const ctx = new AudioContext({ sampleRate })
+  try {
+    for (const node of mediaNodes) {
+      const buffer = await decodeMediaAudio(ctx, node.src)
+      if (!buffer) continue
+      mixNodeIntoOutput({
+        node,
+        buffer,
+        output,
+        segments: opts.segments,
+        fps: opts.fps,
+        sampleRate,
+      })
+    }
+  } finally {
+    void ctx.close()
+  }
+
+  if (!hasSignal(output)) return null
+  return { sampleRate, numberOfChannels, samples: output }
+}
+
+function collectAudibleMediaNodes(api: SceneAPI): MediaAudioNode[] {
+  const nodes: MediaAudioNode[] = []
+  for (const id of api.getAllNodeIds()) {
+    const node = api.getNode(id)
+    if (!node || (node.kind !== 'audio' && node.kind !== 'video')) continue
+    const media = node as Extract<SceneNode, { kind: 'audio' | 'video' }>
+    const muted = media.kind === 'video' ? media.muted : media.muted
+    if (!media.src || muted || (media.volume ?? 1) <= 0) continue
+    nodes.push({
+      id: media.id,
+      src: media.src,
+      duration: media.duration || 0,
+      volume: media.volume ?? 1,
+      muted,
+      startTime: media.startTime ?? 0,
+      trimStart: media.trimStart ?? 0,
+      trimEnd: media.trimEnd || media.duration || 0,
+      loop: media.loop ?? false,
+    })
+  }
+  return nodes
+}
+
+async function decodeMediaAudio(
+  ctx: AudioContext,
+  src: string,
+): Promise<AudioBuffer | null> {
+  try {
+    const response = await fetch(src)
+    const bytes = await response.arrayBuffer()
+    return await ctx.decodeAudioData(bytes.slice(0))
+  } catch {
+    return null
+  }
+}
+
+function mixNodeIntoOutput(opts: {
+  node: MediaAudioNode
+  buffer: AudioBuffer
+  output: Float32Array[]
+  segments: FrameSegment[]
+  fps: number
+  sampleRate: number
+}) {
+  const { node, buffer, output, segments, fps, sampleRate } = opts
+  const clipStart = Math.max(0, Math.min(buffer.duration, node.trimStart))
+  const clipEnd = Math.max(clipStart, Math.min(buffer.duration, node.trimEnd || node.duration || buffer.duration))
+  const clipLen = clipEnd - clipStart
+  if (clipLen <= 0) return
+
+  let outFrameOffset = 0
+  for (const seg of segments) {
+    const segFrames = seg.lastFrame - seg.firstFrame + 1
+    const segStart = seg.firstFrame / fps
+    for (let frame = 0; frame < segFrames; frame++) {
+      const sceneT = segStart + frame / fps
+      const local = sceneTimeToMediaLocal(sceneT, node, clipStart, clipLen)
+      if (local === null) continue
+      const outSampleStart = Math.round(((outFrameOffset + frame) / fps) * sampleRate)
+      const outSampleEnd = Math.round(((outFrameOffset + frame + 1) / fps) * sampleRate)
+      mixSampleSpan({
+        buffer,
+        output,
+        volume: node.volume,
+        mediaStartSec: local,
+        outSampleStart,
+        outSampleEnd,
+        sampleRate,
+      })
+    }
+    outFrameOffset += segFrames
+  }
+}
+
+function sceneTimeToMediaLocal(
+  sceneT: number,
+  node: MediaAudioNode,
+  clipStart: number,
+  clipLen: number,
+): number | null {
+  const rel = sceneT - node.startTime
+  if (rel < 0) return null
+  if (node.loop) return clipStart + (rel % clipLen)
+  if (rel >= clipLen) return null
+  return clipStart + rel
+}
+
+function mixSampleSpan(opts: {
+  buffer: AudioBuffer
+  output: Float32Array[]
+  volume: number
+  mediaStartSec: number
+  outSampleStart: number
+  outSampleEnd: number
+  sampleRate: number
+}) {
+  const { buffer, output, volume, mediaStartSec, outSampleStart, outSampleEnd, sampleRate } = opts
+  const sourceRate = buffer.sampleRate
+  const sourceChannels = Array.from({ length: buffer.numberOfChannels }, (_, i) =>
+    buffer.getChannelData(i),
+  )
+  for (let out = outSampleStart; out < outSampleEnd && out < output[0].length; out++) {
+    const elapsed = (out - outSampleStart) / sampleRate
+    const sourceIndex = Math.floor((mediaStartSec + elapsed) * sourceRate)
+    if (sourceIndex < 0 || sourceIndex >= buffer.length) break
+    for (let ch = 0; ch < output.length; ch++) {
+      const source = sourceChannels[Math.min(ch, sourceChannels.length - 1)]
+      output[ch][out] = clampAudio(output[ch][out] + source[sourceIndex] * volume)
+    }
+  }
+}
+
+function hasSignal(samples: Float32Array[]): boolean {
+  for (const channel of samples) {
+    for (let i = 0; i < channel.length; i += 128) {
+      if (Math.abs(channel[i]) > 0.00001) return true
+    }
+  }
+  return false
+}
+
+function clampAudio(n: number): number {
+  if (n < -1) return -1
+  if (n > 1) return 1
+  return n
+}

--- a/src/export/encodeMp4.ts
+++ b/src/export/encodeMp4.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Muxer, ArrayBufferTarget } from 'mp4-muxer'
+import type { PcmAudioTrack } from './audioMix'
 
 /**
  * MP4 encoder built on WebCodecs + mp4-muxer.
@@ -29,6 +30,7 @@ export interface Mp4EncoderOptions {
   fps: number
   /** Bits per second — defaults to ~0.1 bpp × pixels × fps. */
   bitrate?: number
+  audio?: PcmAudioTrack | null
 }
 
 export interface Mp4Encoder {
@@ -100,6 +102,7 @@ export async function createMp4Encoder(opts: Mp4EncoderOptions): Promise<Mp4Enco
   }
 
   const target = new ArrayBufferTarget()
+  const audio = opts.audio && opts.audio.samples[0]?.length ? opts.audio : null
   const muxer = new Muxer({
     target,
     video: {
@@ -108,6 +111,15 @@ export async function createMp4Encoder(opts: Mp4EncoderOptions): Promise<Mp4Enco
       height,
       frameRate: fps,
     },
+    ...(audio
+      ? {
+          audio: {
+            codec: 'aac' as const,
+            sampleRate: audio.sampleRate,
+            numberOfChannels: audio.numberOfChannels,
+          },
+        }
+      : {}),
     fastStart: 'in-memory',
   })
 
@@ -158,11 +170,87 @@ export async function createMp4Encoder(opts: Mp4EncoderOptions): Promise<Mp4Enco
       if (encoderError) throw encoderError
       await encoder.flush()
       encoder.close()
+      if (audio) await encodeAudioTrack(audio, muxer)
       muxer.finalize()
       if (encoderError) throw encoderError
       return new Blob([target.buffer], { type: 'video/mp4' })
     },
   }
+}
+
+async function encodeAudioTrack(
+  track: PcmAudioTrack,
+  muxer: Muxer<ArrayBufferTarget>,
+): Promise<void> {
+  const AudioEncoderCtor = (window as unknown as {
+    AudioEncoder?: typeof AudioEncoder
+    AudioData?: typeof AudioData
+  }).AudioEncoder
+  const AudioDataCtor = (window as unknown as {
+    AudioEncoder?: typeof AudioEncoder
+    AudioData?: typeof AudioData
+  }).AudioData
+  if (!AudioEncoderCtor || !AudioDataCtor) {
+    throw new Error('MP4 audio export needs WebCodecs AudioEncoder support.')
+  }
+
+  const config: AudioEncoderConfig = {
+    codec: 'mp4a.40.2',
+    sampleRate: track.sampleRate,
+    numberOfChannels: track.numberOfChannels,
+    bitrate: 160_000,
+  }
+  const support = await AudioEncoderCtor.isConfigSupported(config)
+  if (!support.supported) {
+    throw new Error('This browser cannot encode AAC audio for MP4 export.')
+  }
+
+  let encoderError: Error | null = null
+  const encoder = new AudioEncoderCtor({
+    output: (chunk, meta) => muxer.addAudioChunk(chunk, meta),
+    error: (e) => {
+      encoderError = e instanceof Error ? e : new Error(String(e))
+    },
+  })
+  encoder.configure(config)
+
+  const frameSize = 1024
+  const total = track.samples[0]?.length ?? 0
+  for (let offset = 0; offset < total; offset += frameSize) {
+    if (encoderError) throw encoderError
+    const frames = Math.min(frameSize, total - offset)
+    const interleaved = new Float32Array(frames * track.numberOfChannels)
+    for (let i = 0; i < frames; i++) {
+      for (let ch = 0; ch < track.numberOfChannels; ch++) {
+        interleaved[i * track.numberOfChannels + ch] =
+          track.samples[ch]?.[offset + i] ?? 0
+      }
+    }
+    const data = new AudioDataCtor({
+      format: 'f32',
+      sampleRate: track.sampleRate,
+      numberOfFrames: frames,
+      numberOfChannels: track.numberOfChannels,
+      timestamp: Math.round((offset / track.sampleRate) * 1_000_000),
+      data: interleaved,
+    })
+    encoder.encode(data)
+    data.close()
+    if (encoder.encodeQueueSize > 8) {
+      await new Promise<void>((resolve) => {
+        const id = window.setInterval(() => {
+          if (encoder.encodeQueueSize <= 4) {
+            window.clearInterval(id)
+            resolve()
+          }
+        }, 8)
+      })
+    }
+  }
+  if (encoderError) throw encoderError
+  await encoder.flush()
+  encoder.close()
+  if (encoderError) throw encoderError
 }
 
 /**

--- a/src/export/recordTab.ts
+++ b/src/export/recordTab.ts
@@ -171,7 +171,7 @@ export async function recordTabCapture(
           width: { ideal: width },
           height: { ideal: height },
         },
-        audio: false,
+        audio: true,
         ...({ preferCurrentTab: true } as unknown as Record<string, unknown>),
       })
     } catch {

--- a/src/render/RenderWindowApp.tsx
+++ b/src/render/RenderWindowApp.tsx
@@ -26,6 +26,7 @@ import {
   isElectronCaptureSupported,
 } from '@/export/captureRect'
 import { createMp4Encoder } from '@/export/encodeMp4'
+import { mixSceneAudioTrack } from '@/export/audioMix'
 import { createGifEncoder } from '@/export/encodeGif'
 import {
   EXPORT_FORMATS,
@@ -556,6 +557,14 @@ async function runExportLoop(
     (acc, s) => acc + (s.lastFrame - s.firstFrame + 1),
     0,
   )
+  const audioTrack =
+    job.format === 'mp4'
+      ? await mixSceneAudioTrack({
+          api,
+          segments,
+          fps: job.exportFps,
+        })
+      : null
   const firstFrame = segments[0]?.firstFrame ?? 0
   const lastFrame = segments[segments.length - 1]?.lastFrame ?? 0
   const fileName = buildExportFilename(job.sceneName, format, {
@@ -648,6 +657,7 @@ async function runExportLoop(
                 width: canvasEl.width,
                 height: canvasEl.height,
                 fps: job.exportFps,
+                audio: audioTrack,
               })
               encoder = {
                 addFrame: (c, i) => mp4.addFrame(c, i),

--- a/src/scene/doc.ts
+++ b/src/scene/doc.ts
@@ -180,6 +180,13 @@ export interface NodeBaseMutable {
   src: string
   fit: 'cover' | 'contain' | 'fill' | 'none'
   importWarning: string
+  // media-kind fields — used by audio/video layers.
+  volume: number
+  muted: boolean
+  startTime: number
+  trimStart: number
+  trimEnd: number
+  loop: boolean
   // camera-kind fields — settable via Inspector on CameraNode.
   /** Camera's viewport-wide background fill. Null = no fill. */
   background: Fill | null
@@ -467,10 +474,12 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
             (y.get('trimEnd') as number | undefined) ??
             ((y.get('duration') as number) ?? 0),
           loop: (y.get('loop') as boolean) ?? false,
+          muted:
+            (y.get('muted') as boolean | undefined) ??
+            (kind === 'video' ? true : false),
           ...(kind === 'video'
             ? {
                 fit: (y.get('fit') as 'cover' | 'contain' | 'fill' | 'none') ?? 'cover',
-                muted: (y.get('muted') as boolean) ?? true,
               }
             : {}),
         } as Node
@@ -759,11 +768,11 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
           y.set('trimStart', mp.trimStart ?? 0)
           y.set('trimEnd', mp.trimEnd ?? mp.duration ?? 0)
           y.set('loop', mp.loop ?? false)
+          y.set('muted', mp.muted ?? (kind === 'video'))
           if (kind === 'video') {
             y.set('fit', mp.fit ?? 'cover')
             // Motion tools are primarily visual — default to muted so
             // a dropped MP4 doesn't surprise the user with audio.
-            y.set('muted', mp.muted ?? true)
           }
         }
         if (kind === 'image') {

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -561,6 +561,7 @@ export interface AudioNode extends NodeBase {
   src: string
   duration: number
   volume: number
+  muted: boolean
   startTime: number
   trimStart: number
   trimEnd: number

--- a/src/state/ui.ts
+++ b/src/state/ui.ts
@@ -49,6 +49,11 @@ export type ThemePreference = 'dark' | 'light' | 'system'
  * Persisted so the user's choice survives reload.
  */
 export type RulerLabelsMode = 'both' | 'time' | 'frames'
+export interface WorkAreaRange {
+  start: number
+  end: number
+}
+export type WorkAreaPlaybackMode = 'loop' | 'stop'
 
 const THEME_STORAGE_KEY = 'hyper-motion.theme'
 const RULER_LABELS_KEY = 'hyper-motion.rulerLabels'
@@ -427,6 +432,14 @@ interface UIState {
   setIsolatedRange: (
     range: { start: number; end: number; label?: string } | null,
   ) => void
+  /**
+   * Shared preview/export work area. Preview edits this range directly;
+   * Export can use it as a range mode so both surfaces agree.
+   */
+  workAreaRange: WorkAreaRange | null
+  setWorkAreaRange: (range: WorkAreaRange | null) => void
+  workAreaPlaybackMode: WorkAreaPlaybackMode
+  setWorkAreaPlaybackMode: (mode: WorkAreaPlaybackMode) => void
   // Track groups also live in Yjs — see uiState slab + groupActions.
   /** Clamp + commit a new Layers panel width. */
   setLayersWidth: (px: number) => void
@@ -509,6 +522,10 @@ export const useUI = create<UIState>((set) => ({
     }),
   isolatedRange: null,
   setIsolatedRange: (range) => set({ isolatedRange: range }),
+  workAreaRange: null,
+  setWorkAreaRange: (range) => set({ workAreaRange: range }),
+  workAreaPlaybackMode: 'loop',
+  setWorkAreaPlaybackMode: (mode) => set({ workAreaPlaybackMode: mode }),
   // trackGroups moved into Yjs (uiState slab). Helpers in
   // @/state/groupActions handle the mutations.
   scaleLinked: false,

--- a/src/ui/Canvas.tsx
+++ b/src/ui/Canvas.tsx
@@ -3205,6 +3205,8 @@ function NodeView({
   onClick: (e: React.MouseEvent<HTMLDivElement>) => void
   onContextMenu: (e: React.MouseEvent<HTMLDivElement>) => void
 }) {
+  if (node.kind === 'audio') return null
+
   // Node background — serialize whatever Fill shape the model holds
   // (solid / linear / radial) into a CSS background value. Solid fills
   // return a bare color, gradients return a `linear-gradient(...)` or
@@ -3670,9 +3672,6 @@ function NodeView({
       {node.kind === 'video' ? (
         <MediaVideo node={node} />
       ) : null}
-      {node.kind === 'audio' ? (
-        <AudioChip node={node} />
-      ) : null}
       {node.kind === 'text' ? (
         <TextGlyphs
           node={node}
@@ -4121,8 +4120,9 @@ function AudioChip({
   useEffect(() => {
     const el = ref.current
     if (!el) return
+    el.muted = node.muted
     el.volume = Math.max(0, Math.min(1, node.volume))
-  }, [node.volume])
+  }, [node.muted, node.volume])
 
   useEffect(() => {
     const el = ref.current
@@ -4157,7 +4157,7 @@ function AudioChip({
       }}
     >
       <span aria-hidden style={{ fontSize: 14 }}>
-        ♪
+        {node.muted ? '×' : '♪'}
       </span>
       <span
         style={{
@@ -4174,6 +4174,7 @@ function AudioChip({
           ref={ref}
           src={node.src}
           preload="auto"
+          muted={node.muted}
         />
       ) : null}
     </div>

--- a/src/ui/ExportMenu.tsx
+++ b/src/ui/ExportMenu.tsx
@@ -46,7 +46,7 @@ import { useUI } from '@/state/ui'
  */
 
 type FpsId = 24 | 30 | 60
-type RangeMode = 'full' | 'chapter' | 'custom'
+type RangeMode = 'full' | 'chapter' | 'work' | 'custom'
 
 const PANEL_WIDTH = 480
 const LABEL_COL = 88
@@ -60,6 +60,7 @@ export function ExportMenu({
 }) {
   const api = useSceneAPI()
   const isolatedRange = useUI((s) => s.isolatedRange)
+  const workAreaRange = useUI((s) => s.workAreaRange)
 
   const meta = useMemo(() => api.getMeta(), [api])
   const sections = useMemo(() => api.getSections(), [api])
@@ -88,7 +89,11 @@ export function ExportMenu({
   })
 
   // Range. Default to the active chapter when one's isolated, else full.
-  const initialMode: RangeMode = isolatedRange ? 'chapter' : 'full'
+  const initialMode: RangeMode = isolatedRange
+    ? 'chapter'
+    : workAreaRange
+      ? 'work'
+      : 'full'
   const [rangeMode, setRangeMode] = useState<RangeMode>(initialMode)
   // Multi-chapter selection. A Set keyed by section id; rendered + sent
   // to the orchestrator in timeline order. One element = single chapter
@@ -140,8 +145,11 @@ export function ExportMenu({
         })),
       }
     }
+    if (rangeMode === 'work' && workAreaRange) {
+      return { kind: 'time', startSec: workAreaRange.start, endSec: workAreaRange.end }
+    }
     return { kind: 'time', startSec: customStart, endSec: customEnd }
-  }, [rangeMode, selectedChapters, customStart, customEnd])
+  }, [rangeMode, selectedChapters, workAreaRange, customStart, customEnd])
 
   // Filename tag — empty string when not partial, sanitized chapter
   // ids joined when one or more chapters are selected.
@@ -355,6 +363,14 @@ export function ExportMenu({
                   Chapter
                 </SegmentBtn>
               )}
+              {workAreaRange && (
+                <SegmentBtn
+                  active={rangeMode === 'work'}
+                  onClick={() => setRangeMode('work')}
+                >
+                  Work
+                </SegmentBtn>
+              )}
               <SegmentBtn
                 active={rangeMode === 'custom'}
                 onClick={() => setRangeMode('custom')}
@@ -391,6 +407,14 @@ export function ExportMenu({
                   frames={frameCount}
                 />
               </div>
+            )}
+
+            {rangeMode === 'work' && workAreaRange && (
+              <RangeReadout
+                start={rangeStart}
+                end={rangeEnd}
+                frames={frameCount}
+              />
             )}
 
             {rangeMode === 'custom' && (

--- a/src/ui/Inspector.tsx
+++ b/src/ui/Inspector.tsx
@@ -1852,6 +1852,10 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
         <ImageSection node={node} api={api} />
       )}
 
+      {(node.kind === 'audio' || node.kind === 'video') && (
+        <MediaSection node={node} api={api} />
+      )}
+
       {'layout' in node && (
         <LayoutSection layout={node.layout} onPatch={patchLayout} />
       )}
@@ -4351,6 +4355,84 @@ function ImageSection({ node, api }: { node: ImageNode; api: SceneAPI }) {
           ]}
           onCommit={(f) => api.setNodeProperty(node.id, 'fit', f)}
           width="w-full"
+        />
+      </FieldRow>
+    </Section>
+  )
+}
+
+function MediaSection({
+  node,
+  api,
+}: {
+  node: Extract<Node, { kind: 'audio' | 'video' }>
+  api: SceneAPI
+}) {
+  const duration = Math.max(0, node.duration || 0)
+  const trimStart = Math.max(0, Math.min(duration, node.trimStart || 0))
+  const trimEnd = Math.max(trimStart, Math.min(duration, node.trimEnd || duration))
+
+  return (
+    <Section title={node.kind === 'audio' ? 'Audio' : 'Media'}>
+      <FieldRow label="Mute">
+        <CheckboxField
+          value={node.muted}
+          onCommit={(v) => api.setNodeProperty(node.id, 'muted', v)}
+        />
+      </FieldRow>
+      <FieldRow label="Volume">
+        <NumberField
+          value={Math.round((node.volume ?? 1) * 100)}
+          onCommit={(v) =>
+            api.setNodeProperty(node.id, 'volume', Math.max(0, Math.min(200, v)) / 100)
+          }
+          min={0}
+          max={200}
+          step={5}
+          suffix="%"
+        />
+      </FieldRow>
+      <FieldRow label="Start">
+        <NumberField
+          value={node.startTime ?? 0}
+          onCommit={(v) => api.setNodeProperty(node.id, 'startTime', Math.max(0, v))}
+          min={0}
+          step={0.05}
+          suffix="s"
+        />
+      </FieldRow>
+      <FieldRow label="Trim in">
+        <NumberField
+          value={trimStart}
+          onCommit={(v) =>
+            api.setNodeProperty(node.id, 'trimStart', Math.max(0, Math.min(trimEnd, v)))
+          }
+          min={0}
+          max={duration}
+          step={0.05}
+          suffix="s"
+        />
+      </FieldRow>
+      <FieldRow label="Trim out">
+        <NumberField
+          value={trimEnd}
+          onCommit={(v) =>
+            api.setNodeProperty(
+              node.id,
+              'trimEnd',
+              Math.max(trimStart, Math.min(duration, v)),
+            )
+          }
+          min={0}
+          max={duration}
+          step={0.05}
+          suffix="s"
+        />
+      </FieldRow>
+      <FieldRow label="Loop">
+        <CheckboxField
+          value={node.loop}
+          onCommit={(v) => api.setNodeProperty(node.id, 'loop', v)}
         />
       </FieldRow>
     </Section>

--- a/src/ui/LayersPanel.tsx
+++ b/src/ui/LayersPanel.tsx
@@ -647,7 +647,7 @@ function Row({
   const toggleLayerCollapsed = useUI((s) => s.toggleLayerCollapsed)
   const selected = selection.includes(node.id)
   const isComponentNode = node.kind === 'component' || node.kind === 'instance'
-  const children = api.getChildren(node.id)
+  const children = api.getChildren(node.id).filter((child) => child.kind !== 'audio')
   const hasChildren = children.length > 0
   const [editing, setEditing] = useState(false)
   const [draftName, setDraftName] = useState(node.name)
@@ -1007,6 +1007,8 @@ const GLYPHS: Record<NodeKind, string> = {
   component: '◆',
   instance: '◇',
   camera: '◉',
+  video: '▶',
+  audio: '♪',
 }
 
 /**

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import { useEffect, useMemo, useRef, useState, useCallback, type ReactNode } from 'react'
 import { useUI } from '@/state/ui'
 import { useSceneAPI, useSceneVersion } from '@/scene'
 import { removeKeyframe, moveKeyframe, removeTrack } from '@/anim'
-import type { Section, Track } from '@/scene'
+import type { SceneNode, Section, Track } from '@/scene'
 import type { SceneAPI } from '@/scene/doc'
 import {
   groupKeyframes as groupKeyframesHelper,
@@ -15,6 +15,7 @@ import {
   addTracksToGroup as addTracksToGroupHelper,
   toggleTrackGroupCollapsed as toggleTrackGroupCollapsedHelper,
 } from '@/state/groupActions'
+import { importAudioFile } from '@/ui/importMedia'
 
 /**
  * Keyframe multi-select keys are the compound `trackId:kfId` string.
@@ -56,6 +57,8 @@ const TRACK_HEADER_WIDTH = 180
 // store, so closures see fresh values.
 let PX_PER_SECOND = 80
 const ROW_HEIGHT = 24
+type TimelineMode = 'animated' | 'sound'
+type MediaTimelineNode = Extract<SceneNode, { kind: 'audio' | 'video' }>
 
 export function Timeline() {
   // Version is read *and* used as a memo dep — without it, `tracksByNode`
@@ -83,6 +86,10 @@ export function Timeline() {
   const setSelectedTrackIds = useUI((s) => s.setSelectedTrackIds)
   const isolatedRange = useUI((s) => s.isolatedRange)
   const setIsolatedRange = useUI((s) => s.setIsolatedRange)
+  const workAreaRange = useUI((s) => s.workAreaRange)
+  const setWorkAreaRange = useUI((s) => s.setWorkAreaRange)
+  const workAreaPlaybackMode = useUI((s) => s.workAreaPlaybackMode)
+  const setWorkAreaPlaybackMode = useUI((s) => s.setWorkAreaPlaybackMode)
   const rulerLabels = useUI((s) => s.rulerLabels)
   const cycleRulerLabels = useUI((s) => s.cycleRulerLabels)
   // Group dictionaries now live in the Y.Doc — read them off the
@@ -145,6 +152,11 @@ export function Timeline() {
   PX_PER_SECOND = pxPerSecond
   const duration = api.getMeta().duration
   const frameRate = api.getMeta().frameRate
+  const frameStep = 1 / Math.max(1, frameRate)
+  const minWorkArea = Math.max(frameStep, 0.05)
+  const normalizedWorkArea = workAreaRange
+    ? normalizeTimelineWorkArea(workAreaRange, duration, minWorkArea)
+    : null
 
   // Pinch-zoom + Cmd/Ctrl-scroll over the timeline scales horizontally
   // (time-axis zoom). Browser pinch on macOS fires `wheel` with
@@ -195,6 +207,7 @@ export function Timeline() {
     return () => el.removeEventListener('wheel', onWheel)
   }, [setTimelinePxPerSecond])
   const scrollerRef = useRef<HTMLDivElement>(null)
+  const audioInputRef = useRef<HTMLInputElement>(null)
   // The right column wrapper — the element whose `getBoundingClientRect`
   // is the shared coordinate space for the ruler, the segment rows, and
   // the marquee rectangle. Using this instead of computing offsets off
@@ -208,6 +221,7 @@ export function Timeline() {
   // the graph editor in that case). Set is kept here for fast hit
   // tests; the store sees a serializable array.
   const [selectedKfs, setSelectedKfs] = useState<Set<string>>(() => new Set())
+  const [timelineMode, setTimelineMode] = useState<TimelineMode>('animated')
   const setSelectedKeyframes = useUI((s) => s.setSelectedKeyframes)
   useEffect(() => {
     setSelectedKeyframes(Array.from(selectedKfs))
@@ -605,6 +619,68 @@ export function Timeline() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [api, version])
 
+  const mediaClips = useMemo(() => {
+    const out: MediaTimelineNode[] = []
+    for (const id of api.getAllNodeIds()) {
+      const node = api.getNode(id)
+      if (node && (node.kind === 'audio' || node.kind === 'video')) {
+        out.push(node)
+      }
+    }
+    return out.sort((a, b) => a.startTime - b.startTime)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api, version])
+
+  const duplicateMediaClip = useCallback(
+    (node: MediaTimelineNode) => {
+      const parent = node.parent ?? api.getRoot()
+      const id = api.createNode(node.kind, parent, {
+        name: `${node.name} copy`,
+        size: node.size,
+        src: node.src,
+        duration: node.duration,
+        volume: node.volume,
+        muted: node.muted,
+        startTime: node.startTime + 0.25,
+        trimStart: node.trimStart,
+        trimEnd: node.trimEnd,
+        loop: node.loop,
+        ...(node.kind === 'video' ? { fit: node.fit } : {}),
+      } as Partial<SceneNode>)
+      setSelection([id])
+      setInspectorMode('properties')
+    },
+    [api, setInspectorMode, setSelection],
+  )
+
+  const openMediaMenu = useCallback(
+    (e: React.MouseEvent, node: MediaTimelineNode) => {
+      e.preventDefault()
+      e.stopPropagation()
+      openContextMenu({
+        x: e.clientX,
+        y: e.clientY,
+        items: [
+          {
+            label: node.muted ? 'Unmute clip' : 'Mute clip',
+            onClick: () => api.setNodeProperty(node.id, 'muted', !node.muted),
+          },
+          {
+            label: 'Duplicate clip',
+            onClick: () => duplicateMediaClip(node),
+          },
+          { kind: 'separator' },
+          {
+            label: `Delete "${node.name}"`,
+            danger: true,
+            onClick: () => api.deleteNode(node.id),
+          },
+        ],
+      })
+    },
+    [api, duplicateMediaClip, openContextMenu],
+  )
+
   // Flat list of every visible track — threaded into KeyframeDiamond so a
   // batch drag can enumerate all selected keyframes without re-walking
   // the grouped structure. Rebuilds alongside tracksByNode.
@@ -871,6 +947,61 @@ export function Timeline() {
     // When isolated, clamp scrub to the section so the playhead
     // can't roam outside the focused band.
     return clamp(x / PX_PER_SECOND, viewStart, viewEnd)
+  }
+
+  const timeFromWorkAreaClientX = (clientX: number): number => {
+    const el = rightRef.current
+    if (!el) return 0
+    const rect = el.getBoundingClientRect()
+    return clamp((clientX - rect.left) / PX_PER_SECOND, 0, duration)
+  }
+
+  const toggleWorkArea = () => {
+    if (normalizedWorkArea) {
+      setWorkAreaRange(null)
+      return
+    }
+    const start = clamp(playhead, 0, Math.max(0, duration - minWorkArea))
+    const end = Math.min(duration, start + Math.min(2, duration - start))
+    setWorkAreaRange({ start, end: Math.max(start + minWorkArea, end) })
+  }
+
+  const beginWorkAreaDrag = (
+    e: React.PointerEvent,
+    mode: 'start' | 'end' | 'move',
+  ) => {
+    if (!normalizedWorkArea) return
+    e.preventDefault()
+    e.stopPropagation()
+    setPlaying(false)
+    const anchor = timeFromWorkAreaClientX(e.clientX)
+    const base = normalizedWorkArea
+    const span = base.end - base.start
+    const onMove = (ev: PointerEvent) => {
+      const t = timeFromWorkAreaClientX(ev.clientX)
+      if (mode === 'start') {
+        const nextStart = clamp(t, 0, base.end - minWorkArea)
+        setWorkAreaRange({ start: nextStart, end: base.end })
+        setPlayhead(nextStart)
+        return
+      }
+      if (mode === 'end') {
+        const nextEnd = clamp(t, base.start + minWorkArea, duration)
+        setWorkAreaRange({ start: base.start, end: nextEnd })
+        setPlayhead(Math.min(playhead, nextEnd))
+        return
+      }
+      const delta = t - anchor
+      const nextStart = clamp(base.start + delta, 0, duration - span)
+      setWorkAreaRange({ start: nextStart, end: nextStart + span })
+      setPlayhead(clamp(playhead + delta, nextStart, nextStart + span))
+    }
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
   }
 
   /**
@@ -1206,6 +1337,44 @@ export function Timeline() {
           </div>
         )}
 
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={toggleWorkArea}
+            title={
+              normalizedWorkArea
+                ? 'Clear work area'
+                : 'Create work area at playhead'
+            }
+            className={[
+              'h-7 rounded border px-2 font-mono text-[10px] tracking-wider uppercase',
+              normalizedWorkArea
+                ? 'border-[oklch(0.84_0.18_85)] bg-[oklch(0.84_0.18_85)]/15 text-text'
+                : 'border-border bg-panel text-text-muted hover:border-border-strong hover:text-text',
+            ].join(' ')}
+          >
+            Work area
+          </button>
+          {normalizedWorkArea && (
+            <button
+              type="button"
+              onClick={() =>
+                setWorkAreaPlaybackMode(
+                  workAreaPlaybackMode === 'loop' ? 'stop' : 'loop',
+                )
+              }
+              title={
+                workAreaPlaybackMode === 'loop'
+                  ? 'Loop work area while playing'
+                  : 'Stop playback at work area end'
+              }
+              className="h-7 rounded border border-border bg-panel px-2 font-mono text-[10px] tracking-wider text-text-muted uppercase hover:border-border-strong hover:text-text"
+            >
+              {workAreaPlaybackMode}
+            </button>
+          )}
+        </div>
+
         {/* Duration cluster — far-right, After Effects pattern. The
             "Duration" label is back since the field is no longer
             adjacent to the playhead time and needs its own context. */}
@@ -1281,19 +1450,76 @@ export function Timeline() {
               the ruler tick labels across the divider. */}
           <div
             className={[
-              'sticky top-7 z-[29] flex items-end border-b border-border bg-panel px-3 pb-1',
+              'sticky top-7 z-[29] flex items-end gap-1 border-b border-border bg-panel px-2 pb-1',
               rulerLabels === 'both' ? 'h-10' : 'h-7',
             ].join(' ')}
           >
-            <span className="text-[11px] font-medium text-text-muted">
+            <TimelineTabButton
+              active={timelineMode === 'animated'}
+              onClick={() => setTimelineMode('animated')}
+            >
               Animated layers
-            </span>
+            </TimelineTabButton>
+            <TimelineTabButton
+              active={timelineMode === 'sound'}
+              onClick={() => setTimelineMode('sound')}
+            >
+              Audio
+            </TimelineTabButton>
           </div>
+          <input
+            ref={audioInputRef}
+            type="file"
+            accept="audio/*"
+            multiple
+            hidden
+            onChange={(event) => {
+              const files = event.currentTarget.files
+              if (!files) return
+              void Promise.all(
+                Array.from(files).map((file) =>
+                  importAudioFile(file, api, null),
+                ),
+              )
+              event.currentTarget.value = ''
+            }}
+          />
           {/* The h-3 spacer that used to live here is gone — the
               Tracks header above now expands to h-10 in both-labels +
               no-sections mode, so the left column matches the right
               column's ruler height directly. */}
-          {tracksByNode.length === 0 ? (
+          {normalizedWorkArea && (
+            <div className="h-5 border-b border-border/50 bg-panel" />
+          )}
+          {timelineMode === 'sound' ? (
+            mediaClips.length === 0 ? (
+              <div className="space-y-3 px-4 py-5 text-[11px] leading-relaxed text-text-dim">
+                <AudioImportButton onClick={() => audioInputRef.current?.click()} />
+                <div>
+                  No audio clips yet.<br />
+                  Click Import or drag an audio file onto the canvas.
+                </div>
+              </div>
+            ) : (
+              <>
+                {mediaClips.map((clip) => (
+                  <MediaClipLabel
+                    key={clip.id}
+                    node={clip}
+                    selected={selection.includes(clip.id)}
+                    onSelect={() => {
+                      setSelection([clip.id])
+                      setInspectorMode('properties')
+                    }}
+                    onContextMenu={(e) => openMediaMenu(e, clip)}
+                  />
+                ))}
+                <div className="border-t border-border/50 bg-panel px-3 py-2">
+                  <AudioImportButton onClick={() => audioInputRef.current?.click()} />
+                </div>
+              </>
+            )
+          ) : tracksByNode.length === 0 ? (
             <div className="px-4 py-5 text-[11px] leading-relaxed text-text-dim">
               No keyframes yet.<br />
               Pick a preset in the Animate tab to add one.
@@ -1602,8 +1828,85 @@ export function Timeline() {
                   same value was noise; one is enough. */}
             </div>
 
+            {normalizedWorkArea && (
+              <>
+                <div
+                  className="pointer-events-none absolute z-[7] bg-panel/60"
+                  style={{
+                    top: 28 + (rulerLabels === 'both' ? 40 : 28) + 20,
+                    bottom: 0,
+                    left: 0,
+                    width: normalizedWorkArea.start * PX_PER_SECOND,
+                  }}
+                />
+                <div
+                  className="pointer-events-none absolute z-[7] bg-panel/60"
+                  style={{
+                    top: 28 + (rulerLabels === 'both' ? 40 : 28) + 20,
+                    bottom: 0,
+                    left: normalizedWorkArea.end * PX_PER_SECOND,
+                    right: 0,
+                  }}
+                />
+                <div
+                  className="pointer-events-none absolute z-[12] h-2 rounded-full border border-[oklch(0.84_0.18_85)] bg-[oklch(0.84_0.18_85)] shadow-sm"
+                  style={{
+                    top: 28 + (rulerLabels === 'both' ? 40 : 28) + 6,
+                    left: normalizedWorkArea.start * PX_PER_SECOND,
+                    width:
+                      (normalizedWorkArea.end - normalizedWorkArea.start) *
+                      PX_PER_SECOND,
+                  }}
+                >
+                  <div
+                    className="pointer-events-auto absolute top-1/2 left-0 h-5 w-2 -translate-x-1/2 -translate-y-1/2 cursor-ew-resize rounded-full border border-[oklch(0.84_0.18_85)] bg-panel shadow-sm"
+                    title="Drag work area start"
+                    onPointerDown={(e) => beginWorkAreaDrag(e, 'start')}
+                  />
+                  <div
+                    className="pointer-events-auto absolute top-1/2 right-0 h-5 w-2 translate-x-1/2 -translate-y-1/2 cursor-ew-resize rounded-full border border-[oklch(0.84_0.18_85)] bg-panel shadow-sm"
+                    title="Drag work area end"
+                    onPointerDown={(e) => beginWorkAreaDrag(e, 'end')}
+                  />
+                  <div
+                    className="pointer-events-auto absolute inset-y-[-6px] left-2 right-2 cursor-grab active:cursor-grabbing"
+                    title="Drag work area"
+                    onPointerDown={(e) => beginWorkAreaDrag(e, 'move')}
+                  />
+                </div>
+              </>
+            )}
+
+            {normalizedWorkArea && (
+              <div className="h-5 border-b border-border/50 bg-panel" />
+            )}
+
             {/* Track rows */}
-            {tracksByNode.length === 0 ? (
+            {timelineMode === 'sound' ? (
+              mediaClips.length === 0 ? (
+                <div className="h-20" />
+              ) : (
+                mediaClips.map((clip) => (
+                  <MediaClipRow
+                    key={clip.id}
+                    node={clip}
+                    api={api}
+                    duration={duration}
+                    totalWidth={totalWidth}
+                    selected={selection.includes(clip.id)}
+                    onSelect={() => {
+                      setSelection([clip.id])
+                      setInspectorMode('properties')
+                    }}
+                    onScrub={(time) => {
+                      setPlaying(false)
+                      setPlayhead(time)
+                    }}
+                    onContextMenu={(e) => openMediaMenu(e, clip)}
+                  />
+                ))
+              )
+            ) : tracksByNode.length === 0 ? (
               <div className="h-20" />
             ) : (
               tracksByNode.map((group) => {
@@ -2130,6 +2433,323 @@ function TrackLabel({
       </button>
     </div>
   )
+}
+
+function TimelineTabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        'h-5 rounded px-1.5 text-[10px] font-semibold uppercase tracking-[0.06em]',
+        active
+          ? 'bg-accent-soft text-accent'
+          : 'text-text-muted hover:bg-panel-raised hover:text-text',
+      ].join(' ')}
+    >
+      {children}
+    </button>
+  )
+}
+
+function AudioImportButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="h-6 rounded border border-border bg-panel-raised px-2 text-[10px] font-semibold tracking-[0.06em] text-text-muted uppercase hover:border-border-strong hover:text-text"
+      title="Import audio from Finder"
+    >
+      Import audio
+    </button>
+  )
+}
+
+function MediaClipLabel({
+  node,
+  selected,
+  onSelect,
+  onContextMenu,
+}: {
+  node: MediaTimelineNode
+  selected: boolean
+  onSelect: () => void
+  onContextMenu: (e: React.MouseEvent) => void
+}) {
+  return (
+    <div
+      onClick={onSelect}
+      onContextMenu={onContextMenu}
+      aria-selected={selected}
+      className={[
+        'flex h-8 cursor-pointer items-center gap-2 border-t border-border/50 px-3',
+        selected
+          ? 'bg-accent-soft/40 text-accent hover:bg-accent-soft/55'
+          : 'bg-panel-raised/40 text-text hover:bg-panel-raised/70',
+      ].join(' ')}
+    >
+      <span className="w-4 shrink-0 text-center text-[12px] text-text-muted">
+        {node.muted ? '×' : node.kind === 'audio' ? '♪' : '▶'}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[11px] font-medium">{node.name}</div>
+        <div className="truncate font-mono text-[9px] text-text-dim">
+          {node.kind === 'audio' ? 'AUDIO' : 'VIDEO'} · {formatMediaDuration(node)}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function MediaClipRow({
+  node,
+  api,
+  duration,
+  totalWidth,
+  selected,
+  onSelect,
+  onScrub,
+  onContextMenu,
+}: {
+  node: MediaTimelineNode
+  api: SceneAPI
+  duration: number
+  totalWidth: number
+  selected: boolean
+  onSelect: () => void
+  onScrub: (time: number) => void
+  onContextMenu: (e: React.MouseEvent) => void
+}) {
+  const rowRef = useRef<HTMLDivElement>(null)
+  const trimStart = Math.max(0, node.trimStart || 0)
+  const trimEnd = Math.max(trimStart, node.trimEnd || node.duration || 0)
+  const sourceDuration = Math.max(0, node.duration || trimEnd)
+  const clipLength = Math.max(0.01, trimEnd - trimStart)
+  const start = Math.max(0, node.startTime || 0)
+  const left = start * PX_PER_SECOND
+  const width = Math.max(8, clipLength * PX_PER_SECOND)
+
+  const timeFromPointer = (clientX: number) => {
+    const rect = rowRef.current?.getBoundingClientRect()
+    if (!rect) return 0
+    return Math.max(0, Math.min(duration, (clientX - rect.left) / PX_PER_SECOND))
+  }
+
+  const beginDrag = (
+    e: React.PointerEvent,
+    mode: 'move' | 'trim-start' | 'trim-end',
+  ) => {
+    e.preventDefault()
+    e.stopPropagation()
+    onSelect()
+    const startX = e.clientX
+    const baseStart = start
+    const baseTrimStart = trimStart
+    const baseTrimEnd = trimEnd
+    const maxStart = Math.max(0, duration - clipLength)
+
+    const onMove = (ev: PointerEvent) => {
+      const deltaSec = (ev.clientX - startX) / PX_PER_SECOND
+      if (mode === 'move') {
+        const nextStart = Math.max(0, Math.min(maxStart, baseStart + deltaSec))
+        api.setNodeProperty(node.id, 'startTime', nextStart)
+        return
+      }
+      if (mode === 'trim-start') {
+        const nextTrimStart = Math.max(
+          0,
+          Math.min(baseTrimEnd - 0.01, baseTrimStart + deltaSec),
+        )
+        const nextStart = Math.max(0, baseStart + (nextTrimStart - baseTrimStart))
+        api.setNodeProperty(node.id, 'trimStart', nextTrimStart)
+        api.setNodeProperty(node.id, 'startTime', nextStart)
+        return
+      }
+      const nextTrimEnd = Math.max(
+        baseTrimStart + 0.01,
+        Math.min(sourceDuration, baseTrimEnd + deltaSec),
+      )
+      api.setNodeProperty(node.id, 'trimEnd', nextTrimEnd)
+    }
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }
+
+  return (
+    <div
+      ref={rowRef}
+      className={[
+        'relative h-8 border-t border-border/50',
+        selected ? 'bg-accent-soft/20' : '',
+      ].join(' ')}
+      style={{ width: totalWidth }}
+      onPointerDown={(e) => {
+        if ((e.target as HTMLElement).dataset.mediaClipPart) return
+        onScrub(timeFromPointer(e.clientX))
+      }}
+      onContextMenu={onContextMenu}
+    >
+      <div
+        data-media-clip-part="body"
+        className={[
+          'absolute top-1 bottom-1 cursor-grab rounded-md border px-2 active:cursor-grabbing',
+          node.muted
+            ? 'border-border-strong bg-panel-raised text-text-muted'
+            : 'border-accent/60 bg-accent-soft text-accent',
+        ].join(' ')}
+        style={{ left, width }}
+        onPointerDown={(e) => beginDrag(e, 'move')}
+        onContextMenu={onContextMenu}
+        title="Drag to move. Drag edges to trim."
+      >
+        <div
+          data-media-clip-part="trim-start"
+          className="absolute top-0 bottom-0 left-0 w-2 cursor-ew-resize rounded-l-md hover:bg-accent/25"
+          onPointerDown={(e) => beginDrag(e, 'trim-start')}
+        />
+        <div
+          data-media-clip-part="trim-end"
+          className="absolute top-0 right-0 bottom-0 w-2 cursor-ew-resize rounded-r-md hover:bg-accent/25"
+          onPointerDown={(e) => beginDrag(e, 'trim-end')}
+        />
+        <div className="pointer-events-none relative h-full overflow-hidden rounded-md">
+          <WaveformBars node={node} />
+          <div className="absolute inset-0 flex items-center gap-1 px-2">
+            <span className="shrink-0 text-[11px] drop-shadow-sm">
+              {node.muted ? '×' : '♪'}
+            </span>
+            <span className="ml-auto max-w-[45%] truncate bg-accent-soft/80 pl-2 font-mono text-[10px] drop-shadow-sm">
+              {node.name}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const waveformCache = new Map<string, AudioBuffer>()
+
+function WaveformBars({ node }: { node: MediaTimelineNode }) {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const [buffer, setBuffer] = useState<AudioBuffer | null>(
+    () => waveformCache.get(node.src) ?? null,
+  )
+  const [barCount, setBarCount] = useState(64)
+
+  useEffect(() => {
+    let cancelled = false
+    if (!node.src || waveformCache.has(node.src)) {
+      setBuffer(node.src ? waveformCache.get(node.src) ?? null : null)
+      return
+    }
+    async function load() {
+      if (typeof AudioContext === 'undefined') return
+      try {
+        const response = await fetch(node.src)
+        const bytes = await response.arrayBuffer()
+        const ctx = new AudioContext()
+        try {
+          const decoded = await ctx.decodeAudioData(bytes.slice(0))
+          waveformCache.set(node.src, decoded)
+          if (!cancelled) setBuffer(decoded)
+        } finally {
+          void ctx.close()
+        }
+      } catch {
+        if (!cancelled) setBuffer(null)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [node.src])
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host || typeof ResizeObserver === 'undefined') return
+    const resize = () => {
+      setBarCount(Math.max(12, Math.min(500, Math.floor(host.clientWidth / 3))))
+    }
+    resize()
+    const observer = new ResizeObserver(resize)
+    observer.observe(host)
+    return () => observer.disconnect()
+  }, [])
+
+  const bars = useMemo(() => {
+    if (!buffer) return Array.from({ length: barCount }, () => 0.12)
+    const trimStart = Math.max(0, node.trimStart || 0)
+    const trimEnd = Math.max(trimStart, node.trimEnd || node.duration || buffer.duration)
+    return computeWaveformPeaks(buffer, barCount, trimStart, trimEnd)
+  }, [barCount, buffer, node.duration, node.trimEnd, node.trimStart])
+
+  return (
+    <div
+      ref={hostRef}
+      className="absolute inset-x-7 inset-y-1 flex items-center gap-px opacity-90"
+      aria-hidden="true"
+    >
+      {bars.map((p, i) => (
+        <span
+          key={i}
+          className="min-w-px flex-1 rounded-full bg-current"
+          style={{ height: `${Math.max(8, Math.round(p * 100))}%` }}
+        />
+      ))}
+    </div>
+  )
+}
+
+function computeWaveformPeaks(
+  buffer: AudioBuffer,
+  count: number,
+  startSeconds = 0,
+  endSeconds = buffer.duration,
+): number[] {
+  const data = buffer.getChannelData(0)
+  if (data.length === 0) return Array.from({ length: count }, () => 0.1)
+  const startSample = Math.max(
+    0,
+    Math.min(data.length - 1, Math.floor(startSeconds * buffer.sampleRate)),
+  )
+  const endSample = Math.max(
+    startSample + 1,
+    Math.min(data.length, Math.floor(endSeconds * buffer.sampleRate)),
+  )
+  const block = Math.max(1, Math.floor((endSample - startSample) / count))
+  const peaks: number[] = []
+  let maxPeak = 0.0001
+  for (let i = 0; i < count; i++) {
+    let sum = 0
+    const start = startSample + i * block
+    const end = i === count - 1 ? endSample : Math.min(endSample, start + block)
+    for (let j = start; j < end; j++) sum += Math.abs(data[j] ?? 0)
+    const avg = sum / Math.max(1, end - start)
+    peaks.push(avg)
+    if (avg > maxPeak) maxPeak = avg
+  }
+  return peaks.map((p) => Math.max(0.12, Math.min(1, p / maxPeak)))
+}
+
+function formatMediaDuration(node: MediaTimelineNode): string {
+  const trimStart = Math.max(0, node.trimStart || 0)
+  const trimEnd = Math.max(trimStart, node.trimEnd || node.duration || 0)
+  const seconds = Math.max(0, trimEnd - trimStart)
+  return `${seconds.toFixed(seconds < 10 ? 2 : 1)}S`
 }
 
 // ---------------------------------------------------------------------------
@@ -3713,6 +4333,21 @@ function humanProperty(id: string, nodeKind?: string): string {
 
 function clamp(n: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, n))
+}
+
+function normalizeTimelineWorkArea(
+  range: { start: number; end: number },
+  duration: number,
+  minSpan: number,
+): { start: number; end: number } {
+  const safeDuration = Math.max(minSpan, duration)
+  let start = clamp(Math.min(range.start, range.end), 0, safeDuration)
+  let end = clamp(Math.max(range.start, range.end), 0, safeDuration)
+  if (end - start < minSpan) {
+    if (start + minSpan <= safeDuration) end = start + minSpan
+    else start = Math.max(0, end - minSpan)
+  }
+  return { start, end }
 }
 
 /**

--- a/src/ui/hooks/useAnim.ts
+++ b/src/ui/hooks/useAnim.ts
@@ -28,24 +28,38 @@ export function useAnim() {
   const playing = useUI((s) => s.playing)
   const playhead = useUI((s) => s.playhead)
   const setPlayhead = useUI((s) => s.setPlayhead)
+  const setPlaying = useUI((s) => s.setPlaying)
   const isolatedRange = useUI((s) => s.isolatedRange)
+  const workAreaRange = useUI((s) => s.workAreaRange)
+  const workAreaPlaybackMode = useUI((s) => s.workAreaPlaybackMode)
 
   // Attach engine to scene once.
   useEffect(() => {
     getAnimEngine().attach(api)
   }, [api])
 
-  // Mirror the UI's isolated section into the engine's loop range
-  // so Space / play stays inside the section and loops there. When
-  // the user exits isolation, the engine reverts to looping the
-  // full comp duration.
+  // Mirror isolation/work-area playback into the engine. Isolation
+  // keeps its historical behavior and always loops. Otherwise the
+  // shared work area can either loop or stop at its end.
   useEffect(() => {
-    getAnimEngine().setLoopRange(
-      isolatedRange
-        ? { start: isolatedRange.start, end: isolatedRange.end }
+    if (isolatedRange) {
+      getAnimEngine().setPlaybackRange({
+        start: isolatedRange.start,
+        end: isolatedRange.end,
+        mode: 'loop',
+      })
+      return
+    }
+    getAnimEngine().setPlaybackRange(
+      workAreaRange
+        ? {
+            start: workAreaRange.start,
+            end: workAreaRange.end,
+            mode: workAreaPlaybackMode,
+          }
         : null,
     )
-  }, [isolatedRange])
+  }, [isolatedRange, workAreaPlaybackMode, workAreaRange])
 
   // UI → engine: sync playhead when NOT playing (during scrub / fields).
   useEffect(() => {
@@ -69,7 +83,8 @@ export function useAnim() {
     const engine = getAnimEngine()
     const h = window.setInterval(() => {
       setPlayhead(engine.getPlayhead())
+      if (!engine.isPlaying()) setPlaying(false)
     }, 66)
     return () => window.clearInterval(h)
-  }, [playing, setPlayhead])
+  }, [playing, setPlayhead, setPlaying])
 }

--- a/src/ui/importMedia.ts
+++ b/src/ui/importMedia.ts
@@ -81,24 +81,18 @@ export async function importVideoFile(
 export async function importAudioFile(
   file: File,
   api: SceneAPI,
-  parent: NodeId | null,
-  opts?: { dropPos?: { x: number; y: number }; workspaceOnly?: boolean },
+  _parent: NodeId | null,
+  _opts?: { dropPos?: { x: number; y: number }; workspaceOnly?: boolean },
 ): Promise<NodeId> {
   const dataUrl = await readFileAsDataUrl(file)
   const { duration } = await decodeAudioMeta(dataUrl)
 
-  const meta = api.getMeta()
-  const w = 140
-  const h = 44
-  const cx = opts?.dropPos?.x ?? meta.canvas.width / 2
-  const cy = opts?.dropPos?.y ?? meta.canvas.height / 2
   const transform: Transform = {
-    // Audio chips land at the canvas's top-left region by default — a
-    // stack of audio tracks can accumulate there without crowding the
-    // visual layout. We still honor dropPos if the user drags to a
-    // specific spot.
-    x: opts?.dropPos ? Math.round(cx - w / 2) : 16,
-    y: opts?.dropPos ? Math.round(cy - h / 2) : 16,
+    // Audio is a sound-timeline asset, not an artboard object. Keep a
+    // neutral transform for schema compatibility; the editor controls
+    // timing through startTime / trim fields instead.
+    x: 0,
+    y: 0,
     z: 0,
     rotation: 0,
     rotationX: 0,
@@ -109,18 +103,19 @@ export async function importAudioFile(
 
   warnIfLarge(file)
 
-  const id = api.createNode('audio', parent, {
+  const id = api.createNode('audio', null, {
     name: file.name.replace(/\.[^.]+$/, '') || 'Audio',
-    size: { width: w, height: h },
+    size: { width: 1, height: 1 },
     transform,
     src: dataUrl,
     duration,
     trimEnd: duration,
     volume: 1,
+    muted: false,
     startTime: 0,
     trimStart: 0,
     loop: false,
-    workspaceOnly: opts?.workspaceOnly ?? false,
+    workspaceOnly: true,
   } as Parameters<SceneAPI['createNode']>[2])
 
   return id


### PR DESCRIPTION
## Summary
- add timeline-only audio clips with import, mute, trim, move, duplicate, and waveform display
- add in-editor audio playback synced to the playhead and preview
- mix audio into MP4 exports and add work-area export/preview controls

## Verification
- pnpm exec tsc --noEmit --pretty false