### PR TITLE
Update CLI README for .hype scene support

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -42,9 +42,10 @@ hypermotion render -o out.mp4 -q 4k
 Quality presets: `comp` (matches the scene canvas — fastest), `720p`,
 `2k` (2560×1440), `4k` (3840×2160). Default: `comp`.
 
-Render targets whichever scene is currently loaded in your desktop app's
-IndexedDB — i.e. whatever you last edited. Render an arbitrary scene
-from a file? That lands in v0.1.1 with the `.arnimotion` file format.
+Render without a scene path targets whichever scene is currently loaded
+in your desktop app. To script a scene from JSON, build a `.hype` file
+with `hypermotion create`, inspect it with `hypermotion info`, then pass
+it to `hypermotion render` with `--scene`.
 
 ## MCP server — AI agent integration
 
@@ -57,8 +58,8 @@ claude mcp add hypermotion -- hypermotion-mcp
 Then in Claude Code, the agent has access to:
 
 - **`render_scene`** — render the current desktop scene to MP4 / WebM / GIF.
-- **`info_scene`** — read scene metadata. (v0.1.1; today returns a structured
-  "not yet implemented" message so agents know the shape that's coming.)
+- **`create_scene`** — build a `.hype` scene file from a JSON description.
+- **`info_scene`** — read `.hype` scene metadata.
 
 ### Codex CLI
 
@@ -74,26 +75,20 @@ command = "hypermotion-mcp"
 Spawn `hypermotion-mcp` as a subprocess. The server speaks MCP over
 stdio per the [Model Context Protocol spec](https://modelcontextprotocol.io).
 
-## v0.1.0 scope
+## v0.1.2 scope
 
 What works today:
 
 - `hypermotion render -o out.mp4` — renders the desktop app's current scene.
+- `hypermotion create out.hype --from scene.json` — builds a scene file.
+- `hypermotion info out.hype` — prints scene metadata.
 - `hypermotion-mcp` — registers + responds to MCP clients.
-- `render_scene` MCP tool — renders the current scene.
-
-What's coming in v0.1.1:
-
-- `.arnimotion` file format (Y.Doc serialize/deserialize, File → Save /
-  Open in the desktop app).
-- `hypermotion render scene.arnimotion -o out.mp4` — render any scene file.
-- `hypermotion info scene.arnimotion` — print scene metadata.
-- `info_scene` MCP tool wired to actually work.
+- `create_scene`, `render_scene`, and `info_scene` MCP tools.
 
 What's longer-term:
 
-- Scene authoring API (create / modify scenes programmatically) so
-  agents can generate scenes from scratch, not just render existing ones.
+- In-place editing for existing `.hype` files.
+- Chapter / range rendering and batch workflows.
 
 ## How rendering works
 


### PR DESCRIPTION
## Summary
- refresh CLI README quick-reference for current .hype create/info/render support
- document current MCP tools and longer-term roadmap accurately

## Verification
- pnpm test (cli)
- pnpm run build (cli)