### PR TITLE
Update CLI render scene path help text

### DIFF
--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -9,9 +9,8 @@
  * off-screen window, loads the scene, runs the export pipeline, and
  * ships the bytes back. The CLI writes them to `<out>`.
  *
- * v0.1.0 scope: renders the CURRENT scene. A future `--scene <path>`
- * flag will render arbitrary `.arnimotion` files once the file format
- * lands in v0.1.1.
+ * Current scope: renders the CURRENT scene. The `--scene <path>` flag is
+ * forwarded to the desktop app for future `.hype` file-specific rendering.
  */
 
 import { Command } from 'commander'
@@ -42,9 +41,8 @@ export function renderCommand(): Command {
     .option('--fps <n>', 'Frame rate', '30')
     .option(
       '--scene <path>',
-      'Path to a .arnimotion file. NOTE: file format ships in v0.1.1 — ' +
-        'in v0.1.0 this flag is accepted but ignored; the current desktop ' +
-        'scene is rendered instead.',
+      'Path to a .hype file. Accepted for forward compatibility; the ' +
+        'current desktop scene is rendered today.',
     )
     .action(async (opts: Record<string, string>) => {
       const outputPath = path.resolve(opts.output)
@@ -85,8 +83,8 @@ export function renderCommand(): Command {
 
       if (opts.scene) {
         console.warn(
-          '[render] note: --scene is reserved for v0.1.1 (file format). ' +
-            'Ignoring; rendering the current desktop scene.',
+          '[render] note: --scene is accepted for forward compatibility. ' +
+            'Rendering the current desktop scene today.',
         )
       }
 

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -7,7 +7,7 @@
  *
  * Registered tools:
  *
- *   - `render_scene` — render a `.arnimotion` file to MP4 / WebM / GIF.
+ *   - `render_scene` — render the current desktop scene to MP4 / WebM / GIF.
  *                      Internally shells out to the installed desktop app.
  *   - `info_scene`   — read a scene file, return metadata (canvas size,
  *                      duration, layer count, track count).

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -5,8 +5,8 @@
  *
  * Renders the user's CURRENT hyper-motion scene (whatever was last
  * persisted to IndexedDB by the desktop app) to MP4 / WebM / GIF by
- * driving the installed desktop app. v0.1.0 scope — see the render
- * command for context on the file-format roadmap.
+ * driving the installed desktop app. A `scene` path can be forwarded to
+ * the desktop app for future file-specific render support.
  *
  * Returns the absolute output path on success, or a descriptive error
  * if the app isn't installed or the render fails.
@@ -34,8 +34,8 @@ const RenderInput = z.object({
     .string()
     .optional()
     .describe(
-      'Path to a .arnimotion scene file. Reserved for v0.1.1 (file format); ' +
-        'currently ignored — the desktop app\'s current scene is rendered.',
+      'Path to a .hype scene file. Accepted for forward compatibility; ' +
+        'the current desktop scene is rendered today.',
     ),
 })
 
@@ -45,8 +45,8 @@ export const renderSceneTool: Tool = {
     "Render the user's current hyper-motion scene (whatever's loaded in " +
     'the desktop app right now) to MP4, WebM, or GIF. Drives the installed ' +
     'desktop app under the hood — returns a clean error if the app is not ' +
-    'installed. To render a specific .arnimotion file, the v0.1.1 release ' +
-    'will accept a `scene` path; today only the current scene is supported.',
+    'installed. A `scene` path is accepted for forward compatibility, but ' +
+    'today only the current desktop scene is supported.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -64,7 +64,7 @@ export const renderSceneTool: Tool = {
       fps: { type: 'number', description: 'Frame rate (1–120). Default: 30.' },
       scene: {
         type: 'string',
-        description: 'Path to a .arnimotion file (reserved for v0.1.1; ignored today).',
+        description: 'Path to a .hype file (accepted for forward compatibility).',
       },
     },
     required: ['output'],


### PR DESCRIPTION
## Summary
- replace stale .arnimotion/v0.1.1 render help text with current .hype terminology
- clarify that scene paths are accepted for forward compatibility while current-scene rendering remains the behavior

## Tests
- pnpm test (in cli/)