### PR TITLE
Fix export segment const lint

### DIFF
--- a/src/export/formats.ts
+++ b/src/export/formats.ts
@@ -316,7 +316,7 @@ export function resolveFrameSegments(
 ): Array<{ firstFrame: number; lastFrame: number }> {
   const lastSceneFrame = Math.max(0, Math.round(durationSec * fps) - 1)
   const clampPair = (a: number, b: number) => {
-    let first = Math.max(0, Math.min(lastSceneFrame, Math.round(a)))
+    const first = Math.max(0, Math.min(lastSceneFrame, Math.round(a)))
     let last = Math.max(0, Math.min(lastSceneFrame, Math.round(b)))
     if (last < first) last = first
     return { firstFrame: first, lastFrame: last }


### PR DESCRIPTION
## Summary
- Change the export frame segment lower bound from `let` to `const` because it is never reassigned.
- Keep the upper bound mutable because it is clamped when needed.

## Verification
- `pnpm exec eslint src/export/formats.ts`

## Notes
- Fresh baseline repo-wide `pnpm lint` and `pnpm typecheck` currently fail on unrelated existing errors across multiple files, so this PR verifies the touched file only.