### PR TITLE
Validate CLI scene node ids

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -128,6 +128,18 @@ test('buildSceneBytes preserves children as editor-reorderable arrays', () => {
   assert.equal(nodes.title.parent, 'root')
 })
 
+test('buildSceneBytes rejects mismatched node ids', () => {
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  assert.ok(root)
+  root.id = 'not-root'
+
+  assert.throws(
+    () => buildSceneBytes(scene),
+    /node id mismatch: nodes\.root\.id is "not-root"/,
+  )
+})
+
 function inspectScene(bytes: Uint8Array): Record<string, unknown> {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, bytes)

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -226,6 +226,10 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
   scene.set('nodes', nodes)
 
   for (const [agentId, node] of Object.entries(json.nodes ?? {})) {
+    if (node.id !== agentId) {
+      throw new Error(`node id mismatch: nodes.${agentId}.id is ${JSON.stringify(node.id)}`)
+    }
+
     const y = new Y.Map<unknown>()
     y.set('id', agentId)
     y.set('kind', node.kind)


### PR DESCRIPTION
## Summary
- reject CLI-authored scenes when a node map key and its internal id disagree
- add a focused node:test coverage case for the mismatch

## Verification
- pnpm --dir cli test

Note: repository labels do not currently include codex or codex-automation, so no automation label was added.