### PR TITLE
Update CLI quick reference scope

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,8 +1,8 @@
 # @psiddharthdesign/hypermotion
 
-CLI + MCP server for [hyper-motion](https://hypermotion.app). Render the
-current desktop scene from the terminal, and let AI coding agents
-(Claude Code, Codex, Cursor, etc.) drive renders programmatically.
+CLI + MCP server for [hyper-motion](https://hypermotion.app). Render
+desktop scenes from the terminal, and let AI coding agents (Claude Code,
+Codex, Cursor, etc.) create, inspect, and render scenes programmatically.
 
 > **Comprehensive guide** — install steps, all flags, every supported
 > agent, what works today vs. roadmap, and troubleshooting — lives at
@@ -43,8 +43,8 @@ Quality presets: `comp` (matches the scene canvas — fastest), `720p`,
 `2k` (2560×1440), `4k` (3840×2160). Default: `comp`.
 
 Render targets whichever scene is currently loaded in your desktop app's
-IndexedDB — i.e. whatever you last edited. Render an arbitrary scene
-from a file? That lands in v0.1.1 with the `.arnimotion` file format.
+IndexedDB — i.e. whatever you last edited. Agents can also create and
+inspect `.hype` files through the CLI and MCP server.
 
 ## MCP server — AI agent integration
 
@@ -56,9 +56,9 @@ claude mcp add hypermotion -- hypermotion-mcp
 
 Then in Claude Code, the agent has access to:
 
-- **`render_scene`** — render the current desktop scene to MP4 / WebM / GIF.
-- **`info_scene`** — read scene metadata. (v0.1.1; today returns a structured
-  "not yet implemented" message so agents know the shape that's coming.)
+- **`create_scene`** — build a `.hype` scene file from JSON.
+- **`render_scene`** — render a scene to MP4 / WebM / GIF.
+- **`info_scene`** — read `.hype` scene metadata.
 
 ### Codex CLI
 
@@ -74,26 +74,20 @@ command = "hypermotion-mcp"
 Spawn `hypermotion-mcp` as a subprocess. The server speaks MCP over
 stdio per the [Model Context Protocol spec](https://modelcontextprotocol.io).
 
-## v0.1.0 scope
+## Current scope
 
 What works today:
 
+- `hypermotion create out.hype --from scene.json` — creates a scene file.
+- `hypermotion info out.hype` — prints scene metadata.
 - `hypermotion render -o out.mp4` — renders the desktop app's current scene.
 - `hypermotion-mcp` — registers + responds to MCP clients.
-- `render_scene` MCP tool — renders the current scene.
-
-What's coming in v0.1.1:
-
-- `.arnimotion` file format (Y.Doc serialize/deserialize, File → Save /
-  Open in the desktop app).
-- `hypermotion render scene.arnimotion -o out.mp4` — render any scene file.
-- `hypermotion info scene.arnimotion` — print scene metadata.
-- `info_scene` MCP tool wired to actually work.
+- `create_scene`, `render_scene`, and `info_scene` MCP tools.
 
 What's longer-term:
 
-- Scene authoring API (create / modify scenes programmatically) so
-  agents can generate scenes from scratch, not just render existing ones.
+- In-place scene modification.
+- Chapter / range rendering and batch rendering.
 
 ## How rendering works
 


### PR DESCRIPTION
## Summary
- Update the CLI README quick reference to reflect current .hype create/info support
- Remove stale v0.1.0/v0.1.1 roadmap wording from the quick reference

## Verification
- pnpm test (in cli/)