### PR TITLE
Align CLI transform JSON type

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -70,6 +70,11 @@ export interface NodeJson {
     rotationY?: number
     scaleX: number
     scaleY: number
+    anchorX?: number
+    anchorY?: number
+    anchorZ?: number
+    space?: 'local' | 'world'
+    renderMode?: 'flat' | 'plane' | 'group3d'
   }
   appearance?: Record<string, unknown>
   size?: { width: number | 'hug' | 'fill'; height: number | 'hug' | 'fill' }


### PR DESCRIPTION
## Summary\n- add missing optional transform fields to the CLI scene JSON type\n- keep the CLI type aligned with transform fields already persisted by scene creation\n\n## Tests\n- pnpm --dir cli test