### PR TITLE
Clarify reserved scene render help

### DIFF
--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -9,9 +9,9 @@
  * off-screen window, loads the scene, runs the export pipeline, and
  * ships the bytes back. The CLI writes them to `<out>`.
  *
- * v0.1.0 scope: renders the CURRENT scene. A future `--scene <path>`
- * flag will render arbitrary `.arnimotion` files once the file format
- * lands in v0.1.1.
+ * Current scope: renders the CURRENT scene. A future `--scene <path>`
+ * flag will render arbitrary `.hype` files once file-based headless
+ * rendering lands.
  */
 
 import { Command } from 'commander'
@@ -42,8 +42,8 @@ export function renderCommand(): Command {
     .option('--fps <n>', 'Frame rate', '30')
     .option(
       '--scene <path>',
-      'Path to a .arnimotion file. NOTE: file format ships in v0.1.1 — ' +
-        'in v0.1.0 this flag is accepted but ignored; the current desktop ' +
+      'Path to a .hype file. NOTE: file-based headless rendering is not ' +
+        'available yet; this flag is accepted but ignored and the current desktop ' +
         'scene is rendered instead.',
     )
     .action(async (opts: Record<string, string>) => {
@@ -85,7 +85,7 @@ export function renderCommand(): Command {
 
       if (opts.scene) {
         console.warn(
-          '[render] note: --scene is reserved for v0.1.1 (file format). ' +
+          '[render] note: --scene is reserved for file-based headless rendering. ' +
             'Ignoring; rendering the current desktop scene.',
         )
       }

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -33,7 +33,7 @@ export interface HeadlessRenderRequest {
   format: 'mp4' | 'webm' | 'gif'
   quality: 'comp' | '720p' | '2k' | '4k'
   fps: number
-  /** v0.1.1 — currently ignored. */
+  /** Future file-based headless render support; currently ignored. */
   scenePath?: string
 }
 

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -34,7 +34,7 @@ const RenderInput = z.object({
     .string()
     .optional()
     .describe(
-      'Path to a .arnimotion scene file. Reserved for v0.1.1 (file format); ' +
+      'Path to a .hype scene file. Reserved for file-based headless rendering; ' +
         'currently ignored — the desktop app\'s current scene is rendered.',
     ),
 })
@@ -45,8 +45,8 @@ export const renderSceneTool: Tool = {
     "Render the user's current hyper-motion scene (whatever's loaded in " +
     'the desktop app right now) to MP4, WebM, or GIF. Drives the installed ' +
     'desktop app under the hood — returns a clean error if the app is not ' +
-    'installed. To render a specific .arnimotion file, the v0.1.1 release ' +
-    'will accept a `scene` path; today only the current scene is supported.',
+    'installed. A future release will accept a `scene` path for a specific ' +
+    '.hype file; today only the current scene is supported.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -64,7 +64,7 @@ export const renderSceneTool: Tool = {
       fps: { type: 'number', description: 'Frame rate (1–120). Default: 30.' },
       scene: {
         type: 'string',
-        description: 'Path to a .arnimotion file (reserved for v0.1.1; ignored today).',
+        description: 'Path to a .hype file (reserved for file-based headless rendering; ignored today).',
       },
     },
     required: ['output'],

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -70,14 +70,14 @@ if (!gotSingleInstanceLock) {
  *   4. Renderer runs export, posts bytes via `export:headless-done`
  *   5. We write the bytes to <out>, exit 0
  *
- * v0.1.0: renders the user's CURRENT scene (whatever's in IndexedDB).
- * v0.1.1 picks up the `.arnimotion` file format and honors `--scene`.
+ * Current scope: renders the user's CURRENT scene (whatever's in IndexedDB).
+ * Future file-based headless rendering will honor `--scene` for `.hype`.
  *
  * The CLI in `@psiddharthdesign/hypermotion` is what spawns this binary
  * with these flags. See `cli/src/electron/driver.ts` for the parent side.
  */
 interface HeadlessRequest {
-  /** Future-compat: path to a .arnimotion scene file. Ignored in v0.1.0. */
+  /** Future-compat: path to a .hype scene file. Ignored today. */
   scenePath?: string
   outputPath: string
   format: 'mp4' | 'webm' | 'gif'

--- a/src/headlessExport.ts
+++ b/src/headlessExport.ts
@@ -21,8 +21,9 @@
  * `exportScene()` with an `onBlob` interceptor that ships bytes back to
  * main via `export:headless-done`.
  *
- * v0.1.0 scope: renders the user's CURRENT scene from IndexedDB. The
- * `.arnimotion` file format work in v0.1.1 will honor `--scene <path>`.
+ * Current scope: renders the user's CURRENT scene from IndexedDB. Future
+ * file-based headless rendering will honor `--scene <path>` for `.hype`
+ * files.
  */
 
 import {


### PR DESCRIPTION
## Summary
- update reserved `--scene` render help/comments from old `.arnimotion` wording to current `.hype` wording
- avoid version-specific roadmap language in CLI/MCP help text

## Verification
- `pnpm --dir cli test`

Note: `pnpm run typecheck` was attempted after installing root dependencies, but it currently fails on unrelated pre-existing app TypeScript errors outside this docs/help-text change.