### PR TITLE
Preserve declared node ids in CLI scenes

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -128,6 +128,24 @@ test('buildSceneBytes preserves children as editor-reorderable arrays', () => {
   assert.equal(nodes.title.parent, 'root')
 })
 
+test('buildSceneBytes keys nodes by their declared ids', () => {
+  const scene = sampleScene()
+  const sceneNodes = scene.nodes ?? {}
+  scene.nodes = {
+    artboard: sceneNodes.root,
+    headline: sceneNodes.title,
+    viewport: sceneNodes.camera,
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(Object.keys(nodes).sort(), ['camera', 'root', 'title'])
+  assert.equal(nodes.root.id, 'root')
+  assert.equal(data.root, 'root')
+  assert.equal(data.activeCameraId, 'camera')
+})
+
 test('buildSceneBytes seeds an empty uiState map for editor compatibility', () => {
   const data = inspectScene(buildSceneBytes(sampleScene()))
 

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -235,9 +235,9 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
   const nodes = new Y.Map<Y.Map<unknown>>()
   scene.set('nodes', nodes)
 
-  for (const [agentId, node] of Object.entries(json.nodes ?? {})) {
+  for (const node of Object.values(json.nodes ?? {})) {
     const y = new Y.Map<unknown>()
-    y.set('id', agentId)
+    y.set('id', node.id)
     y.set('kind', node.kind)
     y.set('name', node.name ?? defaultName(node.kind))
     y.set('parent', node.parent ?? null)
@@ -369,7 +369,7 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
       y.set('showFocusPlane', node.showFocusPlane ?? false)
     }
 
-    nodes.set(agentId, y)
+    nodes.set(node.id, y)
   }
 
   // --- tracks ---
@@ -400,9 +400,9 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
   if (json.root) scene.set('root', json.root)
   else {
     // Infer: first parentless non-camera node.
-    for (const [agentId, node] of Object.entries(json.nodes ?? {})) {
+    for (const node of Object.values(json.nodes ?? {})) {
       if (!node.parent && node.kind !== 'camera') {
-        scene.set('root', agentId)
+        scene.set('root', node.id)
         break
       }
     }
@@ -411,9 +411,9 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
     scene.set('activeCameraId', json.activeCameraId)
   } else {
     // Infer: first camera node.
-    for (const [agentId, node] of Object.entries(json.nodes ?? {})) {
+    for (const node of Object.values(json.nodes ?? {})) {
       if (node.kind === 'camera') {
-        scene.set('activeCameraId', agentId)
+        scene.set('activeCameraId', node.id)
         break
       }
     }


### PR DESCRIPTION
## Summary\n- key CLI-authored scene nodes by each node's declared id\n- infer root and active camera from declared ids when not provided\n- add regression coverage for arbitrary node map keys\n\n## Tests\n- pnpm --dir cli test