### PR TITLE
docs(cli): include create in entrypoint comment

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@
  * Two ways this binary is invoked:
  *
  *   `hypermotion <subcommand>` — interactive CLI for humans (render, info,
- *                                  serve).
+ *                                  create, serve).
  *   `hypermotion-mcp`          — alias that calls `hypermotion serve --mcp`,
  *                                  used by AI coding agents (Claude Code,
  *                                  Codex) over stdio.


### PR DESCRIPTION
## Summary
- Add the `create` subcommand to the CLI entrypoint comment so it matches the registered commands.

## Tests
- `pnpm test` (in `cli/`)
