### PR TITLE
fix(cli): count Y.Array keyframes in scene summary

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -164,6 +164,29 @@ test('buildSceneBytes centers camera focus defaults on the canvas', () => {
   assert.equal(camera.focusWorldZ, 0)
 })
 
+test('readSceneSummary counts keyframes stored as Y.Array values', () => {
+  const doc = new Y.Doc()
+  const scene = doc.getMap<unknown>('scene')
+  scene.set('meta', new Y.Map<unknown>())
+  scene.set('nodes', new Y.Map<Y.Map<unknown>>())
+  scene.set('sections', new Y.Map<unknown>())
+
+  const tracks = new Y.Map<Y.Map<unknown>>()
+  const track = new Y.Map<unknown>()
+  const keyframes = new Y.Array<unknown>()
+  keyframes.push([
+    { id: 'k1', time: 0, value: 0 },
+    { id: 'k2', time: 1, value: 1 },
+  ])
+  track.set('keyframes', keyframes)
+  tracks.set('fade', track)
+  scene.set('tracks', tracks)
+
+  const summary = readSceneSummary(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(summary.keyframeCount, 2)
+})
+
 function inspectScene(bytes: Uint8Array): Record<string, unknown> {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, bytes)

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -465,8 +465,7 @@ export function readSceneSummary(bytes: Uint8Array): SceneSummary {
   let keyframeCount = 0
   if (tracks) {
     for (const t of tracks.values()) {
-      const kfs = t.get('keyframes') as unknown[] | undefined
-      keyframeCount += kfs?.length ?? 0
+      keyframeCount += keyframeLength(t.get('keyframes'))
     }
   }
 
@@ -517,6 +516,12 @@ function mergeWithDefaults<T extends Record<string, unknown>>(
     }
   }
   return out as T
+}
+
+function keyframeLength(value: unknown): number {
+  if (Array.isArray(value)) return value.length
+  if (value instanceof Y.Array) return value.length
+  return 0
 }
 
 function defaultName(kind: NodeJson['kind']): string {


### PR DESCRIPTION
## Summary
- count scene summary keyframes when a track stores keyframes as a Y.Array
- add a CLI regression test for the alternate persisted representation

## Verification
- pnpm test (in cli/)

Note: root `pnpm typecheck` was attempted but currently fails on pre-existing app-wide TypeScript errors unrelated to this CLI change.