### PR TITLE
fix(cli): key authored tracks by declared id

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -146,6 +146,20 @@ test('buildSceneBytes keys nodes by their declared ids', () => {
   assert.equal(data.activeCameraId, 'camera')
 })
 
+test('buildSceneBytes keys tracks by their declared ids', () => {
+  const scene = sampleScene()
+  const sceneTracks = scene.tracks ?? {}
+  scene.tracks = {
+    alias: sceneTracks['fade-title'],
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const tracks = data.tracks as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(Object.keys(tracks), ['fade-title'])
+  assert.equal(tracks['fade-title'].id, 'fade-title')
+})
+
 test('buildSceneBytes seeds an empty uiState map for editor compatibility', () => {
   const data = inspectScene(buildSceneBytes(sampleScene()))
 

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -385,14 +385,14 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
   // --- tracks ---
   const tracks = new Y.Map<Y.Map<unknown>>()
   scene.set('tracks', tracks)
-  for (const [trackId, track] of Object.entries(json.tracks ?? {})) {
+  for (const track of Object.values(json.tracks ?? {})) {
     const y = new Y.Map<unknown>()
-    y.set('id', track.id ?? trackId)
+    y.set('id', track.id)
     y.set('nodeId', track.nodeId)
     y.set('propertyId', track.propertyId)
     y.set('defaultEasing', track.defaultEasing ?? 'ease-in-out')
     y.set('keyframes', track.keyframes ?? [])
-    tracks.set(trackId, y)
+    tracks.set(track.id, y)
   }
 
   // --- sections ---


### PR DESCRIPTION
## Summary
- store CLI-authored tracks under their declared track id instead of the surrounding object key
- add regression coverage matching the existing node-id behavior

## Tests
- cd cli && pnpm test