### PR TITLE
fix(cli): key authored sections by declared id

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -160,6 +160,20 @@ test('buildSceneBytes keys tracks by their declared ids', () => {
   assert.equal(tracks['fade-title'].id, 'fade-title')
 })
 
+test('buildSceneBytes keys sections by their declared ids', () => {
+  const scene = sampleScene()
+  const sceneSections = scene.sections ?? {}
+  scene.sections = {
+    alias: sceneSections.intro,
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const sections = data.sections as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(Object.keys(sections), ['intro'])
+  assert.equal(sections.intro.id, 'intro')
+})
+
 test('buildSceneBytes seeds an empty uiState map for editor compatibility', () => {
   const data = inspectScene(buildSceneBytes(sampleScene()))
 

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -398,8 +398,8 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
   // --- sections ---
   const sections = new Y.Map<unknown>()
   scene.set('sections', sections)
-  for (const [sectionId, section] of Object.entries(json.sections ?? {})) {
-    sections.set(sectionId, section)
+  for (const section of Object.values(json.sections ?? {})) {
+    sections.set(section.id, section)
   }
 
   // --- scalars ---


### PR DESCRIPTION
## Summary
- Store authored scene sections under their declared section id, matching node and track serialization behavior.
- Add CLI scene builder coverage for aliased section map keys.

## Tests
- pnpm test