### PR TITLE
docs: update bug repro file extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,8 @@ discuss the trade-off.
 
 Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md).
 Include: what you did, what you expected, what happened, your OS +
-browser, and a minimal repro (a `.arnimotion` file or short screen
-recording works great).
+browser, and a minimal repro (a `.hype` file or short screen recording
+works great).
 
 ## Proposing features
 


### PR DESCRIPTION
## Summary
- update contributor bug-report guidance to reference current .hype scene files instead of the old .arnimotion extension

## Verification
- confirmed CONTRIBUTING.md no longer contains .arnimotion
- pnpm test (in cli/) passes: 10 tests

Note: repository-wide pnpm lint and pnpm typecheck currently fail on pre-existing issues outside this docs-only change.