### PR TITLE
Clarify CLI render argv example

### DIFF
--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -7,7 +7,7 @@
  *
  *   1. CLI deletes any stale `<output>` and `<output>.done` from a
  *      previous run.
- *   2. CLI spawns the .app binary with `--render --out <path> ...`.
+ *   2. CLI spawns the .app binary with `--render --out=<path> ...`.
  *   3. Inside the binary, `app.requestSingleInstanceLock()` either
  *      succeeds (we're the first instance) or fails (another hyper-motion
  *      is already running). Either way the running app ends up handling


### PR DESCRIPTION
## Summary
- Update the CLI render driver wire diagram to show the current --key=value argv form.

## Verification
- pnpm test (in cli/)