### PR TITLE
Align CLI component scene metadata defaults

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -180,6 +180,28 @@ test('buildSceneBytes seeds an empty uiState map for editor compatibility', () =
   assert.deepEqual(data.uiState, {})
 })
 
+test('buildSceneBytes writes explicit component metadata defaults', () => {
+  const scene = sampleScene()
+  scene.nodes = {
+    component: {
+      id: 'component',
+      kind: 'component',
+      parent: null,
+      children: [],
+      size: { width: 320, height: 180 },
+      layout: { mode: 'none' },
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+  const component = nodes.component
+
+  assert.equal(component.workspaceOnly, false)
+  assert.deepEqual(component.variantPositions, {})
+  assert.deepEqual(component.componentProperties, [])
+})
+
 test('buildSceneBytes centers camera focus defaults on the canvas', () => {
   const data = inspectScene(buildSceneBytes(sampleScene()))
   const nodes = data.nodes as Record<string, Record<string, unknown>>

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -61,6 +61,7 @@ export interface NodeJson {
   position?: 'flow' | 'absolute'
   isMask?: boolean
   componentSourceId?: string | null
+  workspaceOnly?: boolean
   transform?: {
     x: number
     y: number
@@ -77,6 +78,8 @@ export interface NodeJson {
   variants?: unknown[]
   defaultSelection?: Record<string, string>
   variantOverrides?: unknown[]
+  variantPositions?: Record<string, { x: number; y: number }>
+  componentProperties?: unknown[]
   variantTransition?: unknown
   timelines?: Record<string, unknown>
   interactions?: unknown[]
@@ -271,6 +274,7 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
     y.set('position', node.position ?? 'flow')
     y.set('isMask', node.isMask ?? false)
     y.set('componentSourceId', node.componentSourceId ?? null)
+    y.set('workspaceOnly', node.workspaceOnly ?? false)
 
     // kind-specific fields
     if (node.kind === 'frame' || node.kind === 'component') {
@@ -289,6 +293,8 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
         y.set('variants', node.variants ?? [])
         y.set('defaultSelection', node.defaultSelection ?? {})
         y.set('variantOverrides', node.variantOverrides ?? [])
+        y.set('variantPositions', node.variantPositions ?? {})
+        y.set('componentProperties', node.componentProperties ?? [])
         y.set('variantTransition', node.variantTransition ?? {
           duration: 0.3,
           easing: 'ease-in-out',


### PR DESCRIPTION
## Summary\n- Add CLI scene JSON support for workspace-only and component metadata fields\n- Serialize explicit defaults for component variant positions and component properties\n- Cover the serialized defaults in the CLI scene builder tests\n\n## Tests\n- pnpm test (in cli/)\n\n## Notes\n- Root pnpm typecheck was attempted but currently fails on pre-existing app-wide TypeScript errors unrelated to this change.