### PR TITLE
Preserve image import warnings in CLI scenes

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -159,6 +159,30 @@ test('buildSceneBytes preserves children as editor-reorderable arrays', () => {
   assert.equal(nodes.title.parent, 'root')
 })
 
+test('buildSceneBytes preserves image import warnings', () => {
+  const scene = sampleScene()
+  scene.nodes = {
+    image: {
+      id: 'image',
+      kind: 'image',
+      parent: null,
+      children: [],
+      size: { width: 320, height: 180 },
+      src: '/tmp/source.png',
+      fit: 'contain',
+      importWarning: 'Vector fallback was preserved as a bitmap.',
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.equal(
+    nodes.image.importWarning,
+    'Vector fallback was preserved as a bitmap.',
+  )
+})
+
 test('buildSceneBytes keys nodes by their declared ids', () => {
   const scene = sampleScene()
   const sceneNodes = scene.nodes ?? {}

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -104,6 +104,7 @@ export interface NodeJson {
   color?: string
   src?: string
   fit?: 'cover' | 'contain' | 'fill' | 'none'
+  importWarning?: string
   duration?: number
   volume?: number
   startTime?: number
@@ -347,6 +348,7 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
     if (node.kind === 'image') {
       y.set('src', node.src ?? '')
       y.set('fit', node.fit ?? 'cover')
+      if (node.importWarning !== undefined) y.set('importWarning', node.importWarning)
     }
     if (node.kind === 'instance') {
       y.set('size', mergeWithDefaults(DEFAULT_SIZE, node.size))


### PR DESCRIPTION
## Summary\n- add the optional image importWarning field to the CLI scene schema\n- persist import warnings when creating .hype files from JSON\n- cover the round-trip in the scene-builder tests\n\n## Tests\n- pnpm test