### PR TITLE
docs(cli): list create_scene in MCP serve comment

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -7,7 +7,8 @@
  *
  *   `--mcp` — Model Context Protocol server over stdio. This is the
  *             integration point for AI coding agents (Claude Code,
- *             Codex). Tools exposed: `render_scene`, `info_scene`.
+ *             Codex). Tools exposed: `create_scene`, `render_scene`,
+ *             `info_scene`.
  *
  * `hypermotion-mcp` is a separate bin that defaults to this mode, so
  * `claude mcp add hypermotion -- hypermotion-mcp` "just works".


### PR DESCRIPTION
## Summary
- Update the CLI serve command comment so the MCP tool list includes create_scene alongside render_scene and info_scene.

## Verification
- pnpm test (in cli/)