### PR TITLE
Fix CLI camera projection type

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -269,6 +269,18 @@ test('buildSceneBytes centers camera focus defaults on the canvas', () => {
   assert.equal(camera.focusWorldZ, 0)
 })
 
+test('buildSceneBytes preserves perspective camera projection', () => {
+  const scene = sampleScene()
+  const camera = scene.nodes?.camera
+  if (!camera) throw new Error('missing sample camera')
+  camera.projection = 'perspective'
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.equal(nodes.camera.projection, 'perspective')
+})
+
 test('buildSceneBytes respects explicit root and active camera ids', () => {
   const scene = sampleScene()
   scene.nodes = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -112,7 +112,7 @@ export interface NodeJson {
   trimEnd?: number
   loop?: boolean
   muted?: boolean
-  projection?: '2d' | '3d'
+  projection?: '2d' | 'perspective'
   enabled?: boolean
   background?: unknown
   focalLength?: number


### PR DESCRIPTION
## Summary
- Align the CLI scene JSON camera projection type with the desktop scene type by accepting `perspective`
- Add a CLI builder test that verifies perspective camera projection round-trips into .hype bytes

## Tests
- `pnpm --dir cli test`