### PR TITLE
Narrow CLI keyframe value typing

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -295,6 +295,27 @@ test('buildSceneBytes defaults omitted track keyframes to empty', () => {
   assert.equal(summary.keyframeCount, 0)
 })
 
+test('buildSceneBytes preserves variant selection keyframe values', () => {
+  const scene = sampleScene()
+  scene.tracks = {
+    variant: {
+      id: 'variant',
+      nodeId: 'title',
+      propertyId: 'variant',
+      keyframes: [
+        { id: 'k1', time: 0, value: { size: 'compact', tone: 'muted' } },
+      ],
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const tracks = data.tracks as Record<string, Record<string, unknown>>
+  const variantTrack = tracks.variant
+  const keyframes = variantTrack.keyframes as Array<Record<string, unknown>>
+
+  assert.deepEqual(keyframes[0].value, { size: 'compact', tone: 'muted' })
+})
+
 test('buildSceneBytes keys sections by their declared ids', () => {
   const scene = sampleScene()
   const sceneSections = scene.sections ?? {}

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -161,10 +161,17 @@ export type EasingJson =
 export interface KeyframeJson {
   id: string
   time: number
-  value: unknown
+  value: KeyframeValueJson
   easingOut?: EasingJson
   presetOrigin?: 'in' | 'out'
 }
+
+export type KeyframeValueJson =
+  | number
+  | string
+  | Record<string, string>
+  | 'row'
+  | 'column'
 
 export interface SectionJson {
   id: string


### PR DESCRIPTION
## Summary\n- Add a CLI-side KeyframeValueJson type matching the serializable desktop keyframe value shapes\n- Cover variant-selection keyframe values in the scene-builder round-trip tests\n\n## Tests\n- pnpm --dir cli test