### PR TITLE
chore(cli): name keyframe json type

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -145,13 +145,15 @@ export interface TrackJson {
   nodeId: string
   propertyId: string
   defaultEasing?: unknown
-  keyframes: Array<{
-    id: string
-    time: number
-    value: unknown
-    easingOut?: unknown
-    presetOrigin?: 'in' | 'out'
-  }>
+  keyframes: KeyframeJson[]
+}
+
+export interface KeyframeJson {
+  id: string
+  time: number
+  value: unknown
+  easingOut?: unknown
+  presetOrigin?: 'in' | 'out'
 }
 
 export interface SectionJson {


### PR DESCRIPTION
## Summary
- extract the CLI scene keyframe schema into an exported KeyframeJson type
- keep TrackJson behavior unchanged while making the authoring schema easier to reference

## Tests
- pnpm --dir cli test