### PR TITLE
Tighten CLI layout guide scene type

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -92,7 +92,7 @@ export interface NodeJson {
   selection?: Record<string, string>
   overrides?: Record<string, Record<string, unknown>>
   clipsContent?: boolean
-  layoutGuides?: unknown[]
+  layoutGuides?: LayoutGuideJson[]
   // kind-specific
   text?: string
   fontFamily?: string
@@ -160,6 +160,12 @@ export interface SectionJson {
   color: string
   start: number
   end: number
+}
+
+export interface LayoutGuideJson {
+  id: string
+  axis: 'x' | 'y'
+  position: number
 }
 
 export interface SceneSummary {


### PR DESCRIPTION
## Summary
- add a concrete LayoutGuideJson type for CLI scene layout guide metadata
- type NodeJson.layoutGuides with that schema instead of unknown[]

## Tests
- pnpm --dir cli test