### PR TITLE
Clone CLI scene defaults deeply

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -120,6 +120,36 @@ test('buildSceneBytes fills nested defaults expected by the desktop app', () => 
   })
 })
 
+test('buildSceneBytes gives each node independent nested defaults', () => {
+  const scene = sampleScene()
+  scene.nodes = {
+    first: {
+      id: 'first',
+      kind: 'frame',
+      parent: null,
+      children: [],
+      size: { width: 100, height: 100 },
+      layout: { mode: 'none', padding: { top: 8 } },
+    },
+    second: {
+      id: 'second',
+      kind: 'frame',
+      parent: null,
+      children: [],
+      size: { width: 100, height: 100 },
+      layout: { mode: 'none' },
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+  const firstLayout = nodes.first.layout as Record<string, unknown>
+  const secondLayout = nodes.second.layout as Record<string, unknown>
+
+  assert.deepEqual(firstLayout.padding, { top: 8, right: 0, bottom: 0, left: 0 })
+  assert.deepEqual(secondLayout.padding, { top: 0, right: 0, bottom: 0, left: 0 })
+})
+
 test('buildSceneBytes preserves explicit transform anchor and 3D mode fields', () => {
   const scene = sampleScene()
   const root = scene.nodes?.root

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -539,8 +539,8 @@ function mergeWithDefaults<T extends Record<string, unknown>>(
   defaults: T,
   patch: Partial<T> | undefined,
 ): T {
-  if (!patch) return { ...defaults }
-  const out: Record<string, unknown> = { ...defaults }
+  const out: Record<string, unknown> = clonePlainObject(defaults)
+  if (!patch) return out as T
   for (const [k, v] of Object.entries(patch)) {
     const d = (defaults as Record<string, unknown>)[k]
     if (
@@ -555,6 +555,20 @@ function mergeWithDefaults<T extends Record<string, unknown>>(
         d as Record<string, unknown>,
         v as Record<string, unknown>,
       )
+    } else {
+      out[k] = v
+    }
+  }
+  return out as T
+}
+
+function clonePlainObject<T extends Record<string, unknown>>(value: T): T {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(value)) {
+    if (Array.isArray(v)) {
+      out[k] = [...v]
+    } else if (v != null && typeof v === 'object') {
+      out[k] = clonePlainObject(v as Record<string, unknown>)
     } else {
       out[k] = v
     }


### PR DESCRIPTION
## Summary
- Deep-copy CLI scene default objects before applying partial patches
- Add a regression test proving sibling frame layout padding defaults stay independent

## Verification
- pnpm test (in cli/)

Note: root pnpm typecheck currently fails on existing app-level TypeScript errors outside this CLI change.