### PR TITLE
Tighten CLI easing JSON types

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -144,15 +144,23 @@ export interface TrackJson {
   id: string
   nodeId: string
   propertyId: string
-  defaultEasing?: unknown
+  defaultEasing?: EasingJson
   keyframes: KeyframeJson[]
 }
+
+export type EasingJson =
+  | 'linear'
+  | 'ease-in'
+  | 'ease-out'
+  | 'ease-in-out'
+  | { bezier: [number, number, number, number] }
+  | { spring: { stiffness: number; damping: number; mass: number } }
 
 export interface KeyframeJson {
   id: string
   time: number
   value: unknown
-  easingOut?: unknown
+  easingOut?: EasingJson
   presetOrigin?: 'in' | 'out'
 }
 


### PR DESCRIPTION
## Summary
- add a concrete EasingJson union for CLI-authored scene tracks and keyframes
- align CLI JSON typing with the desktop scene easing contract

## Tests
- pnpm test (in cli/)