### PR TITLE
test(cli): cover optional track keyframes

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -215,6 +215,24 @@ test('buildSceneBytes keys tracks by their declared ids', () => {
   assert.equal(tracks['fade-title'].id, 'fade-title')
 })
 
+test('buildSceneBytes defaults omitted track keyframes to empty', () => {
+  const scene = sampleScene()
+  scene.tracks = {
+    'fade-title': {
+      id: 'fade-title',
+      nodeId: 'title',
+      propertyId: 'appearance.opacity',
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const tracks = data.tracks as Record<string, Record<string, unknown>>
+  const summary = readSceneSummary(buildSceneBytes(scene))
+
+  assert.deepEqual(tracks['fade-title'].keyframes, [])
+  assert.equal(summary.keyframeCount, 0)
+})
+
 test('buildSceneBytes keys sections by their declared ids', () => {
   const scene = sampleScene()
   const sceneSections = scene.sections ?? {}

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -145,7 +145,7 @@ export interface TrackJson {
   nodeId: string
   propertyId: string
   defaultEasing?: EasingJson
-  keyframes: KeyframeJson[]
+  keyframes?: KeyframeJson[]
 }
 
 export type EasingJson =


### PR DESCRIPTION
## Summary
- Make CLI TrackJson keyframes optional to match the builder's existing defaulting behavior
- Add a focused scene builder test for omitted track keyframes

## Tests
- cd cli && pnpm install --frozen-lockfile && pnpm test