### PR TITLE
Clarify headless render log fallback

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1263,7 +1263,7 @@ app.whenReady().then(() => {
     headlessRequest = parsed
     // eslint-disable-next-line no-console
     console.log(
-      `[headless] rendering ${parsed.scenePath} → ${parsed.outputPath} ` +
+      `[headless] rendering ${parsed.scenePath ?? 'current scene'} → ${parsed.outputPath} ` +
         `(${parsed.format} · ${parsed.quality} · ${parsed.fps}fps)`,
     )
     createMainWindow()


### PR DESCRIPTION
## Summary
- clarify the headless render startup log when no scene path is provided
- avoid printing `undefined` in the normal current-scene render path

## Verification
- `pnpm exec tsc -p tsconfig.electron.json --noEmit`
- `pnpm exec eslint electron/main.ts` (passes with existing warnings)

Note: full-repo `pnpm typecheck` and `pnpm lint` still report existing unrelated failures on main.