### PR TITLE
test(cli): cover missing keyframes summary

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -399,6 +399,23 @@ test('readSceneSummary counts keyframes stored as plain array values', () => {
   assert.equal(summary.keyframeCount, 2)
 })
 
+test('readSceneSummary treats missing keyframes as empty', () => {
+  const doc = new Y.Doc()
+  const scene = doc.getMap<unknown>('scene')
+  scene.set('meta', new Y.Map<unknown>())
+  scene.set('nodes', new Y.Map<Y.Map<unknown>>())
+  scene.set('sections', new Y.Map<unknown>())
+
+  const tracks = new Y.Map<Y.Map<unknown>>()
+  tracks.set('fade', new Y.Map<unknown>())
+  scene.set('tracks', tracks)
+
+  const summary = readSceneSummary(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(summary.trackCount, 1)
+  assert.equal(summary.keyframeCount, 0)
+})
+
 function inspectScene(bytes: Uint8Array): Record<string, unknown> {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, bytes)


### PR DESCRIPTION
## Summary
- add CLI scene summary coverage for tracks that omit keyframes
- verify missing keyframes count as zero while preserving track count

## Tests
- pnpm --dir cli test