### PR TITLE
Preserve tracks in scene snapshots

### DIFF
--- a/src/scene/doc.ts
+++ b/src/scene/doc.ts
@@ -95,6 +95,8 @@ export interface SceneAPI {
   /** All node ids in the scene. */
   getAllNodeIds(): NodeId[]
   getTrack(id: TrackId): Track | null
+  /** All animation tracks in insertion order. */
+  getAllTracks(): Track[]
   getTracksForNode(nodeId: NodeId): Track[]
 
   // --- mutations -----------------------------------------------------------
@@ -680,6 +682,8 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
       return y ? yTrackToTrack(y) : null
     },
 
+    getAllTracks: () => Array.from(tracks.values()).map(yTrackToTrack),
+
     getTracksForNode: (nodeId) => {
       const out: Track[] = []
       for (const t of tracks.values()) {
@@ -1217,12 +1221,14 @@ export function snapshotScene(api: SceneAPI): Scene {
   for (const s of api.getSections()) sections[s.id] = s
   const customFonts: Record<string, import('@/scene/types').CustomFont> = {}
   for (const f of api.getAllCustomFonts()) customFonts[f.id] = f
+  const tracks: Record<TrackId, Track> = {}
+  for (const t of api.getAllTracks()) tracks[t.id] = t
   return {
     meta: api.getMeta(),
     root: api.getRoot(),
     activeCameraId: api.getActiveCameraId() ?? '',
     nodes,
-    tracks: {}, // TODO: fill when tracks become mutable through the API
+    tracks,
     sections,
     customFonts,
   }


### PR DESCRIPTION
## Summary
- add a read-only SceneAPI helper for all animation tracks
- include tracks when snapshotting a scene so exported scene objects preserve authored animations

## Verification
- PASS: pnpm exec eslint src/scene/doc.ts
- PASS: git diff --check
- FULL CHECK NOT CLEAN: pnpm lint and pnpm typecheck currently fail on pre-existing issues outside src/scene/doc.ts (for example React hook lint errors in RenderWindowApp/Canvas and existing TypeScript errors around SceneNode exports and NodeBaseMutable keys).