### PR TITLE
Remove stale CLI locator lint suppression

### DIFF
--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -32,7 +32,6 @@ export async function locateDesktopApp(): Promise<string | null> {
     // Loud failure — silently falling through when the user set an
     // explicit override usually means a typo or a build that hasn't
     // happened yet. Telling them is more helpful than searching elsewhere.
-    // eslint-disable-next-line no-console
     console.error(
       `[locator] HYPERMOTION_APP_PATH is set but the file does not exist:\n` +
         `          ${override}\n` +


### PR DESCRIPTION
## Summary\n- remove an obsolete eslint-disable comment from the CLI desktop app locator\n\n## Verification\n- pnpm run test (in cli/)\n- pnpm exec eslint cli/src/electron/locator.ts --max-warnings=0