### PR TITLE
chore(cli): name scene node kind type

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -42,19 +42,21 @@ export interface SceneJson {
 
 export type TextAlignJson = 'start' | 'center' | 'end'
 
+export type NodeKindJson =
+  | 'frame'
+  | 'rect'
+  | 'ellipse'
+  | 'text'
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'component'
+  | 'instance'
+  | 'camera'
+
 export interface NodeJson {
   id: string
-  kind:
-    | 'frame'
-    | 'rect'
-    | 'ellipse'
-    | 'text'
-    | 'image'
-    | 'video'
-    | 'audio'
-    | 'component'
-    | 'instance'
-    | 'camera'
+  kind: NodeKindJson
   name?: string
   parent?: string | null
   children?: string[]
@@ -616,7 +618,7 @@ function keyframeLength(value: unknown): number {
   return 0
 }
 
-function defaultName(kind: NodeJson['kind']): string {
+function defaultName(kind: NodeKindJson): string {
   switch (kind) {
     case 'frame': return 'Frame'
     case 'rect': return 'Rectangle'
@@ -631,7 +633,7 @@ function defaultName(kind: NodeJson['kind']): string {
   }
 }
 
-function defaultAppearance(kind: NodeJson['kind']): Record<string, unknown> {
+function defaultAppearance(kind: NodeKindJson): Record<string, unknown> {
   if (kind === 'text') {
     return { ...DEFAULT_APPEARANCE, fill: null }
   }


### PR DESCRIPTION
## Summary
- name the CLI scene node kind union as NodeKindJson
- reuse the type for node schema helpers

## Tests
- pnpm --dir cli test