### PR TITLE
docs: update file menu state comment

### DIFF
--- a/src/ui/hooks/useFileMenu.ts
+++ b/src/ui/hooks/useFileMenu.ts
@@ -18,9 +18,10 @@ import { useUI } from '@/state/ui'
  *   file:save    — write current scene to remembered path (or Save As)
  *   file:save-as — show save dialog, write current scene to chosen path
  *
- * Current file path is tracked at module scope. Saved path persists for
- * the session; reopening the app resets to "no current path" (Save then
- * acts like Save As). Persisting the recent-files list is a v0.1.2 add.
+ * Current file path lives in UI state. Saved path persists for the
+ * session; reopening the app resets to "no current path" (Save then
+ * acts like Save As). The Electron main process owns the persisted
+ * recent-projects list.
  */
 
 declare global {


### PR DESCRIPTION
## Summary
- Update the File menu hook comment to reflect that current file path lives in UI state.
- Clarify that persisted recent projects are owned by the Electron main process.

## Validation
- PASS: `pnpm exec eslint src/ui/hooks/useFileMenu.ts`
- BASELINE FAIL: `pnpm lint` fails on existing unrelated lint errors on `origin/main`.
- BASELINE FAIL: `pnpm typecheck` fails on existing unrelated TypeScript errors on `origin/main`.
