### PR TITLE
Tighten CLI track property id type

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -147,10 +147,50 @@ export interface NodeJson {
 export interface TrackJson {
   id: string
   nodeId: string
-  propertyId: string
+  propertyId: PropertyIdJson
   defaultEasing?: EasingJson
   keyframes?: KeyframeJson[]
 }
+
+export type PropertyIdJson =
+  | 'transform.x'
+  | 'transform.y'
+  | 'transform.z'
+  | 'transform.rotation'
+  | 'transform.rotationX'
+  | 'transform.rotationY'
+  | 'transform.scaleX'
+  | 'transform.scaleY'
+  | 'camera.focusDistance'
+  | 'camera.focusX'
+  | 'camera.focusY'
+  | 'camera.focusWorldX'
+  | 'camera.focusWorldY'
+  | 'camera.focusWorldZ'
+  | 'camera.focusRadius'
+  | 'camera.focusFalloff'
+  | 'camera.pointOfInterestX'
+  | 'camera.pointOfInterestY'
+  | 'camera.pointOfInterestZ'
+  | 'camera.focalLength'
+  | 'camera.fieldOfView'
+  | 'camera.nearClip'
+  | 'camera.farClip'
+  | 'camera.aperture'
+  | 'camera.blurLevel'
+  | 'camera.blurQuality'
+  | 'appearance.opacity'
+  | 'appearance.cornerRadius'
+  | 'appearance.fill'
+  | 'layout.gap'
+  | 'layout.padding.top'
+  | 'layout.padding.right'
+  | 'layout.padding.bottom'
+  | 'layout.padding.left'
+  | 'layout.direction'
+  | 'size.width'
+  | 'size.height'
+  | 'variant'
 
 export type EasingJson =
   | 'linear'


### PR DESCRIPTION
## Summary
- Add a dedicated CLI `PropertyIdJson` union for supported animation track property IDs.
- Keep runtime scene serialization unchanged while improving authoring type safety.

## Verification
- `pnpm --dir cli test`
