### PR TITLE
Add MCP handler return types

### DIFF
--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -23,7 +23,7 @@
  */
 
 import { z } from 'zod'
-import type { Tool } from '@modelcontextprotocol/sdk/types.js'
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
 import path from 'node:path'
 import { buildSceneBytes, type SceneJson } from '../../scene/build.js'
@@ -87,7 +87,9 @@ export const createSceneTool: Tool = {
   },
 }
 
-export async function handleCreateScene(args: Record<string, unknown>) {
+export async function handleCreateScene(
+  args: Record<string, unknown>,
+): Promise<CallToolResult> {
   const parsed = CreateInput.safeParse(args)
   if (!parsed.success) {
     return {

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -8,7 +8,7 @@
  */
 
 import { z } from 'zod'
-import type { Tool } from '@modelcontextprotocol/sdk/types.js'
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
 import { readSceneSummary } from '../../scene/build.js'
 
@@ -31,7 +31,9 @@ export const infoSceneTool: Tool = {
   },
 }
 
-export async function handleInfoScene(args: Record<string, unknown>) {
+export async function handleInfoScene(
+  args: Record<string, unknown>,
+): Promise<CallToolResult> {
   const parsed = InfoInput.safeParse(args)
   if (!parsed.success) {
     return {

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -13,7 +13,7 @@
  */
 
 import { z } from 'zod'
-import type { Tool } from '@modelcontextprotocol/sdk/types.js'
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import path from 'node:path'
 import fs from 'node:fs'
 import { locateDesktopApp } from '../../electron/locator.js'
@@ -71,7 +71,9 @@ export const renderSceneTool: Tool = {
   },
 }
 
-export async function handleRenderScene(args: Record<string, unknown>) {
+export async function handleRenderScene(
+  args: Record<string, unknown>,
+): Promise<CallToolResult> {
   const parsed = RenderInput.parse(args)
 
   const outputPath = path.resolve(parsed.output)


### PR DESCRIPTION
## Summary
- add explicit MCP CallToolResult return types to create_scene, info_scene, and render_scene handlers

## Verification
- cd cli && pnpm test

Labels: codex/codex-automation not added because this repository does not currently define them.