### PR TITLE
Type CLI scene appearance input

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -157,6 +157,23 @@ test('buildSceneBytes gives each node independent nested defaults', () => {
   assert.deepEqual(secondLayout.padding, { top: 0, right: 0, bottom: 0, left: 0 })
 })
 
+test('buildSceneBytes preserves per-corner radii in appearance', () => {
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  if (!root) throw new Error('missing sample root')
+  root.appearance = {
+    cornerRadius: 8,
+    cornerRadii: { tl: 4, tr: 8, br: 12, bl: 16 },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+  const appearance = nodes.root.appearance as Record<string, unknown>
+
+  assert.equal(appearance.cornerRadius, 8)
+  assert.deepEqual(appearance.cornerRadii, { tl: 4, tr: 8, br: 12, bl: 16 })
+})
+
 test('buildSceneBytes preserves explicit transform anchor and 3D mode fields', () => {
   const scene = sampleScene()
   const root = scene.nodes?.root

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -81,7 +81,7 @@ export interface NodeJson {
     space?: 'local' | 'world'
     renderMode?: 'flat' | 'plane' | 'group3d'
   }
-  appearance?: Record<string, unknown>
+  appearance?: AppearanceJson
   size?: { width: number | 'hug' | 'fill'; height: number | 'hug' | 'fill' }
   layout?: Record<string, unknown>
   variants?: unknown[]
@@ -150,6 +150,21 @@ export interface TrackJson {
   propertyId: PropertyIdJson
   defaultEasing?: EasingJson
   keyframes?: KeyframeJson[]
+}
+
+export interface AppearanceJson {
+  [key: string]: unknown
+  opacity?: number
+  fill?: unknown | null
+  stroke?: unknown | null
+  cornerRadius?: number
+  cornerRadii?: {
+    tl: number
+    tr: number
+    br: number
+    bl: number
+  }
+  effects?: unknown[]
 }
 
 export type PropertyIdJson =


### PR DESCRIPTION
## Summary
- Add an explicit CLI scene appearance input type with per-corner radii support
- Add a focused CLI authoring test that verifies per-corner radii are preserved in .hype output

## Verification
- PASS: pnpm --dir cli test
- NOTE: pnpm typecheck currently fails on existing app-wide TypeScript issues outside this change
- NOTE: pnpm lint currently fails on existing app-wide lint issues outside this change