### PR TITLE
Clarify terminal render workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,8 +375,12 @@ Or from the terminal:
 ```sh
 cat scene.json | hypermotion create ~/Desktop/calendar.hype --from -
 hypermotion info ~/Desktop/calendar.hype
-hypermotion render ~/Desktop/calendar.hype ~/Desktop/calendar.mp4 --quality 2k --fps 60
+hypermotion render -o ~/Desktop/current-scene.mp4 --quality 2k --fps 60
 ```
+
+Terminal render still targets the scene currently loaded in the desktop
+app; use `create_scene` + `render_scene` from MCP when an agent needs to
+pass a `.hype` scene path through the render request.
 
 ---
 


### PR DESCRIPTION
## Summary
- update AGENTS.md terminal workflow to use the supported current-scene render command
- note that passing a .hype scene path through render is currently MCP-only

## Tests
- pnpm --dir cli test