### PR TITLE
Clarify camera point of interest test

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -555,7 +555,7 @@ test('buildSceneBytes writes camera lens and depth defaults', () => {
   assert.equal(camera.showFocusPlane, false)
 })
 
-test('buildSceneBytes derives camera point of interest from transform', () => {
+test('buildSceneBytes derives camera point of interest x/y from transform', () => {
   const scene = sampleScene()
   const camera = scene.nodes?.camera
   if (!camera) throw new Error('missing sample camera')


### PR DESCRIPTION
## Summary
- Clarify the CLI scene builder test name so it matches the asserted camera point-of-interest behavior: X/Y are derived from transform, while Z remains separately defaulted.

## Verification
- PASS: `pnpm --dir cli test`
- NOTE: `pnpm typecheck` fails on existing app-wide TypeScript errors unrelated to this one-line CLI test description change.
- NOTE: `pnpm lint` fails on existing app-wide lint errors unrelated to this one-line CLI test description change.