### PR TITLE
Fill default media size axes in CLI scenes

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -6,6 +6,7 @@ import * as Y from 'yjs'
 import {
   buildSceneBytes,
   readSceneSummary,
+  type NodeJson,
   type SceneJson,
 } from './build.js'
 
@@ -482,6 +483,25 @@ test('buildSceneBytes writes media timing defaults', () => {
   assert.equal(nodes.clip.trimEnd, 3)
   assert.equal(nodes.clip.fit, 'cover')
   assert.equal(nodes.clip.muted, true)
+})
+
+test('buildSceneBytes fills omitted media size axes', () => {
+  const scene = sampleScene()
+  scene.nodes = {
+    clip: {
+      id: 'clip',
+      kind: 'video',
+      parent: null,
+      children: [],
+      src: '/tmp/clip.mp4',
+      size: { width: 640 } as NodeJson['size'],
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(nodes.clip.size, { width: 640, height: 100 })
 })
 
 test('buildSceneBytes preserves explicit media timing fields', () => {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -459,9 +459,12 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
       y.set('interactions', node.interactions ?? [])
     }
     if (node.kind === 'video' || node.kind === 'audio') {
+      const defaultMediaSize: SceneSize = node.kind === 'audio'
+        ? { width: 120, height: 40 }
+        : { width: 100, height: 100 }
       y.set(
         'size',
-        node.size ?? (node.kind === 'audio' ? { width: 120, height: 40 } : { width: 100, height: 100 }),
+        mergeWithDefaults(defaultMediaSize, node.size),
       )
       y.set('src', node.src ?? '')
       y.set('duration', node.duration ?? 0)


### PR DESCRIPTION
## Summary
- default missing media size axes when building CLI-authored scenes
- add a regression test for partial video size payloads

## Verification
- cd cli && pnpm test