### PR TITLE
Add CLI scene appearance corner radii type

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -282,6 +282,7 @@ interface SceneAppearance {
   fill: unknown | null
   stroke: unknown | null
   cornerRadius: number
+  cornerRadii?: AppearanceJson['cornerRadii']
   effects: unknown[]
 }
 


### PR DESCRIPTION
## Summary\n- Add the optional per-corner radius field to the CLI scene builder's internal normalized appearance type.\n- Keeps the internal type aligned with the public AppearanceJson shape and existing serialization behavior.\n\n## Tests\n- pnpm test (in cli/)\n