### PR TITLE
Allow JSON variant keyframe values

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -334,6 +334,26 @@ test('buildSceneBytes preserves variant selection keyframe values', () => {
   assert.deepEqual(keyframes[0].value, { size: 'compact', tone: 'muted' })
 })
 
+test('buildSceneBytes accepts non-string variant keyframe fields', () => {
+  const scene = sampleScene()
+  scene.tracks = {
+    variant: {
+      id: 'variant',
+      nodeId: 'title',
+      propertyId: 'variant',
+      keyframes: [
+        { id: 'k1', time: 0, value: { enabled: true, columns: 3 } },
+      ],
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const tracks = data.tracks as Record<string, Record<string, unknown>>
+  const keyframes = tracks.variant.keyframes as Array<Record<string, unknown>>
+
+  assert.deepEqual(keyframes[0].value, { enabled: true, columns: 3 })
+})
+
 test('buildSceneBytes accepts transform anchor keyframes', () => {
   const scene = sampleScene()
   scene.tracks = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -229,9 +229,21 @@ export interface KeyframeJson {
 export type KeyframeValueJson =
   | number
   | string
-  | Record<string, string>
+  | JsonObject
   | 'row'
   | 'column'
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | JsonObject
+
+interface JsonObject {
+  [key: string]: JsonValue
+}
 
 export interface SectionJson {
   id: string


### PR DESCRIPTION
## Summary
- Widen CLI keyframe value typing so variant keyframes can carry JSON object fields beyond strings
- Add a regression test covering boolean and numeric variant keyframe fields

## Verification
- pnpm test