### PR TITLE
Allow partial CLI scene sizes

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -6,7 +6,6 @@ import * as Y from 'yjs'
 import {
   buildSceneBytes,
   readSceneSummary,
-  type NodeJson,
   type SceneJson,
 } from './build.js'
 
@@ -514,7 +513,7 @@ test('buildSceneBytes fills omitted media size axes', () => {
       parent: null,
       children: [],
       src: '/tmp/clip.mp4',
-      size: { width: 640 } as NodeJson['size'],
+      size: { width: 640 },
     },
   }
 

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -54,6 +54,11 @@ export type NodeKindJson =
   | 'instance'
   | 'camera'
 
+export interface SizeJson extends Record<string, unknown> {
+  width?: number | 'hug' | 'fill'
+  height?: number | 'hug' | 'fill'
+}
+
 export interface NodeJson {
   id: string
   kind: NodeKindJson
@@ -82,7 +87,7 @@ export interface NodeJson {
     renderMode?: 'flat' | 'plane' | 'group3d'
   }
   appearance?: AppearanceJson
-  size?: { width: number | 'hug' | 'fill'; height: number | 'hug' | 'fill' }
+  size?: SizeJson
   layout?: Record<string, unknown>
   variants?: unknown[]
   defaultSelection?: Record<string, string>
@@ -282,7 +287,10 @@ type SceneTransform = NonNullable<NodeJson['transform']> & {
   renderMode: 'flat' | 'plane' | 'group3d'
 }
 
-type SceneSize = NonNullable<NodeJson['size']>
+type SceneSize = Record<string, unknown> & {
+  width: number | 'hug' | 'fill'
+  height: number | 'hug' | 'fill'
+}
 interface SceneCanvas {
   width: number
   height: number


### PR DESCRIPTION
## Summary
- add a public SizeJson type that permits omitted width or height axes
- remove the test cast now that partial media sizes typecheck directly

## Verification
- pnpm test (in cli/)