### PR TITLE
Fill default text size axes in CLI scenes

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -262,6 +262,24 @@ test('buildSceneBytes writes text defaults expected by the desktop app', () => {
   assert.equal(text.color, '#0a0a0c')
 })
 
+test('buildSceneBytes fills omitted text size axes', () => {
+  const scene = sampleScene()
+  scene.nodes = {
+    title: {
+      id: 'title',
+      kind: 'text',
+      parent: null,
+      text: 'Sized text',
+      size: { width: 320 },
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(nodes.title.size, { width: 320, height: 'hug' })
+})
+
 test('buildSceneBytes keys nodes by their declared ids', () => {
   const scene = sampleScene()
   const sceneNodes = scene.nodes ?? {}

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -500,7 +500,11 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
       }
     }
     if (node.kind === 'text') {
-      y.set('size', node.size ?? { width: 'hug', height: 'hug' })
+      const defaultTextSize: SceneSize = { width: 'hug', height: 'hug' }
+      y.set(
+        'size',
+        mergeWithDefaults(defaultTextSize, node.size),
+      )
       y.set('text', node.text ?? 'Text')
       y.set('fontFamily', node.fontFamily ?? 'Inter')
       y.set('fontSize', node.fontSize ?? 16)


### PR DESCRIPTION
## Summary
- merge partial text node sizes with hug defaults in CLI-authored scenes
- add regression coverage for a text node with only one size axis provided

## Tests
- pnpm test (in cli/)