### PR TITLE
test: cover image fit preservation

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -231,6 +231,7 @@ test('buildSceneBytes preserves image import warnings', () => {
   const data = inspectScene(buildSceneBytes(scene))
   const nodes = data.nodes as Record<string, Record<string, unknown>>
 
+  assert.equal(nodes.image.fit, 'contain')
   assert.equal(
     nodes.image.importWarning,
     'Vector fallback was preserved as a bitmap.',


### PR DESCRIPTION
## Summary\n- add a CLI scene builder assertion that image node fit values are preserved with import warnings\n\n## Tests\n- pnpm run build\n- node --test dist/scene/build.test.js\n- pnpm test