### PR TITLE
chore(cli): type camera background fill

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -640,11 +640,13 @@ test('buildSceneBytes preserves perspective camera projection', () => {
   const camera = scene.nodes?.camera
   if (!camera) throw new Error('missing sample camera')
   camera.projection = 'perspective'
+  camera.background = { kind: 'solid', color: '#111827' }
 
   const data = inspectScene(buildSceneBytes(scene))
   const nodes = data.nodes as Record<string, Record<string, unknown>>
 
   assert.equal(nodes.camera.projection, 'perspective')
+  assert.deepEqual(nodes.camera.background, { kind: 'solid', color: '#111827' })
 })
 
 test('buildSceneBytes respects explicit root and active camera ids', () => {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -59,6 +59,34 @@ export interface SizeJson extends Record<string, unknown> {
   height?: number | 'hug' | 'fill'
 }
 
+export interface GradientStopJson {
+  at: number
+  color: string
+}
+
+export type FillJson =
+  | { kind: 'solid'; color: string }
+  | { kind: 'linear'; stops: GradientStopJson[]; angle: number }
+  | {
+      kind: 'radial'
+      stops: GradientStopJson[]
+      cx: number
+      cy: number
+      shape: 'circle' | 'ellipse'
+    }
+  | {
+      kind: 'conic'
+      stops: GradientStopJson[]
+      angle: number
+      cx: number
+      cy: number
+    }
+  | {
+      kind: 'image'
+      src: string
+      fit: 'cover' | 'contain' | 'fill' | 'tile'
+    }
+
 export interface LayoutJson extends Record<string, unknown> {
   mode?: 'none' | 'flex' | 'grid'
   direction?: 'row' | 'column'
@@ -136,7 +164,7 @@ export interface NodeJson {
   muted?: boolean
   projection?: '2d' | 'perspective'
   enabled?: boolean
-  background?: unknown
+  background?: FillJson | null
   focalLength?: number
   fieldOfView?: number
   pointOfInterestX?: number


### PR DESCRIPTION
## Summary
- add a narrow CLI JSON fill type for scene-authored camera backgrounds
- cover camera background preservation in the existing scene builder test

## Tests
- pnpm test