### PR TITLE
Allow null CLI keyframe values

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -378,6 +378,26 @@ test('buildSceneBytes preserves variant selection keyframe values', () => {
   assert.deepEqual(keyframes[0].value, { size: 'compact', tone: 'muted' })
 })
 
+test('buildSceneBytes accepts null keyframe values', () => {
+  const scene = sampleScene()
+  scene.tracks = {
+    clearFill: {
+      id: 'clearFill',
+      nodeId: 'title',
+      propertyId: 'appearance.fill',
+      keyframes: [
+        { id: 'k1', time: 0, value: null },
+      ],
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const tracks = data.tracks as Record<string, Record<string, unknown>>
+  const keyframes = tracks.clearFill.keyframes as Array<Record<string, unknown>>
+
+  assert.equal(keyframes[0].value, null)
+})
+
 test('buildSceneBytes accepts non-string variant keyframe fields', () => {
   const scene = sampleScene()
   scene.tracks = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -275,6 +275,7 @@ export interface KeyframeJson {
 export type KeyframeValueJson =
   | number
   | string
+  | null
   | JsonObject
   | 'row'
   | 'column'


### PR DESCRIPTION
## Summary
- Allow CLI-authored keyframes to use null values, matching properties such as appearance.fill
- Add a focused scene-builder round-trip test for null keyframe values

## Tests
- pnpm --dir cli test