### PR TITLE
docs(cli): list supported scene keyframe properties

### DIFF
--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -62,11 +62,13 @@ export const createSceneTool: Tool = {
     "blurQuality, and showFocusPlane.\n" +
     "Property IDs you can keyframe: transform.x, transform.y, transform.z, transform.rotation, " +
     "transform.rotationX, transform.rotationY, transform.scaleX, transform.scaleY, " +
+    "transform.anchorX, transform.anchorY, transform.anchorZ, " +
     "camera.focusWorldX, camera.focusWorldY, camera.focusWorldZ, camera.focusDistance, camera.focusRadius, camera.focusFalloff, " +
     "camera.pointOfInterestX, camera.pointOfInterestY, camera.pointOfInterestZ, " +
     "camera.focalLength, camera.fieldOfView, camera.nearClip, camera.farClip, " +
     "camera.aperture, camera.blurLevel, camera.blurQuality, " +
-    "appearance.opacity, appearance.cornerRadius, layout.gap, layout.padding.top, " +
+    "appearance.opacity, appearance.cornerRadius, appearance.cornerRadii.tl, appearance.cornerRadii.tr, " +
+    "appearance.cornerRadii.br, appearance.cornerRadii.bl, layout.gap, layout.padding.top, " +
     "layout.padding.right, layout.padding.bottom, layout.padding.left, size.width, size.height, " +
     "layout.direction, variant.\n\n" +
     "Include a 'camera' kind node (parent: null) plus a 'frame' kind root (parent: null) for the " +


### PR DESCRIPTION
## Summary\n- Update the create_scene MCP tool description to include transform anchor and per-corner radius keyframe property IDs already supported by the schema.\n\n## Tests\n- pnpm --dir cli test