### PR TITLE
chore(cli): type scene stroke input

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -87,6 +87,24 @@ export type FillJson =
       fit: 'cover' | 'contain' | 'fill' | 'tile'
     }
 
+export type StrokeStyleJson = 'solid' | 'dashed' | 'dotted'
+
+export interface StrokeJson {
+  color: string
+  width: number
+  align: 'inside' | 'center' | 'outside'
+  style: StrokeStyleJson
+  dashLength: number
+  dashGap: number
+  widths?: {
+    top: number
+    right: number
+    bottom: number
+    left: number
+  }
+  fill?: FillJson | null
+}
+
 export interface LayoutJson extends Record<string, unknown> {
   mode?: 'none' | 'flex' | 'grid'
   direction?: 'row' | 'column'
@@ -202,7 +220,7 @@ export interface AppearanceJson {
   [key: string]: unknown
   opacity?: number
   fill?: unknown | null
-  stroke?: unknown | null
+  stroke?: StrokeJson | null
   cornerRadius?: number
   cornerRadii?: {
     tl: number


### PR DESCRIPTION
## Summary
- add a typed CLI scene stroke input shape matching the desktop scene stroke schema
- narrow AppearanceJson.stroke from unknown to StrokeJson | null

## Tests
- pnpm test (cli)