### PR TITLE
Add CLI media fit type alias

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -89,6 +89,8 @@ export type FillJson =
 
 export type StrokeStyleJson = 'solid' | 'dashed' | 'dotted'
 
+export type MediaFitJson = 'cover' | 'contain' | 'fill' | 'none'
+
 export interface StrokeJson {
   color: string
   width: number
@@ -171,7 +173,7 @@ export interface NodeJson {
   textAlign?: TextAlignJson
   color?: string
   src?: string
-  fit?: 'cover' | 'contain' | 'fill' | 'none'
+  fit?: MediaFitJson
   importWarning?: string
   duration?: number
   volume?: number


### PR DESCRIPTION
## Summary
- Add a shared exported MediaFitJson alias for CLI image/video node fit values.
- Use the alias from NodeJson so the CLI scene schema has one named media-fit surface.

## Verification
- pnpm --dir cli test