### PR TITLE
chore(cli): type variant transitions

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -155,7 +155,7 @@ export interface NodeJson {
   variantOverrides?: unknown[]
   variantPositions?: Record<string, { x: number; y: number }>
   componentProperties?: unknown[]
-  variantTransition?: unknown
+  variantTransition?: VariantTransitionJson
   timelines?: Record<string, unknown>
   interactions?: unknown[]
   componentId?: string
@@ -287,6 +287,13 @@ export type EasingJson =
   | 'ease-in-out'
   | { bezier: [number, number, number, number] }
   | { spring: { stiffness: number; damping: number; mass: number } }
+
+export interface VariantTransitionJson {
+  duration: number
+  easing: EasingJson
+  presetId?: string
+  strength?: number
+}
 
 export interface KeyframeJson {
   id: string


### PR DESCRIPTION
## Summary
- add a typed CLI scene schema shape for component variant transitions
- keep the existing default transition behavior unchanged

## Tests
- pnpm --dir cli test

## Notes
- Root `pnpm run typecheck` and `pnpm run lint` currently fail on pre-existing app-wide issues outside this CLI-only change.