### PR TITLE
test(cli): cover inferred scene root and camera

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -325,6 +325,20 @@ test('buildSceneBytes keys nodes by their declared ids', () => {
   assert.equal(data.activeCameraId, 'camera')
 })
 
+test('buildSceneBytes infers root and active camera when omitted', () => {
+  const scene = sampleScene()
+  delete scene.root
+  delete scene.activeCameraId
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const summary = readSceneSummary(buildSceneBytes(scene))
+
+  assert.equal(data.root, 'root')
+  assert.equal(data.activeCameraId, 'camera')
+  assert.equal(summary.root, 'root')
+  assert.equal(summary.activeCameraId, 'camera')
+})
+
 test('buildSceneBytes keys tracks by their declared ids', () => {
   const scene = sampleScene()
   const sceneTracks = scene.tracks ?? {}


### PR DESCRIPTION
## Summary
- add focused CLI scene-builder coverage for omitted root and activeCameraId fields
- assert both raw decoded scene data and readSceneSummary report inferred values

## Tests
- pnpm test (in cli/)