### PR TITLE
Tighten CLI appearance fill type

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -221,7 +221,7 @@ export interface TrackJson {
 export interface AppearanceJson {
   [key: string]: unknown
   opacity?: number
-  fill?: unknown | null
+  fill?: FillJson | null
   stroke?: StrokeJson | null
   cornerRadius?: number
   cornerRadii?: {


### PR DESCRIPTION
## Summary
- Narrow CLI scene appearance fill input from unknown to the existing FillJson union

## Verification
- pnpm test (in cli/) ✅
- pnpm run typecheck (root) ❌ pre-existing unrelated app-wide TypeScript errors; CLI build/typecheck passed as part of pnpm test

Mergify should merge this automatically when checks pass.