### PR TITLE
docs(cli): list screen focus keyframes

### DIFF
--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -63,7 +63,8 @@ export const createSceneTool: Tool = {
     "Property IDs you can keyframe: transform.x, transform.y, transform.z, transform.rotation, " +
     "transform.rotationX, transform.rotationY, transform.scaleX, transform.scaleY, " +
     "transform.anchorX, transform.anchorY, transform.anchorZ, " +
-    "camera.focusWorldX, camera.focusWorldY, camera.focusWorldZ, camera.focusDistance, camera.focusRadius, camera.focusFalloff, " +
+    "camera.focusX, camera.focusY, camera.focusWorldX, camera.focusWorldY, camera.focusWorldZ, " +
+    "camera.focusDistance, camera.focusRadius, camera.focusFalloff, " +
     "camera.pointOfInterestX, camera.pointOfInterestY, camera.pointOfInterestZ, " +
     "camera.focalLength, camera.fieldOfView, camera.nearClip, camera.farClip, " +
     "camera.aperture, camera.blurLevel, camera.blurQuality, " +


### PR DESCRIPTION
## Summary\n- Add camera.focusX and camera.focusY to the create_scene MCP keyframe property list.\n- Keep the tool description aligned with the existing CLI SceneJson type.\n\n## Tests\n- pnpm --dir cli test