### PR TITLE
Clarify MCP create_scene follow-up text

### DIFF
--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -203,7 +203,7 @@ export async function handleCreateScene(
         type: 'text' as const,
         text:
           `Wrote ${outputPath} (${formatBytes(bytes.length)}, ${layers} layer${layers === 1 ? '' : 's'}, ${tracks} track${tracks === 1 ? '' : 's'}). ` +
-          `Pass this path to render_scene to produce an MP4 / WebM / GIF, or open it in the desktop app for hand-editing.`,
+          `Open it in the desktop app for hand-editing or rendering to MP4 / WebM / GIF.`,
       },
     ],
   }


### PR DESCRIPTION
## Summary
- Clarifies the create_scene MCP success text so it tells users to open the generated .hype file in the desktop app for hand-editing or rendering.
- Avoids implying render_scene directly renders the newly created file when the current headless path still renders the desktop scene.

## Verification
- pnpm test (from cli/)