### PR TITLE
test(cli): clean up info command temp dir

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -11,46 +11,50 @@ import { buildSceneBytes, type SceneSummary } from '../scene/build.js'
 test('info command prints JSON scene summaries', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
   const scenePath = path.join(dir, 'scene.hype')
-  fs.writeFileSync(
-    scenePath,
-    buildSceneBytes({
-      meta: {
-        name: 'Info JSON',
-        duration: 1.5,
-        frameRate: 24,
-        canvas: { width: 320, height: 180 },
-      },
-      nodes: {
-        root: {
-          id: 'root',
-          kind: 'frame',
-          parent: null,
-          children: [],
-          size: { width: 320, height: 180 },
-          layout: { mode: 'none' },
-        },
-      },
-    }),
-  )
-
-  let stdout = ''
-  const write = process.stdout.write
-  process.stdout.write = ((value: string | Uint8Array) => {
-    stdout += value.toString()
-    return true
-  }) as typeof process.stdout.write
   try {
-    await infoCommand()
-      .exitOverride()
-      .parseAsync([scenePath, '--json'], { from: 'user' })
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Info JSON',
+          duration: 1.5,
+          frameRate: 24,
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    let stdout = ''
+    const write = process.stdout.write
+    process.stdout.write = ((value: string | Uint8Array) => {
+      stdout += value.toString()
+      return true
+    }) as typeof process.stdout.write
+    try {
+      await infoCommand()
+        .exitOverride()
+        .parseAsync([scenePath, '--json'], { from: 'user' })
+    } finally {
+      process.stdout.write = write
+    }
+
+    const summary = JSON.parse(stdout) as SceneSummary
+
+    assert.equal(summary.meta.name, 'Info JSON')
+    assert.deepEqual(summary.meta.canvas, { width: 320, height: 180 })
+    assert.equal(summary.layerCount, 1)
+    assert.equal(summary.root, 'root')
   } finally {
-    process.stdout.write = write
+    fs.rmSync(dir, { recursive: true, force: true })
   }
-
-  const summary = JSON.parse(stdout) as SceneSummary
-
-  assert.equal(summary.meta.name, 'Info JSON')
-  assert.deepEqual(summary.meta.canvas, { width: 320, height: 180 })
-  assert.equal(summary.layerCount, 1)
-  assert.equal(summary.root, 'root')
 })


### PR DESCRIPTION
## Summary
- clean up the temporary directory created by the CLI info command test
- keep stdout restoration inside its existing finally block

## Verification
- pnpm --dir cli test

## Notes
- Attempted root `pnpm typecheck && pnpm lint`, but root typecheck currently fails on unrelated existing app/export/UI TypeScript errors before lint runs.