### PR TITLE
test(cli): cover human-readable info output

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -58,3 +58,67 @@ test('info command prints JSON scene summaries', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('info command prints human-readable scene summaries', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Info Text',
+          duration: 2,
+          frameRate: 30,
+          canvas: { width: 640, height: 360 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 640, height: 360 },
+            layout: { mode: 'none' },
+          },
+          camera: {
+            id: 'camera',
+            kind: 'camera',
+            parent: null,
+            transform: {
+              x: 320,
+              y: 180,
+              z: 0,
+              rotation: 0,
+              scaleX: 1,
+              scaleY: 1,
+            },
+          },
+        },
+      }),
+    )
+
+    let stdout = ''
+    const write = process.stdout.write
+    process.stdout.write = ((value: string | Uint8Array) => {
+      stdout += value.toString()
+      return true
+    }) as typeof process.stdout.write
+    try {
+      await infoCommand().exitOverride().parseAsync([scenePath], {
+        from: 'user',
+      })
+    } finally {
+      process.stdout.write = write
+    }
+
+    assert.match(stdout, /^Scene: Info Text$/m)
+    assert.match(stdout, /^  Canvas:    640 × 360$/m)
+    assert.match(stdout, /^  Duration:  2s @ 30fps$/m)
+    assert.match(stdout, /^  Layers:    2$/m)
+    assert.match(stdout, /^  Root id:   root$/m)
+    assert.match(stdout, /^  Camera id: camera$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary\n- add CLI coverage for the default human-readable `hypermotion info` output\n- assert the key scene metadata, layer, root, and camera lines\n\n## Tests\n- `pnpm test` from `cli/`