### PR TITLE
Deep merge scene metadata defaults

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -120,6 +120,29 @@ test('buildSceneBytes fills default metadata for minimal scenes', () => {
   assert.equal(summary.activeCameraId, null)
 })
 
+test('buildSceneBytes deep-merges partial metadata defaults', () => {
+  const bytes = buildSceneBytes({
+    meta: {
+      name: 'Partial canvas',
+      canvas: { width: 1080 },
+    } as SceneJson['meta'],
+    nodes: {
+      root: {
+        id: 'root',
+        kind: 'frame',
+        parent: null,
+        children: [],
+        size: { width: 1080, height: 540 },
+        layout: { mode: 'none' },
+      },
+    },
+  })
+  const summary = readSceneSummary(bytes)
+
+  assert.equal(summary.meta.name, 'Partial canvas')
+  assert.deepEqual(summary.meta.canvas, { width: 1080, height: 540 })
+})
+
 test('buildSceneBytes fills nested defaults expected by the desktop app', () => {
   const data = inspectScene(buildSceneBytes(sampleScene()))
   const nodes = data.nodes as Record<string, Record<string, unknown>>

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -546,7 +546,7 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
   // --- meta ---
   const meta = new Y.Map<unknown>()
   scene.set('meta', meta)
-  const metaIn = { ...DEFAULT_META, ...(json.meta ?? {}) }
+  const metaIn = mergeWithDefaults(DEFAULT_META, json.meta)
   for (const [k, v] of Object.entries(metaIn)) meta.set(k, v)
 
   // --- nodes ---


### PR DESCRIPTION
## Summary
- deep-merge scene metadata defaults in the CLI builder so partial nested metadata keeps default canvas fields
- add a focused regression test for partial canvas metadata

## Tests
- pnpm test