### PR TITLE
docs(cli): align Claude MCP registration scope

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -54,7 +54,7 @@ desktop app's current scene.
 ### Claude Code
 
 ```sh
-claude mcp add hypermotion -- hypermotion-mcp
+claude mcp add -s user hypermotion -- hypermotion-mcp
 ```
 
 Then in Claude Code, the agent has access to:


### PR DESCRIPTION
## Summary
- Align the CLI README Claude MCP registration command with the canonical user-scope command in AGENTS.md.

## Verification
- pnpm --dir cli test

Ready for review.