### PR TITLE
Share CLI stdout capture test helper

### DIFF
--- a/cli/src/commands/create.test.ts
+++ b/cli/src/commands/create.test.ts
@@ -7,21 +7,7 @@ import path from 'node:path'
 import test from 'node:test'
 import { createCommand } from './create.js'
 import { readSceneSummary } from '../scene/build.js'
-
-async function captureStdout(run: () => Promise<void>): Promise<string> {
-  let stdout = ''
-  const write = process.stdout.write
-  process.stdout.write = ((value: string | Uint8Array) => {
-    stdout += value.toString()
-    return true
-  }) as typeof process.stdout.write
-  try {
-    await run()
-  } finally {
-    process.stdout.write = write
-  }
-  return stdout
-}
+import { captureStdout } from '../testUtils/stdout.js'
 
 test('create command makes nested output directories', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-create-'))

--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -7,21 +7,7 @@ import path from 'node:path'
 import test from 'node:test'
 import { infoCommand } from './info.js'
 import { buildSceneBytes, type SceneSummary } from '../scene/build.js'
-
-async function captureStdout(run: () => Promise<void>): Promise<string> {
-  let stdout = ''
-  const write = process.stdout.write
-  process.stdout.write = ((value: string | Uint8Array) => {
-    stdout += value.toString()
-    return true
-  }) as typeof process.stdout.write
-  try {
-    await run()
-  } finally {
-    process.stdout.write = write
-  }
-  return stdout
-}
+import { captureStdout } from '../testUtils/stdout.js'
 
 test('info command prints JSON scene summaries', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))

--- a/cli/src/testUtils/stdout.ts
+++ b/cli/src/testUtils/stdout.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export async function captureStdout(run: () => Promise<void>): Promise<string> {
+  let stdout = ''
+  const write = process.stdout.write
+  process.stdout.write = ((value: string | Uint8Array) => {
+    stdout += value.toString()
+    return true
+  }) as typeof process.stdout.write
+  try {
+    await run()
+  } finally {
+    process.stdout.write = write
+  }
+  return stdout
+}


### PR DESCRIPTION
## Summary
- Extract the duplicated CLI test stdout capture helper into a shared test utility.
- Update create/info command tests to use the shared helper.

## Tests
- pnpm test (from cli/)