### PR TITLE
Add aggregate corner radii CLI property type

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -514,6 +514,29 @@ test('buildSceneBytes accepts per-corner radius keyframes', () => {
   assert.equal(readSceneSummary(buildSceneBytes(scene)).keyframeCount, 2)
 })
 
+test('buildSceneBytes accepts aggregate corner radii keyframes', () => {
+  const scene = sampleScene()
+  scene.tracks = {
+    corners: {
+      id: 'corners',
+      nodeId: 'root',
+      propertyId: 'appearance.cornerRadii',
+      keyframes: [
+        { id: 'k1', time: 0, value: { tl: 4, tr: 4, br: 4, bl: 4 } },
+        { id: 'k2', time: 1, value: { tl: 4, tr: 8, br: 12, bl: 16 } },
+      ],
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const tracks = data.tracks as Record<string, Record<string, unknown>>
+  const keyframes = tracks.corners.keyframes as Array<Record<string, unknown>>
+
+  assert.equal(tracks.corners.propertyId, 'appearance.cornerRadii')
+  assert.deepEqual(keyframes[1].value, { tl: 4, tr: 8, br: 12, bl: 16 })
+  assert.equal(readSceneSummary(buildSceneBytes(scene)).keyframeCount, 2)
+})
+
 test('buildSceneBytes keys sections by their declared ids', () => {
   const scene = sampleScene()
   const sceneSections = scene.sections ?? {}

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -265,6 +265,7 @@ export type PropertyIdJson =
   | 'camera.blurQuality'
   | 'appearance.opacity'
   | 'appearance.cornerRadius'
+  | 'appearance.cornerRadii'
   | 'appearance.cornerRadii.tl'
   | 'appearance.cornerRadii.tr'
   | 'appearance.cornerRadii.br'


### PR DESCRIPTION
## Summary
- Add aggregate `appearance.cornerRadii` to the CLI scene builder property ID type
- Cover aggregate corner radii keyframes in the CLI scene builder tests

## Verification
- `pnpm test` in `cli/`

Note: root `pnpm typecheck` currently fails on unrelated app-level type errors outside the CLI package.