### PR TITLE
Preserve stdout callbacks in CLI tests

### DIFF
--- a/cli/src/testUtils/stdout.ts
+++ b/cli/src/testUtils/stdout.ts
@@ -3,8 +3,15 @@
 export async function captureStdout(run: () => Promise<void>): Promise<string> {
   let stdout = ''
   const write = process.stdout.write
-  process.stdout.write = ((value: string | Uint8Array) => {
+  process.stdout.write = ((
+    value: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((err?: Error) => void),
+    callback?: (err?: Error) => void,
+  ) => {
     stdout += value.toString()
+    const done =
+      typeof encodingOrCallback === 'function' ? encodingOrCallback : callback
+    done?.()
     return true
   }) as typeof process.stdout.write
   try {


### PR DESCRIPTION
## Summary
- Preserve optional process.stdout.write callbacks in the CLI stdout capture test helper
- Keep the existing stdout mocking behavior for command tests

## Tests
- pnpm test (from cli/)