### PR TITLE
Test image fill scene serialization

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -223,6 +223,31 @@ test('buildSceneBytes preserves per-corner radii in appearance', () => {
   assert.deepEqual(appearance.cornerRadii, { tl: 4, tr: 8, br: 12, bl: 16 })
 })
 
+test('buildSceneBytes preserves image fills in appearance', () => {
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  if (!root) throw new Error('missing sample root')
+  root.appearance = {
+    fill: {
+      kind: 'image',
+      src: '/tmp/texture.png',
+      fit: 'tile',
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+  const appearance = nodes.root.appearance as Record<string, unknown>
+
+  assert.deepEqual(appearance.fill, {
+    kind: 'image',
+    src: '/tmp/texture.png',
+    fit: 'tile',
+  })
+  assert.equal(appearance.opacity, 1)
+  assert.equal(appearance.cornerRadius, 0)
+})
+
 test('buildSceneBytes preserves explicit transform anchor and 3D mode fields', () => {
   const scene = sampleScene()
   const root = scene.nodes?.root


### PR DESCRIPTION
## Summary
- Add CLI scene builder coverage for authored image fills in node appearance.
- Assert default appearance fields still deep-merge around the image fill.

## Verification
- PASS: `cd cli && pnpm install --frozen-lockfile && pnpm test`
- NOTE: root `pnpm typecheck` fails on existing app TypeScript errors unrelated to this CLI test-only change, including missing `SceneNode` exports and `NodeBaseMutable` key mismatches.