### PR TITLE
test: assert default node visibility in scene builder

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -167,6 +167,7 @@ test('buildSceneBytes fills nested defaults expected by the desktop app', () => 
     cornerRadius: 0,
     effects: [],
   })
+  assert.equal(root.visible, true)
   assert.deepEqual(nodes.title.size, { width: 'hug', height: 'hug' })
   assert.equal(nodes.title.fontFamily, 'Inter')
   assert.equal(nodes.title.fontWeight, 400)


### PR DESCRIPTION
## Summary
- add a focused CLI scene builder assertion for the default node visibility persisted into .hype files

## Verification
- pnpm test