### PR TITLE
List supported MCP appearance property ids

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -6,7 +6,16 @@ import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { readSceneSummary } from '../scene/build.js'
-import { handleCreateScene } from './tools/createScene.js'
+import { createSceneTool, handleCreateScene } from './tools/createScene.js'
+
+test('create_scene description lists supported appearance property ids', () => {
+  const description = createSceneTool.description
+  if (typeof description !== 'string') {
+    throw new Error('create_scene description is missing')
+  }
+  assert.match(description, /appearance\.fill/)
+  assert.match(description, /appearance\.cornerRadii,/)
+})
 
 test('create_scene reports persisted layer and track counts', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-create-'))

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -68,8 +68,9 @@ export const createSceneTool: Tool = {
     "camera.pointOfInterestX, camera.pointOfInterestY, camera.pointOfInterestZ, " +
     "camera.focalLength, camera.fieldOfView, camera.nearClip, camera.farClip, " +
     "camera.aperture, camera.blurLevel, camera.blurQuality, " +
-    "appearance.opacity, appearance.cornerRadius, appearance.cornerRadii.tl, appearance.cornerRadii.tr, " +
-    "appearance.cornerRadii.br, appearance.cornerRadii.bl, layout.gap, layout.padding.top, " +
+    "appearance.opacity, appearance.cornerRadius, appearance.cornerRadii, " +
+    "appearance.cornerRadii.tl, appearance.cornerRadii.tr, appearance.cornerRadii.br, " +
+    "appearance.cornerRadii.bl, appearance.fill, layout.gap, layout.padding.top, " +
     "layout.padding.right, layout.padding.bottom, layout.padding.left, size.width, size.height, " +
     "layout.direction, variant.\n\n" +
     "Include a 'camera' kind node (parent: null) plus a 'frame' kind root (parent: null) for the " +


### PR DESCRIPTION
## Summary\n- add missing supported appearance property ids to the create_scene MCP tool description\n- cover the advertised appearance property ids with a focused MCP test\n\n## Tests\n- pnpm test (in cli/)