### PR TITLE
Clarify CLI scene path driver comment

### DIFF
--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -33,7 +33,7 @@ export interface HeadlessRenderRequest {
   format: 'mp4' | 'webm' | 'gif'
   quality: 'comp' | '720p' | '2k' | '4k'
   fps: number
-  /** Optional file-based scene to render instead of the current editor scene. */
+  /** Optional .hype scene path to forward to compatible desktop builds. */
   scenePath?: string
 }
 


### PR DESCRIPTION
## Summary\n- Clarifies the CLI headless render request comment for scene paths so it describes forwarding the path to compatible desktop builds.\n\n## Tests\n- pnpm --dir cli test