### PR TITLE
test: cover create_scene appearance property ids

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -13,8 +13,19 @@ test('create_scene description lists supported appearance property ids', () => {
   if (typeof description !== 'string') {
     throw new Error('create_scene description is missing')
   }
-  assert.match(description, /appearance\.fill/)
-  assert.match(description, /appearance\.cornerRadii,/)
+  for (const propertyId of [
+    'appearance.opacity',
+    'appearance.cornerRadius',
+    'appearance.cornerRadii',
+    'appearance.cornerRadii.tl',
+    'appearance.cornerRadii.tr',
+    'appearance.cornerRadii.br',
+    'appearance.cornerRadii.bl',
+    'appearance.fill',
+  ]) {
+    const escapedPropertyId = propertyId.replaceAll('.', '\\.')
+    assert.match(description, new RegExp(`${escapedPropertyId}(?:,|\\.)`))
+  }
 })
 
 test('create_scene reports persisted layer and track counts', async () => {


### PR DESCRIPTION
## Summary
- Expand the create_scene MCP description test to cover every supported appearance property id in the tool description.

## Tests
- pnpm --dir cli test