### PR TITLE
test: cover camera point-of-interest tracks

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -519,6 +519,27 @@ test('buildSceneBytes accepts transform anchor keyframes', () => {
   assert.equal(readSceneSummary(buildSceneBytes(scene)).keyframeCount, 2)
 })
 
+test('buildSceneBytes accepts camera point-of-interest keyframes', () => {
+  const scene = sampleScene()
+  scene.tracks = {
+    poi: {
+      id: 'poi',
+      nodeId: 'camera',
+      propertyId: 'camera.pointOfInterestZ',
+      keyframes: [
+        { id: 'k1', time: 0, value: 0 },
+        { id: 'k2', time: 1, value: 120 },
+      ],
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const tracks = data.tracks as Record<string, Record<string, unknown>>
+
+  assert.equal(tracks.poi.propertyId, 'camera.pointOfInterestZ')
+  assert.equal(readSceneSummary(buildSceneBytes(scene)).keyframeCount, 2)
+})
+
 test('buildSceneBytes accepts layout direction keyframes', () => {
   const scene = sampleScene()
   scene.tracks = {


### PR DESCRIPTION
## Summary\n- add CLI scene-builder coverage for camera point-of-interest animation tracks\n- verify the generated scene summary still counts persisted keyframes\n\n## Tests\n- pnpm --dir cli test