### PR TITLE
test: cover info output without camera

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -144,3 +144,41 @@ test('info command prints human-readable scene summaries', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('info command omits camera line when no active camera exists', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'No Camera',
+          canvas: { width: 400, height: 300 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 400, height: 300 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await infoCommand().exitOverride().parseAsync([scenePath], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^Scene: No Camera$/m)
+    assert.match(stdout, /^ {2}Root id: {3}root$/m)
+    assert.doesNotMatch(stdout, /^ {2}Camera id:/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary\n- add CLI info command coverage for scenes without an active camera\n- verify the human-readable summary omits the camera line in that case\n\n## Tests\n- pnpm --dir cli test