### PR TITLE
test(cli): cover camera iso tracks

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -540,6 +540,27 @@ test('buildSceneBytes accepts camera point-of-interest keyframes', () => {
   assert.equal(readSceneSummary(buildSceneBytes(scene)).keyframeCount, 2)
 })
 
+test('buildSceneBytes accepts camera ISO keyframes', () => {
+  const scene = sampleScene()
+  scene.tracks = {
+    iso: {
+      id: 'iso',
+      nodeId: 'camera',
+      propertyId: 'camera.iso',
+      keyframes: [
+        { id: 'k1', time: 0, value: 100 },
+        { id: 'k2', time: 1, value: 400 },
+      ],
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const tracks = data.tracks as Record<string, Record<string, unknown>>
+
+  assert.equal(tracks.iso.propertyId, 'camera.iso')
+  assert.equal(readSceneSummary(buildSceneBytes(scene)).keyframeCount, 2)
+})
+
 test('buildSceneBytes accepts layout direction keyframes', () => {
   const scene = sampleScene()
   scene.tracks = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -268,6 +268,7 @@ export type PropertyIdJson =
   | 'camera.nearClip'
   | 'camera.farClip'
   | 'camera.aperture'
+  | 'camera.iso'
   | 'camera.blurLevel'
   | 'camera.blurQuality'
   | 'appearance.opacity'


### PR DESCRIPTION
## Summary\n- allow CLI scene typings to accept camera ISO animation tracks\n- add a focused round-trip test for camera.iso tracks\n\n## Tests\n- pnpm test