### PR TITLE
test: cover camera focus MCP property ids

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -34,6 +34,17 @@ test('create_scene description lists supported camera property ids', () => {
     throw new Error('create_scene description is missing')
   }
   for (const propertyId of [
+    'camera.focusX',
+    'camera.focusY',
+    'camera.focusWorldX',
+    'camera.focusWorldY',
+    'camera.focusWorldZ',
+    'camera.focusDistance',
+    'camera.focusRadius',
+    'camera.focusFalloff',
+    'camera.pointOfInterestX',
+    'camera.pointOfInterestY',
+    'camera.pointOfInterestZ',
     'camera.focalLength',
     'camera.fieldOfView',
     'camera.nearClip',


### PR DESCRIPTION
## Summary
- Extend the create_scene MCP description test to assert advertised camera focus and point-of-interest property ids.

## Verification
- pnpm --dir cli test