### PR TITLE
docs(cli): clarify MCP registration scope

### DIFF
--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -18,7 +18,7 @@
  *
  * To wire into Claude Code, the user runs:
  *
- *   claude mcp add hypermotion -- hypermotion-mcp
+ *   claude mcp add -s user hypermotion -- hypermotion-mcp
  *
  * To wire into Codex CLI, they add to ~/.codex/config.toml:
  *


### PR DESCRIPTION
## Summary
- align the MCP server Claude Code registration example with the documented user-scoped command

## Verification
- pnpm test (in cli/)