### PR TITLE
Add camera ISO animation property

### DIFF
--- a/src/anim/engine.ts
+++ b/src/anim/engine.ts
@@ -88,6 +88,7 @@ export interface AnimatedValue {
   nearClip?: number
   farClip?: number
   aperture?: number
+  iso?: number
   blurLevel?: number
   blurQuality?: number
 }
@@ -445,6 +446,9 @@ function writeProperty(
       break
     case 'camera.aperture':
       into.aperture = value
+      break
+    case 'camera.iso':
+      into.iso = value
       break
     case 'camera.blurLevel':
       into.blurLevel = value

--- a/src/anim/recordKeyframes.ts
+++ b/src/anim/recordKeyframes.ts
@@ -75,6 +75,7 @@ const CAMERA_PROP_IDS: Partial<Record<string, PropertyId>> = {
   nearClip: 'camera.nearClip',
   farClip: 'camera.farClip',
   aperture: 'camera.aperture',
+  iso: 'camera.iso',
   blurLevel: 'camera.blurLevel',
   blurQuality: 'camera.blurQuality',
 }

--- a/src/interaction/componentRuntime.ts
+++ b/src/interaction/componentRuntime.ts
@@ -356,6 +356,7 @@ function writeProperty(
     case 'camera.nearClip': into.nearClip = value; break
     case 'camera.farClip': into.farClip = value; break
     case 'camera.aperture': into.aperture = value; break
+    case 'camera.iso': into.iso = value; break
     case 'camera.blurLevel': into.blurLevel = value; break
     case 'camera.blurQuality': into.blurQuality = value; break
     default: break

--- a/src/scene/props.ts
+++ b/src/scene/props.ts
@@ -147,6 +147,10 @@ export const PROPERTIES: Record<PropertyId, PropertyDescriptor> = {
     id: 'camera.aperture', group: 'camera', label: 'Aperture',
     layoutAffecting: false, interpolation: 'numeric', defaultValue: 0,
   },
+  'camera.iso': {
+    id: 'camera.iso', group: 'camera', label: 'ISO',
+    layoutAffecting: false, interpolation: 'numeric', defaultValue: 100,
+  },
   'camera.blurLevel': {
     id: 'camera.blurLevel', group: 'camera', label: 'Blur Level',
     layoutAffecting: false, interpolation: 'numeric', defaultValue: 1,

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -882,6 +882,7 @@ export type PropertyId =
   | 'camera.nearClip'
   | 'camera.farClip'
   | 'camera.aperture'
+  | 'camera.iso'
   | 'camera.blurLevel'
   | 'camera.blurQuality'
   // appearance group — post-layout, cheap


### PR DESCRIPTION
## Summary\n- register camera.iso in the desktop animation property registry\n- allow record mode, component timelines, and the animation engine to write ISO animation values\n- align desktop property support with existing CLI/MCP camera.iso scene authoring coverage\n\n## Verification\n- pnpm exec eslint src/scene/types.ts src/scene/props.ts src/anim/recordKeyframes.ts src/anim/engine.ts src/interaction/componentRuntime.ts\n- (cd cli && pnpm install --frozen-lockfile && pnpm test)\n\nNote: full `pnpm typecheck` is currently blocked by pre-existing repository errors outside this change.