### PR TITLE
Allow clearing CLI active camera

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -388,6 +388,15 @@ test('buildSceneBytes infers root and active camera when omitted', () => {
   assert.equal(summary.activeCameraId, 'camera')
 })
 
+test('buildSceneBytes preserves an explicitly cleared active camera', () => {
+  const scene = sampleScene()
+  scene.activeCameraId = null
+
+  const summary = readSceneSummary(buildSceneBytes(scene))
+
+  assert.equal(summary.activeCameraId, null)
+})
+
 test('buildSceneBytes keys tracks by their declared ids', () => {
   const scene = sampleScene()
   const sceneTracks = scene.tracks ?? {}

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -34,7 +34,7 @@ export interface SceneJson {
     canvas?: Partial<SceneCanvas>
   }
   root?: string
-  activeCameraId?: string
+  activeCameraId?: string | null
   nodes?: Record<string, NodeJson>
   tracks?: Record<string, TrackJson>
   sections?: Record<string, SectionJson>
@@ -750,7 +750,7 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
       }
     }
   }
-  if (json.activeCameraId) {
+  if (json.activeCameraId !== undefined) {
     scene.set('activeCameraId', json.activeCameraId)
   } else {
     // Infer: first camera node.


### PR DESCRIPTION
## Summary\n- allow CLI-authored scenes to explicitly clear activeCameraId with null\n- add a regression test so null is preserved instead of inferring the first camera\n\n## Tests\n- pnpm --dir cli test