### PR TITLE
Test explicit media scene sizes

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -976,6 +976,25 @@ test('buildSceneBytes fills omitted media size axes', () => {
   assert.deepEqual(nodes.clip.size, { width: 640, height: 100 })
 })
 
+test('buildSceneBytes preserves explicit media size axes', () => {
+  const scene = sampleScene()
+  scene.nodes = {
+    clip: {
+      id: 'clip',
+      kind: 'video',
+      parent: null,
+      children: [],
+      src: '/tmp/clip.mp4',
+      size: { width: 640, height: 360 },
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(nodes.clip.size, { width: 640, height: 360 })
+})
+
 test('buildSceneBytes preserves explicit media timing fields', () => {
   const scene = sampleScene()
   scene.nodes = {


### PR DESCRIPTION
## Summary
- Add CLI scene builder coverage for preserving explicit video width and height axes.

## Tests
- pnpm test (from cli/)