### PR TITLE
Handle invalid render_scene arguments

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { handleRenderScene } from './tools/renderScene.js'
+
+test('render_scene reports invalid arguments as MCP errors', async () => {
+  const result = await handleRenderScene({
+    output: 'demo.mp4',
+    fps: 0,
+  })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.match(text, /^render_scene: invalid arguments/)
+})

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -74,12 +74,23 @@ export const renderSceneTool: Tool = {
 export async function handleRenderScene(
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
-  const parsed = RenderInput.parse(args)
+  const parsed = RenderInput.safeParse(args)
+  if (!parsed.success) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `render_scene: invalid arguments — ${parsed.error.message}`,
+        },
+      ],
+    }
+  }
 
-  const outputPath = path.resolve(parsed.output)
-  const format = parsed.format ?? inferFormat(outputPath)
-  const quality = parsed.quality ?? 'comp'
-  const fps = parsed.fps ?? 30
+  const outputPath = path.resolve(parsed.data.output)
+  const format = parsed.data.format ?? inferFormat(outputPath)
+  const quality = parsed.data.quality ?? 'comp'
+  const fps = parsed.data.fps ?? 30
 
   const appPath = await locateDesktopApp()
   if (!appPath) {
@@ -107,7 +118,7 @@ export async function handleRenderScene(
     format,
     quality,
     fps,
-    scenePath: parsed.scene,
+    scenePath: parsed.data.scene,
   })
 
   return {
@@ -116,7 +127,7 @@ export async function handleRenderScene(
         type: 'text' as const,
         text:
           `Rendered current desktop scene → ${outputPath} (${format} · ${quality} · ${fps}fps)` +
-          (parsed.scene ? `\nNote: ignored scene path ${parsed.scene}` : ''),
+          (parsed.data.scene ? `\nNote: ignored scene path ${parsed.data.scene}` : ''),
       },
     ],
   }


### PR DESCRIPTION
## Summary
- Return an MCP error payload when render_scene receives invalid arguments instead of throwing from Zod.
- Add a focused unit test for invalid fps input.

## Tests
- pnpm test