### PR TITLE
docs(cli): clarify render scene flag status

### DIFF
--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -9,9 +9,9 @@
  * off-screen window, loads the scene, runs the export pipeline, and
  * ships the bytes back. The CLI writes them to `<out>`.
  *
- * Current scope: renders the CURRENT scene. A future `--scene <path>`
- * flag will render arbitrary `.hype` files once file-based headless
- * rendering lands.
+ * Current scope: renders the CURRENT scene. `--scene <path>` is accepted
+ * for command compatibility, but file-based headless rendering is still
+ * pending and the current desktop scene is rendered instead.
  */
 
 import { Command } from 'commander'


### PR DESCRIPTION
## Summary
- Update the CLI render command header comment to match the current `--scene` behavior.
- Clarify that the flag is accepted for compatibility but current desktop scene rendering is still used until file-based headless rendering lands.

## Verification
- `pnpm test` in `cli/`