### PR TITLE
Export CLI scene JSON value types

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -400,7 +400,7 @@ export type KeyframeValueJson =
   | 'row'
   | 'column'
 
-type JsonValue =
+export type JsonValue =
   | string
   | number
   | boolean
@@ -408,7 +408,7 @@ type JsonValue =
   | JsonValue[]
   | JsonObject
 
-interface JsonObject {
+export interface JsonObject {
   [key: string]: JsonValue
 }
 


### PR DESCRIPTION
## Summary
- Export the CLI scene builder's JsonValue and JsonObject helper types used by the public JSON schema
- Keep runtime behavior unchanged

## Tests
- pnpm --dir cli test