### PR TITLE
Add text animation presets

### DIFF
--- a/src/anim/engine.ts
+++ b/src/anim/engine.ts
@@ -72,6 +72,8 @@ export interface AnimatedValue {
   cornerRadius?: number
   /** Override for the node's `appearance.fill` solid color. */
   fill?: string
+  /** 0→1 progress for text-specific animation effects. */
+  textProgress?: number
   focusDistance?: number
   focusX?: number
   focusY?: number
@@ -398,6 +400,9 @@ function writeProperty(
       break
     case 'appearance.cornerRadius':
       into.cornerRadius = value
+      break
+    case 'text.progress':
+      into.textProgress = value
       break
     case 'camera.focusDistance':
       into.focusDistance = value

--- a/src/anim/index.ts
+++ b/src/anim/index.ts
@@ -44,3 +44,21 @@ export {
   type EasingPresetId,
   type EasingPresetDef,
 } from './easingPresets'
+export {
+  DEFAULT_TEXT_ANIMATION,
+  TEXT_ANIMATION_PRESETS,
+  applyTextAnimation,
+  normalizeTextAnimation,
+  stampTextAnimationKeyframes,
+  textAnimationDefaults,
+  updateTextAnimationEasing,
+  type TextAnimationAcceleration,
+  type TextAnimationApplyTo,
+  type TextAnimationConfig,
+  type TextAnimationDirection,
+  type TextAnimationId,
+  type TextAnimationMode,
+  type TextAnimationOrder,
+  type TextAnimationPreset,
+  type TextAnimationSmoothing,
+} from './textAnimations'

--- a/src/anim/textAnimations.ts
+++ b/src/anim/textAnimations.ts
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Fill } from '@/scene/types'
+import { addKeyframe } from './tracks'
+import { findEasingPreset, type EasingPresetId } from './easingPresets'
+import type { SceneAPI } from '@/scene/doc'
+import type { EasingKind, NodeId } from '@/scene/types'
+
+export type TextAnimationId =
+  | 'appear'
+  | 'fade'
+  | 'slide-up'
+  | 'slide-down'
+  | 'slide-left'
+  | 'slide-right'
+  | 'mask-up'
+  | 'mask-down'
+  | 'grow'
+  | 'shrink'
+  | 'blur'
+  | 'blur-slide'
+  | 'scramble'
+  | 'flip'
+  | 'character-wave'
+  | 'color-fade'
+  | 'gradient-reveal'
+  | 'typewriter'
+  | 'tracking'
+  | 'skew'
+
+export type TextAnimationMode = 'in' | 'out'
+export type TextAnimationApplyTo = 'letters' | 'words' | 'lines' | 'layer'
+export type TextAnimationOrder = 'forward' | 'backward'
+export type TextAnimationDirection = 'up' | 'down' | 'left' | 'right'
+export type TextAnimationAcceleration =
+  | 'linear'
+  | 'speed-up'
+  | 'slow-down'
+  | 'smooth'
+  | 'spring'
+export type TextAnimationSmoothing = 'none' | 'soft' | 'smooth'
+
+export interface TextAnimationConfig {
+  id: TextAnimationId
+  mode: TextAnimationMode
+  applyTo: TextAnimationApplyTo
+  order: TextAnimationOrder
+  delay: number
+  smoothing: TextAnimationSmoothing
+  duration: number
+  startTime: number
+  acceleration: TextAnimationAcceleration
+  easingPresetId: EasingPresetId
+  easingStrength: number
+  customEasing?: EasingKind
+  direction: TextAnimationDirection
+  travelDistance: number
+  blurRadius: number
+  startColor?: string
+  endColor?: string
+  startGradient?: Fill
+  endGradient?: Fill
+}
+
+export interface TextAnimationPreset {
+  id: TextAnimationId
+  label: string
+  category: string
+  defaults: Partial<TextAnimationConfig>
+}
+
+export const DEFAULT_TEXT_ANIMATION: TextAnimationConfig = {
+  id: 'blur-slide',
+  mode: 'in',
+  applyTo: 'letters',
+  order: 'forward',
+  delay: 0.12,
+  smoothing: 'none',
+  duration: 0.8,
+  startTime: 0,
+  acceleration: 'slow-down',
+  easingPresetId: 'smooth',
+  easingStrength: 50,
+  direction: 'up',
+  travelDistance: 0.5,
+  blurRadius: 20,
+  startGradient: {
+    kind: 'linear',
+    angle: 90,
+    stops: [
+      { at: 0, color: '#7c3aed' },
+      { at: 1, color: '#06b6d4' },
+    ],
+  },
+  endGradient: {
+    kind: 'linear',
+    angle: 90,
+    stops: [
+      { at: 0, color: '#06b6d4' },
+      { at: 0.5, color: '#f43f5e' },
+      { at: 1, color: '#f59e0b' },
+    ],
+  },
+}
+
+export const TEXT_ANIMATION_PRESETS: TextAnimationPreset[] = [
+  { id: 'appear', label: 'Appear', category: 'Basic', defaults: { duration: 0.35, blurRadius: 0, travelDistance: 0 } },
+  { id: 'fade', label: 'Fade', category: 'Basic', defaults: { duration: 0.5, blurRadius: 0, travelDistance: 0 } },
+  { id: 'slide-up', label: 'Slide ↑', category: 'Slide', defaults: { direction: 'up', travelDistance: 0.5, blurRadius: 0 } },
+  { id: 'slide-down', label: 'Slide ↓', category: 'Slide', defaults: { direction: 'down', travelDistance: 0.5, blurRadius: 0 } },
+  { id: 'slide-left', label: 'Slide ←', category: 'Slide', defaults: { direction: 'left', travelDistance: 0.5, blurRadius: 0 } },
+  { id: 'slide-right', label: 'Slide →', category: 'Slide', defaults: { direction: 'right', travelDistance: 0.5, blurRadius: 0 } },
+  { id: 'mask-up', label: 'Mask ↑', category: 'Mask', defaults: { direction: 'up', travelDistance: 0.7, blurRadius: 0 } },
+  { id: 'mask-down', label: 'Mask ↓', category: 'Mask', defaults: { direction: 'down', travelDistance: 0.7, blurRadius: 0 } },
+  { id: 'grow', label: 'Grow', category: 'Scale', defaults: { travelDistance: 0, blurRadius: 0 } },
+  { id: 'shrink', label: 'Shrink', category: 'Scale', defaults: { travelDistance: 0, blurRadius: 0 } },
+  { id: 'blur', label: 'Blur', category: 'Blur', defaults: { travelDistance: 0, blurRadius: 20 } },
+  { id: 'blur-slide', label: 'Blur & Slide', category: 'Blur', defaults: { direction: 'up', travelDistance: 0.5, blurRadius: 20 } },
+  { id: 'scramble', label: 'Scramble', category: 'Expressive', defaults: { duration: 0.9, delay: 0.04 } },
+  { id: 'flip', label: 'Flip', category: 'Expressive', defaults: { duration: 0.75, delay: 0.08 } },
+  { id: 'character-wave', label: 'Character Wave', category: 'Expressive', defaults: { duration: 0.9, delay: 0.06, smoothing: 'soft' } },
+  { id: 'color-fade', label: 'Color Fade', category: 'Color', defaults: { duration: 0.65, delay: 0.05 } },
+  { id: 'gradient-reveal', label: 'Gradient Reveal', category: 'Color', defaults: { duration: 0.85, delay: 0.08 } },
+  { id: 'typewriter', label: 'Typewriter', category: 'Reveal', defaults: { duration: 0.9, delay: 0.06 } },
+  { id: 'tracking', label: 'Tracking', category: 'Reveal', defaults: { duration: 0.7, delay: 0.04 } },
+  { id: 'skew', label: 'Skew', category: 'Reveal', defaults: { duration: 0.65, delay: 0.06 } },
+]
+
+export function textAnimationDefaults(id: TextAnimationId): TextAnimationConfig {
+  const preset = TEXT_ANIMATION_PRESETS.find((p) => p.id === id)
+  const direction = directionFromPresetId(id)
+  return {
+    ...DEFAULT_TEXT_ANIMATION,
+    ...(direction ? { direction } : {}),
+    id,
+    ...(preset?.defaults ?? {}),
+  }
+}
+
+export function applyTextAnimation(
+  api: SceneAPI,
+  nodeId: NodeId,
+  id: TextAnimationId,
+  startTime: number,
+  existing?: TextAnimationConfig | null,
+): TextAnimationConfig {
+  const defaults = textAnimationDefaults(id)
+  const previous = existing ? normalizeTextAnimation(existing) : null
+  const next: TextAnimationConfig = {
+    ...defaults,
+    ...(previous
+      ? {
+          mode: previous.mode,
+          applyTo: previous.applyTo,
+          order: previous.order,
+          delay: previous.delay,
+          smoothing: previous.smoothing,
+          easingPresetId: previous.easingPresetId,
+          easingStrength: previous.easingStrength,
+          customEasing: previous.customEasing,
+        }
+      : {}),
+    startTime,
+  }
+  api.setNodeProperty(nodeId, 'textAnimation', next)
+  const node = api.getNode(nodeId)
+  stampTextAnimationKeyframes(
+    api,
+    nodeId,
+    next,
+    node?.kind === 'text' ? node.text : '',
+  )
+  return next
+}
+
+export function stampTextAnimationKeyframes(
+  api: SceneAPI,
+  nodeId: NodeId,
+  config: TextAnimationConfig,
+  text: string,
+): void {
+  clearTextAnimationKeyframes(api, nodeId, config.mode)
+  const start = config.startTime
+  const end = start + config.duration + Math.max(0, textSegmentCount(text, config.applyTo) - 1) * config.delay
+  const from = config.mode === 'in' ? 0 : 1
+  const to = config.mode === 'in' ? 1 : 0
+  addKeyframe(api, nodeId, 'text.progress', start, from, easingForText(config), config.mode)
+  addKeyframe(api, nodeId, 'text.progress', end, to, undefined, config.mode)
+}
+
+export function updateTextAnimationEasing(
+  api: SceneAPI,
+  nodeId: NodeId,
+  config: TextAnimationConfig,
+): void {
+  const easing = easingForText(config)
+  for (const track of api.getTracksForNode(nodeId)) {
+    if (track.propertyId !== 'text.progress') continue
+    const keyframes = track.keyframes.map((keyframe, index) => {
+      const isLast = index === track.keyframes.length - 1
+      if (keyframe.presetOrigin !== config.mode || isLast) return keyframe
+      return { ...keyframe, easingOut: easing }
+    })
+    api.setTrack({ ...track, defaultEasing: easing, keyframes })
+  }
+}
+
+function clearTextAnimationKeyframes(
+  api: SceneAPI,
+  nodeId: NodeId,
+  mode: TextAnimationMode,
+): void {
+  for (const track of api.getTracksForNode(nodeId)) {
+    if (track.propertyId !== 'text.progress') continue
+    const kept = track.keyframes.filter((keyframe) => keyframe.presetOrigin !== mode)
+    if (kept.length === track.keyframes.length) continue
+    if (kept.length === 0) api.deleteTrack(track.id)
+    else api.setTrack({ ...track, keyframes: kept })
+  }
+}
+
+function textSegmentCount(text: string, applyTo: TextAnimationApplyTo): number {
+  if (applyTo === 'layer') return 1
+  if (applyTo === 'lines') return Math.max(1, text.split('\n').filter(Boolean).length)
+  if (applyTo === 'words') return Math.max(1, text.split(/\s+/).filter(Boolean).length)
+  return Math.max(1, Array.from(text).filter((char) => char !== ' ' && char !== '\n').length)
+}
+
+function easingForText(config: TextAnimationConfig): EasingKind {
+  if (config.easingPresetId === 'custom' && config.customEasing) {
+    return config.customEasing
+  }
+  return findEasingPreset(config.easingPresetId).build(config.easingStrength)
+}
+
+export function normalizeTextAnimation(raw: unknown): TextAnimationConfig | null {
+  if (!raw || typeof raw !== 'object') return null
+  const value = raw as Partial<TextAnimationConfig>
+  const id = isTextAnimationId(value.id) ? value.id : DEFAULT_TEXT_ANIMATION.id
+  const base = textAnimationDefaults(id)
+  return {
+    ...base,
+    mode: value.mode === 'out' ? 'out' : 'in',
+    applyTo: isApplyTo(value.applyTo) ? value.applyTo : base.applyTo,
+    order: value.order === 'backward' ? 'backward' : 'forward',
+    delay: finiteNumber(value.delay, base.delay),
+    smoothing: isSmoothing(value.smoothing) ? value.smoothing : base.smoothing,
+    duration: Math.max(0.05, finiteNumber(value.duration, base.duration)),
+    startTime: Math.max(0, finiteNumber(value.startTime, base.startTime)),
+    acceleration: isAcceleration(value.acceleration) ? value.acceleration : base.acceleration,
+    easingPresetId: isEasingPresetId(value.easingPresetId) ? value.easingPresetId : base.easingPresetId,
+    easingStrength: Math.max(0, Math.min(100, finiteNumber(value.easingStrength, base.easingStrength))),
+    customEasing: isEasingKind(value.customEasing) ? value.customEasing : base.customEasing,
+    direction: isDirection(value.direction) ? value.direction : base.direction,
+    travelDistance: Math.max(0, finiteNumber(value.travelDistance, base.travelDistance)),
+    blurRadius: Math.max(0, finiteNumber(value.blurRadius, base.blurRadius)),
+    startColor: typeof value.startColor === 'string' ? value.startColor : base.startColor,
+    endColor: typeof value.endColor === 'string' ? value.endColor : base.endColor,
+    startGradient: value.startGradient ?? base.startGradient,
+    endGradient: value.endGradient ?? base.endGradient,
+  }
+}
+
+function finiteNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function directionFromPresetId(id: TextAnimationId): TextAnimationDirection | null {
+  if (id.endsWith('-up')) return 'up'
+  if (id.endsWith('-down')) return 'down'
+  if (id.endsWith('-left')) return 'left'
+  if (id.endsWith('-right')) return 'right'
+  return null
+}
+
+function isTextAnimationId(value: unknown): value is TextAnimationId {
+  return typeof value === 'string' && TEXT_ANIMATION_PRESETS.some((p) => p.id === value)
+}
+
+function isApplyTo(value: unknown): value is TextAnimationApplyTo {
+  return value === 'letters' || value === 'words' || value === 'lines' || value === 'layer'
+}
+
+function isSmoothing(value: unknown): value is TextAnimationSmoothing {
+  return value === 'none' || value === 'soft' || value === 'smooth'
+}
+
+function isDirection(value: unknown): value is TextAnimationDirection {
+  return value === 'up' || value === 'down' || value === 'left' || value === 'right'
+}
+
+function isAcceleration(value: unknown): value is TextAnimationAcceleration {
+  return (
+    value === 'linear' ||
+    value === 'speed-up' ||
+    value === 'slow-down' ||
+    value === 'smooth' ||
+    value === 'spring'
+  )
+}
+
+function isEasingPresetId(value: unknown): value is EasingPresetId {
+  return (
+    value === 'none' ||
+    value === 'smooth' ||
+    value === 'natural' ||
+    value === 'slow-down' ||
+    value === 'accelerate' ||
+    value === 'elastic' ||
+    value === 'bounce' ||
+    value === 'overshoot' ||
+    value === 'impulse' ||
+    value === 'swing' ||
+    value === 'custom'
+  )
+}
+
+function isEasingKind(value: unknown): value is EasingKind {
+  if (typeof value === 'string') {
+    return value === 'linear' || value === 'ease-in' || value === 'ease-out' || value === 'ease-in-out'
+  }
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<{ bezier: unknown }>
+  return (
+    Array.isArray(candidate.bezier) &&
+    candidate.bezier.length === 4 &&
+    candidate.bezier.every((n) => typeof n === 'number' && Number.isFinite(n))
+  )
+}

--- a/src/anim/tracks.ts
+++ b/src/anim/tracks.ts
@@ -57,7 +57,11 @@ export function ensureTrack(
 }
 
 export function removeTrack(api: SceneAPI, trackId: TrackId): void {
+  const track = api.getTrack(trackId)
   api.deleteTrack(trackId)
+  if (track?.propertyId === 'text.progress') {
+    api.setNodeProperty(track.nodeId, 'textAnimation', null)
+  }
 }
 
 /**
@@ -140,9 +144,16 @@ export function removeKeyframe(
   const track = api.getTrack(trackId)
   if (!track) return
   const kfs = track.keyframes.filter((k) => k.id !== kfId)
-  if (kfs.length === 0) {
-    // Empty track is dead weight — clean it up.
+  if (
+    kfs.length === 0 ||
+    (track.propertyId === 'text.progress' && kfs.length < 2)
+  ) {
+    // Empty track is dead weight. Text animations need a start and end
+    // progress keyframe; with fewer than two, the effect is inactive.
     api.deleteTrack(trackId)
+    if (track.propertyId === 'text.progress') {
+      api.setNodeProperty(track.nodeId, 'textAnimation', null)
+    }
   } else {
     api.setTrack({ ...track, keyframes: kfs })
   }

--- a/src/index.css
+++ b/src/index.css
@@ -510,3 +510,143 @@ body[data-preview-mode='1'] [data-canvas-root] {
   100%      { opacity: 1; transform: scale(1); }
 }
 .hm-preset-scale-out { animation-name: hm-scale-out; }
+
+/* ============================================================
+   Text animation preset previews
+   ============================================================ */
+
+.hm-text-preset-stage {
+  position: relative;
+  display: flex;
+  height: 74px;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 5px;
+  background: var(--color-panel);
+}
+
+.hm-text-preset-subject {
+  display: inline-block;
+  font-size: 24px;
+  line-height: 1;
+  color: var(--color-text);
+}
+
+.hm-text-preview-letter {
+  display: inline-block;
+  animation-duration: 1.8s;
+  animation-iteration-count: infinite;
+  animation-fill-mode: both;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  animation-delay: calc(var(--i) * 70ms);
+  transform-origin: 50% 70%;
+}
+
+@keyframes hm-text-fade {
+  0%, 10% { opacity: 0; }
+  55%, 88% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+@keyframes hm-text-slide-up {
+  0%, 10% { opacity: 0; transform: translateY(18px); }
+  55%, 88% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(18px); }
+}
+
+@keyframes hm-text-slide-down {
+  0%, 10% { opacity: 0; transform: translateY(-18px); }
+  55%, 88% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-18px); }
+}
+
+@keyframes hm-text-slide-left {
+  0%, 10% { opacity: 0; transform: translateX(22px); }
+  55%, 88% { opacity: 1; transform: translateX(0); }
+  100% { opacity: 0; transform: translateX(22px); }
+}
+
+@keyframes hm-text-slide-right {
+  0%, 10% { opacity: 0; transform: translateX(-22px); }
+  55%, 88% { opacity: 1; transform: translateX(0); }
+  100% { opacity: 0; transform: translateX(-22px); }
+}
+
+@keyframes hm-text-mask-up {
+  0%, 10% { clip-path: inset(0 0 100% 0); transform: translateY(10px); }
+  55%, 88% { clip-path: inset(0); transform: translateY(0); }
+  100% { clip-path: inset(0 0 100% 0); transform: translateY(10px); }
+}
+
+@keyframes hm-text-mask-down {
+  0%, 10% { clip-path: inset(100% 0 0 0); transform: translateY(-10px); }
+  55%, 88% { clip-path: inset(0); transform: translateY(0); }
+  100% { clip-path: inset(100% 0 0 0); transform: translateY(-10px); }
+}
+
+@keyframes hm-text-grow {
+  0%, 10% { opacity: 0; transform: scale(0.72); }
+  55%, 88% { opacity: 1; transform: scale(1); }
+  100% { opacity: 0; transform: scale(0.72); }
+}
+
+@keyframes hm-text-shrink {
+  0%, 10% { opacity: 0; transform: scale(1.35); }
+  55%, 88% { opacity: 1; transform: scale(1); }
+  100% { opacity: 0; transform: scale(1.35); }
+}
+
+@keyframes hm-text-blur {
+  0%, 10% { opacity: 0; filter: blur(8px); }
+  55%, 88% { opacity: 1; filter: blur(0); }
+  100% { opacity: 0; filter: blur(8px); }
+}
+
+@keyframes hm-text-flip {
+  0%, 10% { opacity: 0; transform: rotateX(-90deg); }
+  55%, 88% { opacity: 1; transform: rotateX(0); }
+  100% { opacity: 0; transform: rotateX(-90deg); }
+}
+
+@keyframes hm-text-wave {
+  0%, 10% { opacity: 0.25; transform: translateY(14px); }
+  30% { opacity: 1; transform: translateY(-8px); }
+  55%, 88% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0.25; transform: translateY(14px); }
+}
+
+@keyframes hm-text-gradient {
+  0%, 10% { background-position: 100% 50%; opacity: 0; }
+  55%, 88% { background-position: 0% 50%; opacity: 1; }
+  100% { background-position: 100% 50%; opacity: 0; }
+}
+
+.hm-text-preset-appear .hm-text-preview-letter,
+.hm-text-preset-fade .hm-text-preview-letter,
+.hm-text-preset-typewriter .hm-text-preview-letter { animation-name: hm-text-fade; }
+.hm-text-preset-slide-up .hm-text-preview-letter,
+.hm-text-preset-blur-slide .hm-text-preview-letter { animation-name: hm-text-slide-up; }
+.hm-text-preset-slide-down .hm-text-preview-letter { animation-name: hm-text-slide-down; }
+.hm-text-preset-slide-left .hm-text-preview-letter { animation-name: hm-text-slide-left; }
+.hm-text-preset-slide-right .hm-text-preview-letter { animation-name: hm-text-slide-right; }
+.hm-text-preset-mask-up .hm-text-preview-letter { animation-name: hm-text-mask-up; }
+.hm-text-preset-mask-down .hm-text-preview-letter { animation-name: hm-text-mask-down; }
+.hm-text-preset-grow .hm-text-preview-letter { animation-name: hm-text-grow; }
+.hm-text-preset-shrink .hm-text-preview-letter { animation-name: hm-text-shrink; }
+.hm-text-preset-blur .hm-text-preview-letter,
+.hm-text-preset-scramble .hm-text-preview-letter { animation-name: hm-text-blur; }
+.hm-text-preset-flip .hm-text-preview-letter { animation-name: hm-text-flip; }
+.hm-text-preset-character-wave .hm-text-preview-letter,
+.hm-text-preset-skew .hm-text-preview-letter,
+.hm-text-preset-tracking .hm-text-preview-letter { animation-name: hm-text-wave; }
+.hm-text-preset-color-fade .hm-text-preview-letter,
+.hm-text-preset-gradient-reveal .hm-text-preview-letter {
+  animation-name: hm-text-gradient;
+  background: linear-gradient(90deg, #7c3aed, #06b6d4, #f43f5e);
+  background-size: 220% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}

--- a/src/scene/doc.ts
+++ b/src/scene/doc.ts
@@ -22,6 +22,7 @@ import type {
   TrackId,
   Transform,
 } from '@/scene/types'
+import { normalizeTextAnimation } from '@/anim/textAnimations'
 
 /**
  * Persistent, undoable UI state — track groups, keyframe groups,
@@ -175,6 +176,7 @@ export interface NodeBaseMutable {
   locked: boolean
   position: import('@/scene/types').Position
   text: string
+  textAnimation: import('@/anim/textAnimations').TextAnimationConfig | null
   // image-kind fields — settable via Inspector on ImageNode. The scene
   // API doesn't (yet) enforce that these keys only land on an image
   // node, so callers should only pass them through when they know
@@ -501,6 +503,7 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
           letterSpacing: (y.get('letterSpacing') as number) ?? 0,
           textAlign: (y.get('textAlign') as 'start' | 'center' | 'end') ?? 'start',
           color: (y.get('color') as string) ?? '#0a0a0c',
+          textAnimation: normalizeTextAnimation(y.get('textAnimation')),
         } as Node
       case 'component':
         return {
@@ -818,6 +821,7 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
           y.set('letterSpacing', tp?.letterSpacing ?? 0)
           y.set('textAlign', tp?.textAlign ?? 'start')
           y.set('color', tp?.color ?? '#0a0a0c')
+          y.set('textAnimation', normalizeTextAnimation(tp?.textAnimation) ?? null)
         }
         if (kind === 'camera') {
           // Cameras carry no size / layout / fill. They exist at the

--- a/src/scene/props.ts
+++ b/src/scene/props.ts
@@ -17,7 +17,7 @@ import type { PropertyId } from '@/scene/types'
  *   3. Anim engine will pick it up automatically
  */
 
-export type PropertyGroup = 'transform' | 'camera' | 'appearance' | 'layout' | 'size' | 'semantic'
+export type PropertyGroup = 'transform' | 'camera' | 'appearance' | 'text' | 'layout' | 'size' | 'semantic'
 export type Interpolation = 'numeric' | 'discrete' | 'color' | 'angle'
 
 export interface PropertyDescriptor {
@@ -178,6 +178,12 @@ export const PROPERTIES: Record<PropertyId, PropertyDescriptor> = {
   'appearance.fill': {
     id: 'appearance.fill', group: 'appearance', label: 'Fill',
     layoutAffecting: false, interpolation: 'color', defaultValue: 'oklch(0.8 0.05 250)',
+  },
+
+  // text effect group — post-layout; controls text-specific reveal progress
+  'text.progress': {
+    id: 'text.progress', group: 'text', label: 'Text Animation',
+    layoutAffecting: false, interpolation: 'numeric', defaultValue: 0,
   },
 
   // layout group — triggers relayout + FLIP

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -499,6 +499,12 @@ export interface TextNode extends NodeBase {
   letterSpacing: number
   textAlign: 'start' | 'center' | 'end'
   color: Color
+  /**
+   * Text-specific animation effect. Unlike ordinary layer presets,
+   * this can target letters, words, lines, or the whole layer while
+   * keeping one editable effect row in the Animate inspector.
+   */
+  textAnimation?: import('@/anim/textAnimations').TextAnimationConfig | null
 }
 
 export interface ImageNode extends NodeBase {
@@ -889,6 +895,8 @@ export type PropertyId =
   | 'appearance.opacity'
   | 'appearance.cornerRadius'
   | 'appearance.fill'
+  // text effect group — drives text-specific reveal effects
+  | 'text.progress'
   // layout group — triggers relayout + FLIP
   | 'layout.gap'
   | 'layout.padding.top'

--- a/src/ui/Canvas.tsx
+++ b/src/ui/Canvas.tsx
@@ -42,7 +42,9 @@ import {
 import {
   recordKeyframesForPatch,
   stampToActiveTracksForPatch,
+  normalizeTextAnimation,
 } from '@/anim'
+import type { TextAnimationConfig } from '@/anim'
 
 /**
  * Per-node values accumulated from every ancestor in the scene tree.
@@ -3676,6 +3678,7 @@ function NodeView({
         <TextGlyphs
           node={node}
           effectiveFill={effectiveFill}
+          anim={anim}
         />
       ) : null}
       {shouldRenderStrokeOverlay ? (
@@ -3890,17 +3893,21 @@ function clamp01Local(n: number): number {
 function TextGlyphs({
   node,
   effectiveFill,
+  anim,
 }: {
   node: Extract<SceneNode, { kind: 'text' }>
   // Match the type computed in NodeView — either node.appearance.fill
   // (whatever Fill union the scene model uses) or the synth solid the
   // animation engine emits.
   effectiveFill: Extract<SceneNode, { kind: 'text' }>['appearance']['fill']
+  anim: AnimatedValue | undefined
 }) {
   const editingTextId = useUI((s) => s.editingTextId)
   const setEditingTextId = useUI((s) => s.setEditingTextId)
+  const playhead = useUI((s) => s.playhead)
   const api = useSceneAPI()
   const isEditing = editingTextId === node.id
+  const textAnimation = normalizeTextAnimation(node.textAnimation)
 
   // Common typography style block. Shared between read and edit modes
   // so the text doesn't shift visually when you press Enter to edit.
@@ -4023,9 +4030,272 @@ function TextGlyphs({
         userSelect: 'none',
       }}
     >
-      {node.text}
+      {textAnimation
+        ? renderTextAnimationSegments(
+            node.text,
+            textAnimation,
+            playhead,
+            sharedStyle,
+            anim?.textProgress,
+          )
+        : node.text}
     </span>
   )
+}
+
+function renderTextAnimationSegments(
+  text: string,
+  config: TextAnimationConfig,
+  playhead: number,
+  sharedStyle: CSSProperties,
+  progress?: number,
+) {
+  const segments = splitTextAnimationSegments(text, config.applyTo)
+  const orderedCount = Math.max(1, segments.filter((s) => s.animate).length)
+  let animateIndex = 0
+  return segments.map((segment, index) => {
+    if (!segment.animate) return segment.text
+    const orderIndex =
+      config.order === 'backward'
+        ? orderedCount - animateIndex - 1
+        : animateIndex
+    animateIndex++
+    const style = textAnimationSegmentStyle(
+      config,
+      playhead,
+      progress,
+      orderIndex,
+      orderedCount,
+      sharedStyle,
+      segment.kind,
+    )
+    return (
+      <span key={`${index}-${segment.text}`} style={style}>
+        {displayTextForSegment(
+          segment.text,
+          config,
+          playhead,
+          progress,
+          orderIndex,
+          orderedCount,
+        )}
+      </span>
+    )
+  })
+}
+
+function splitTextAnimationSegments(
+  text: string,
+  applyTo: TextAnimationConfig['applyTo'],
+): Array<{ text: string; animate: boolean; kind: 'inline' | 'line' }> {
+  if (applyTo === 'layer') return [{ text, animate: true, kind: 'inline' }]
+  if (applyTo === 'lines') {
+    const lines = text.split(/(\n)/)
+    return lines.map((part) => ({
+      text: part,
+      animate: part !== '\n' && part.length > 0,
+      kind: part === '\n' ? 'inline' : 'line',
+    }))
+  }
+  if (applyTo === 'words') {
+    return text.split(/(\s+)/).map((part) => ({
+      text: part,
+      animate: !/^\s+$/.test(part) && part.length > 0,
+      kind: 'inline',
+    }))
+  }
+  return Array.from(text).map((char) => ({
+    text: char,
+    animate: char !== '\n' && char !== ' ',
+    kind: 'inline',
+  }))
+}
+
+function textAnimationSegmentStyle(
+  config: TextAnimationConfig,
+  playhead: number,
+  progress: number | undefined,
+  orderIndex: number,
+  count: number,
+  sharedStyle: CSSProperties,
+  kind: 'inline' | 'line',
+): CSSProperties {
+  const totalSpan = config.duration + Math.max(0, count - 1) * config.delay
+  const timelineProgress = progress === undefined
+    ? undefined
+    : Math.max(0, Math.min(1, progress))
+  const globalElapsed = timelineProgress === undefined
+    ? playhead - config.startTime
+    : (config.mode === 'in' ? timelineProgress : 1 - timelineProgress) * totalSpan
+  const raw = (globalElapsed - orderIndex * config.delay) / Math.max(0.05, config.duration)
+  const u = Math.max(0, Math.min(1, raw))
+  const eased = progress === undefined ? easeTextAnimation(u, config.acceleration) : u
+  const exit = config.mode === 'out'
+  const amount = exit ? eased : 1 - eased
+  const lineHeight =
+    typeof sharedStyle.fontSize === 'number' && typeof sharedStyle.lineHeight === 'number'
+      ? sharedStyle.fontSize * sharedStyle.lineHeight
+      : 32
+  const travel = Math.max(1, lineHeight * config.travelDistance)
+  const [dx, dy] = directionOffset(config.direction, travel * amount)
+  const transforms: string[] = []
+  let opacity = 1
+  let filter: string | undefined
+  let clipPath: string | undefined
+  let color: string | undefined
+
+  if (
+    config.id === 'fade' ||
+    config.id === 'slide-up' ||
+    config.id === 'slide-down' ||
+    config.id === 'slide-left' ||
+    config.id === 'slide-right' ||
+    config.id === 'blur-slide' ||
+    config.id === 'blur' ||
+    config.id === 'appear' ||
+    config.id === 'typewriter'
+  ) {
+    opacity = config.id === 'appear' || config.id === 'typewriter'
+      ? amount < 0.5 ? 0 : 1
+      : 1 - amount
+  }
+  if (config.id.startsWith('slide') || config.id === 'blur-slide') {
+    transforms.push(`translate(${dx}px, ${dy}px)`)
+  }
+  if (config.id === 'grow') {
+    transforms.push(`scale(${1 - amount * 0.35})`)
+    opacity = 1 - amount
+  }
+  if (config.id === 'shrink') {
+    transforms.push(`scale(${1 + amount * 0.35})`)
+    opacity = 1 - amount
+  }
+  if (config.id === 'blur' || config.id === 'blur-slide') {
+    filter = `blur(${config.blurRadius * amount}px)`
+  }
+  if (config.id === 'mask-up' || config.id === 'mask-down' || config.id === 'gradient-reveal') {
+    const pct = Math.round(amount * 100)
+    clipPath =
+      config.direction === 'down'
+        ? `inset(${pct}% 0 0 0)`
+        : `inset(0 0 ${pct}% 0)`
+    opacity = 1
+  }
+  if (config.id === 'gradient-reveal') {
+    const gradient = config.mode === 'in'
+      ? config.endGradient ?? config.startGradient
+      : config.startGradient ?? config.endGradient
+    const background = fillToCss(gradient ?? null)
+    if (background) {
+      return {
+        display: kind === 'line' ? 'block' : 'inline-block',
+        whiteSpace: kind === 'line' ? 'pre-wrap' : 'pre',
+        opacity,
+        filter,
+        clipPath,
+        background,
+        WebkitBackgroundClip: 'text',
+        backgroundClip: 'text',
+        WebkitTextFillColor: 'transparent',
+        color: 'transparent',
+        transform: transforms.length > 0 ? transforms.join(' ') : undefined,
+        transformOrigin: '50% 50%',
+        willChange: 'transform, opacity, filter, clip-path',
+      }
+    }
+  }
+  if (config.id === 'flip') {
+    transforms.push(`rotateX(${amount * -90}deg)`)
+    opacity = 1 - amount
+  }
+  if (config.id === 'character-wave') {
+    const phase = count <= 1 ? 0 : orderIndex / (count - 1)
+    transforms.push(`translateY(${Math.sin((phase + u) * Math.PI * 2) * 8 * amount}px)`)
+    opacity = 1 - amount * 0.35
+  }
+  if (config.id === 'tracking') {
+    transforms.push(`translateX(${amount * 10}px)`)
+    opacity = 1 - amount
+  }
+  if (config.id === 'skew') {
+    transforms.push(`translate(${dx}px, ${dy}px) skewX(${amount * -14}deg)`)
+    opacity = 1 - amount
+  }
+  if (config.id === 'color-fade') {
+    color = config.mode === 'in'
+      ? `color-mix(in oklab, currentColor ${Math.round(eased * 100)}%, transparent)`
+      : `color-mix(in oklab, currentColor ${Math.round((1 - eased) * 100)}%, transparent)`
+  }
+
+  return {
+    display: kind === 'line' ? 'block' : 'inline-block',
+    whiteSpace: kind === 'line' ? 'pre-wrap' : 'pre',
+    opacity,
+    filter,
+    clipPath,
+    color,
+    transform: transforms.length > 0 ? transforms.join(' ') : undefined,
+    transformOrigin: '50% 50%',
+    willChange: 'transform, opacity, filter, clip-path',
+  }
+}
+
+function easeTextAnimation(
+  u: number,
+  acceleration: TextAnimationConfig['acceleration'],
+): number {
+  if (acceleration === 'linear') return u
+  if (acceleration === 'speed-up') return u * u
+  if (acceleration === 'spring') {
+    return Math.min(1, 1 - Math.cos(u * Math.PI * 2.4) * Math.exp(-5 * u))
+  }
+  if (acceleration === 'smooth') return u * u * (3 - 2 * u)
+  return 1 - Math.pow(1 - u, 3)
+}
+
+function directionOffset(
+  direction: TextAnimationConfig['direction'],
+  distance: number,
+): [number, number] {
+  switch (direction) {
+    case 'down':
+      return [0, -distance]
+    case 'left':
+      return [distance, 0]
+    case 'right':
+      return [-distance, 0]
+    case 'up':
+    default:
+      return [0, distance]
+  }
+}
+
+function displayTextForSegment(
+  text: string,
+  config: TextAnimationConfig,
+  playhead: number,
+  progress: number | undefined,
+  orderIndex: number,
+  count: number,
+): string {
+  if (config.id !== 'scramble') return text
+  const totalSpan = config.duration + Math.max(0, count - 1) * config.delay
+  const timelineProgress = progress === undefined
+    ? undefined
+    : Math.max(0, Math.min(1, progress))
+  const globalElapsed = timelineProgress === undefined
+    ? playhead - config.startTime
+    : (config.mode === 'in' ? timelineProgress : 1 - timelineProgress) * totalSpan
+  const u = Math.max(0, Math.min(1, (globalElapsed - orderIndex * config.delay) / Math.max(0.05, config.duration)))
+  if ((config.mode === 'in' && u >= 0.85) || (config.mode === 'out' && u <= 0.15)) return text
+  const glyphs = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#$%&'
+  return Array.from(text)
+    .map((char, index) => {
+      if (/\s/.test(char)) return char
+      const n = Math.abs(Math.sin((orderIndex + 1) * 17.17 + index * 9.91 + playhead * 24))
+      return glyphs[Math.floor(n * glyphs.length) % glyphs.length]!
+    })
+    .join('')
 }
 
 function MediaVideo({

--- a/src/ui/EasingPicker.tsx
+++ b/src/ui/EasingPicker.tsx
@@ -37,6 +37,8 @@ export interface EasingPickerProps {
   }) => void
   /** Title shown above the picker; hidden when null. */
   title?: string | null
+  /** Optional subset for contexts where some curves are too noisy. */
+  allowedPresetIds?: EasingPresetId[]
 }
 
 export function EasingPicker({
@@ -44,13 +46,23 @@ export function EasingPicker({
   strength,
   onChange,
   title = 'Easing',
+  allowedPresetIds,
 }: EasingPickerProps) {
-  const current = EASING_PRESETS.find((p) => p.id === presetId) ?? EASING_PRESETS[0]!
-  const easing = useMemo(() => current.build(strength), [current, strength])
-  const curve = useMemo(() => bezierOf(easing), [easing])
+  const allowedKey = allowedPresetIds?.join('|') ?? ''
+  const presets = useMemo(
+    () =>
+      allowedPresetIds
+        ? EASING_PRESETS.filter((p) => allowedPresetIds.includes(p.id))
+        : EASING_PRESETS,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [allowedKey],
+  )
+  const current = presets.find((p) => p.id === presetId) ?? presets[0] ?? EASING_PRESETS[0]!
+  const easing = current.build(strength)
+  const curve = bezierOf(easing)
 
   const pickPreset = (id: EasingPresetId) => {
-    const def = EASING_PRESETS.find((p) => p.id === id) ?? current
+    const def = presets.find((p) => p.id === id) ?? current
     onChange({ presetId: id, strength, easing: def.build(strength) })
   }
 
@@ -71,7 +83,7 @@ export function EasingPicker({
 
       {/* Preset tile grid — 3 columns, compact. */}
       <div className="grid grid-cols-3 gap-1 p-2">
-        {EASING_PRESETS.map((p) => {
+        {presets.map((p) => {
           const active = p.id === presetId
           const curveForTile = bezierOf(p.build(strength))
           return (

--- a/src/ui/GraphEditor.tsx
+++ b/src/ui/GraphEditor.tsx
@@ -506,6 +506,7 @@ function humanProperty(id: string): string {
     'appearance.opacity': 'Opacity',
     'appearance.cornerRadius': 'Corner',
     'appearance.fill': 'Fill',
+    'text.progress': 'Text Animation',
   }
   return map[id] ?? id
 }

--- a/src/ui/PresetsPanel.tsx
+++ b/src/ui/PresetsPanel.tsx
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { useState, type CSSProperties, type ReactNode } from 'react'
 import { useUI } from '@/state/ui'
 import { useSceneAPI, useSceneVersion } from '@/scene'
-import type { EasingKind, NodeId } from '@/scene'
+import type { EasingKind, Fill, NodeId } from '@/scene'
 import type { SceneAPI } from '@/scene/doc'
 import {
   PRESETS,
@@ -10,11 +11,37 @@ import {
   listTracksForNode,
   removeTrack,
   findEasingPreset,
+  bezierOf,
+  TEXT_ANIMATION_PRESETS,
+  applyTextAnimation,
+  normalizeTextAnimation,
+  stampTextAnimationKeyframes,
+  updateTextAnimationEasing,
 } from '@/anim'
-import type { AnimPresetId } from '@/anim'
+import type {
+  AnimPresetId,
+  TextAnimationApplyTo,
+  TextAnimationConfig,
+  TextAnimationDirection,
+  TextAnimationId,
+  TextAnimationOrder,
+  TextAnimationSmoothing,
+} from '@/anim'
 import { EasingPicker } from '@/ui/EasingPicker'
 import { GraphEditor } from '@/ui/GraphEditor'
 import { NumberField } from '@/ui/fields'
+
+const TEXT_EASING_PRESETS = [
+  'smooth',
+  'natural',
+  'slow-down',
+  'accelerate',
+  'impulse',
+  'swing',
+  'none',
+  'custom',
+] as const
+const TEXT_ANIMATION_PREVIEW_WORD = 'HYPER'
 
 /**
  * Animate-mode right panel.
@@ -54,6 +81,15 @@ export function PresetsPanel() {
   const staggerDelay = useUI((s) => s.staggerDelay)
   const setStaggerOn = useUI((s) => s.setStaggerOn)
   const setStaggerDelay = useUI((s) => s.setStaggerDelay)
+  const [showLayerOptions, setShowLayerOptions] = useState(false)
+  const [layerPresetTab, setLayerPresetTab] = useState<'in' | 'out'>('in')
+  const [openSectionState, setOpenSectionState] = useState({
+    selectionKey: '',
+    sections: {
+      layer: true,
+      text: false,
+    },
+  })
   // Timeline selection sources, in order of precedence:
   //   1. selectedKeyframes — individual diamonds the user marquee'd or
   //      shift-clicked. Compound keys "trackId:kfId" — we derive track
@@ -73,6 +109,37 @@ export function PresetsPanel() {
     for (const id of selectedTrackIds) set.add(id)
     return set.size > 0 ? set : undefined
   })()
+
+  const selectedNodes = selection
+    .map((id) => api.getNode(id))
+    .filter(Boolean)
+  const selectedTextNodes = selectedNodes.filter((node) => node?.kind === 'text')
+  const hasTextSelection = selectedTextNodes.length > 0
+  const selectionKey = selection.join('|')
+  const defaultOpenSections = {
+    layer: !hasTextSelection,
+    text: hasTextSelection,
+  }
+  const openSections =
+    openSectionState.selectionKey === selectionKey
+      ? openSectionState.sections
+      : defaultOpenSections
+  const toggleSection = (section: 'layer' | 'text') => {
+    setOpenSectionState((current) => {
+      const activeSections =
+        current.selectionKey === selectionKey
+          ? current.sections
+          : defaultOpenSections
+      const nextOpen = !activeSections[section]
+      return {
+        selectionKey,
+        sections: {
+          layer: section === 'layer' ? nextOpen : false,
+          text: section === 'text' ? nextOpen : false,
+        },
+      }
+    })
+  }
 
   if (selection.length === 0) {
     return (
@@ -96,7 +163,10 @@ export function PresetsPanel() {
   const clearAll = () => {
     for (const id of selection) {
       const tracks = listTracksForNode(api, id)
-      for (const t of tracks) removeTrack(api, t.id)
+      for (const t of tracks) {
+        if (t.propertyId === 'text.progress') continue
+        removeTrack(api, t.id)
+      }
     }
   }
 
@@ -129,31 +199,77 @@ export function PresetsPanel() {
 
   const ins = PRESETS.filter((p) => p.direction === 'in')
   const outs = PRESETS.filter((p) => p.direction === 'out')
-
-  return (
-    <div className="space-y-5">
-      <div className="rounded border border-border bg-panel-raised p-2.5">
-        <div className="text-[10px] font-medium tracking-wider text-text-dim uppercase">
-          Applies at playhead
+  const visibleLayerPresets = layerPresetTab === 'in' ? ins : outs
+  const primaryTextNode = selectedTextNodes[0]
+  const primaryTextTrack = primaryTextNode
+    ? api
+        .getTracksForNode(primaryTextNode.id)
+        .find((track) => track.propertyId === 'text.progress' && track.keyframes.length >= 2)
+    : null
+  const primaryTextConfig = primaryTextTrack
+    ? normalizeTextAnimation(primaryTextNode?.textAnimation)
+    : null
+  const primaryTextPreset = primaryTextConfig
+    ? textPresetForConfig(primaryTextConfig)
+    : null
+  const layerSummary = `${playhead.toFixed(2)}s · ${
+    selection.length === 1 ? '1 layer' : `${selection.length} layers`
+  }`
+  const textSummary = primaryTextConfig
+    ? `${primaryTextPreset?.label ?? 'Text effect'} · ${textApplyLabel(primaryTextConfig.applyTo)} · ${
+        primaryTextConfig.mode === 'in' ? 'In' : 'Out'
+      }`
+    : 'No text animation'
+  const layerSection = (
+    <AnimationAccordion
+      title="Layer animation"
+      summary={layerSummary}
+      open={openSections.layer}
+      primary={!hasTextSelection}
+      onToggle={() => toggleSection('layer')}
+    >
+      <div className="rounded-md border border-border bg-panel-raised">
+        <div className="flex items-center gap-2 p-2.5">
+          <div className="min-w-0 flex-1">
+            <div className="font-mono text-[13px] text-text tabular-nums">
+              {playhead.toFixed(2)}s
+            </div>
+            <div className="mt-0.5 truncate text-[11px] text-text-dim">
+              {describeTargets(selection, targets, isStaggerActive)}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowLayerOptions((v) => !v)}
+            className={[
+              'rounded px-2.5 py-1.5 text-[11px] font-semibold',
+              showLayerOptions || staggerOn
+                ? 'bg-accent/12 text-accent hover:bg-accent/18'
+                : 'bg-panel text-text-muted hover:text-text',
+            ].join(' ')}
+          >
+            Timing
+          </button>
         </div>
-        <div className="mt-0.5 font-mono text-[11px] text-text tabular-nums">
-          {playhead.toFixed(2)}s
-        </div>
-        <div className="mt-1 text-[11px] text-text-dim">
-          {describeTargets(selection, targets, isStaggerActive)}
-        </div>
+        {showLayerOptions ? (
+          <div className="border-t border-border p-2.5">
+            <StaggerControls
+              on={staggerOn}
+              delay={staggerDelay}
+              onToggle={() => setStaggerOn(!staggerOn)}
+              onDelayChange={setStaggerDelay}
+            />
+          </div>
+        ) : null}
       </div>
 
-      <StaggerControls
-        on={staggerOn}
-        delay={staggerDelay}
-        onToggle={() => setStaggerOn(!staggerOn)}
-        onDelayChange={setStaggerDelay}
+      <PresetTabs
+        value={layerPresetTab}
+        onChange={setLayerPresetTab}
+        inCount={ins.length}
+        outCount={outs.length}
       />
-
-      <PresetGroup title="In" presets={ins} onPick={stampPreset} />
-
-      <PresetGroup title="Out" presets={outs} onPick={stampPreset} />
+      <PresetGrid presets={visibleLayerPresets} onPick={stampPreset} />
 
       <EasingPicker
         presetId={easingPresetId}
@@ -174,27 +290,827 @@ export function PresetsPanel() {
         className="w-full rounded border border-border bg-panel px-3 py-2 text-[11px] text-text-muted hover:border-border-strong hover:text-text"
       >
         {selection.length > 1
-          ? 'Clear all animation on selected layers'
-          : 'Clear all animation on this layer'}
+          ? 'Clear layer animation on selected layers'
+          : 'Clear layer animation on this layer'}
       </button>
+    </AnimationAccordion>
+  )
+  const textSection = hasTextSelection ? (
+    <AnimationAccordion
+      title="Text animation"
+      summary={textSummary}
+      open={openSections.text}
+      primary={hasTextSelection}
+      onToggle={() => toggleSection('text')}
+    >
+      <TextAnimationPanel />
+    </AnimationAccordion>
+  ) : null
+
+  return (
+    <div className="space-y-2">
+      {hasTextSelection ? (
+        <>
+          {textSection}
+          {layerSection}
+        </>
+      ) : (
+        <>
+          {layerSection}
+          {textSection}
+        </>
+      )}
     </div>
   )
 }
 
-function PresetGroup({
+function AnimationAccordion({
   title,
+  summary,
+  open,
+  primary,
+  onToggle,
+  children,
+}: {
+  title: string
+  summary: string
+  open: boolean
+  primary?: boolean
+  onToggle: () => void
+  children: ReactNode
+}) {
+  return (
+    <section
+      className={[
+        'overflow-hidden rounded-md border bg-panel-raised',
+        primary ? 'border-border-strong shadow-sm' : 'border-border',
+      ].join(' ')}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="flex w-full min-w-0 items-center gap-2 px-2.5 py-2.5 text-left hover:bg-panel"
+      >
+        <span
+          className={[
+            'text-[11px] font-semibold tracking-wider uppercase',
+            open || primary ? 'text-text' : 'text-text-muted',
+          ].join(' ')}
+        >
+          {title}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-right text-[10px] text-text-dim">
+          {summary}
+        </span>
+        <span
+          className={[
+            'grid h-5 w-5 shrink-0 place-items-center rounded text-[12px]',
+            open ? 'text-accent' : 'text-text-dim',
+          ].join(' ')}
+          aria-hidden="true"
+        >
+          {open ? '−' : '+'}
+        </span>
+      </button>
+      <div
+        className={[
+          'grid transition-[grid-template-rows] duration-200 ease-out',
+          open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+        ].join(' ')}
+        aria-hidden={!open}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div
+            className={[
+              'space-y-3 border-t border-border p-2.5 transition-opacity duration-150',
+              open ? 'opacity-100' : 'pointer-events-none opacity-0',
+            ].join(' ')}
+          >
+            {children}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function TextAnimationPanel() {
+  useSceneVersion()
+  const api = useSceneAPI()
+  const selection = useUI((s) => s.selection)
+  const playhead = useUI((s) => s.playhead)
+  const [showPicker, setShowPicker] = useState(false)
+  const [showEasing, setShowEasing] = useState(false)
+  const [copiedEasing, setCopiedEasing] = useState(false)
+  const [easingDraft, setEasingDraft] = useState({ source: '', value: '' })
+  const selectedTextNodes = selection
+    .map((id) => api.getNode(id))
+    .filter((node): node is NonNullable<typeof node> & { kind: 'text' } => node?.kind === 'text')
+  const primary = selectedTextNodes[0]
+  const primaryTextAnimationTrack = primary
+    ? api
+        .getTracksForNode(primary.id)
+        .find((track) => track.propertyId === 'text.progress' && track.keyframes.length >= 2)
+    : null
+  const current = primaryTextAnimationTrack
+    ? normalizeTextAnimation(primary?.textAnimation)
+    : null
+  const currentEasingText = current ? easingToText(current) : ''
+  const visibleEasingDraft =
+    easingDraft.source === currentEasingText ? easingDraft.value : currentEasingText
+
+  const patch = (next: Partial<TextAnimationConfig>) => {
+    if (!current) return
+    for (const node of selectedTextNodes) {
+      const base = normalizeTextAnimation(node.textAnimation) ?? current
+      const config = {
+        ...base,
+        ...next,
+      }
+      api.setNodeProperty(node.id, 'textAnimation', config)
+      if (isTextEasingOnlyPatch(next)) {
+        updateTextAnimationEasing(api, node.id, config)
+      } else {
+        stampTextAnimationKeyframes(api, node.id, config, node.text)
+      }
+    }
+  }
+  const updateEasingText = (value: string) => {
+    setEasingDraft({ source: currentEasingText, value })
+    const parsed = parseEasingText(value)
+    if (!parsed) return
+    patch(parsed)
+  }
+  const copyEasing = async () => {
+    try {
+      await navigator.clipboard?.writeText(visibleEasingDraft)
+      setCopiedEasing(true)
+      window.setTimeout(() => setCopiedEasing(false), 1200)
+    } catch {
+      setCopiedEasing(false)
+    }
+  }
+
+  const pickPreset = (id: TextAnimationId) => {
+    for (const node of selectedTextNodes) {
+      applyTextAnimation(
+        api,
+        node.id,
+        id,
+        playhead,
+        normalizeTextAnimation(node.textAnimation),
+      )
+    }
+    setShowPicker(false)
+  }
+
+  if (!current) {
+    return (
+      <div className="space-y-3">
+        <div className="rounded-md border border-border-strong/60 bg-panel-raised p-2">
+          <div className="flex items-center gap-2">
+            <div className="min-w-0 flex-1">
+              <div className="text-[11px] font-semibold text-text">
+                No text animation
+              </div>
+              <div className="mt-0.5 text-[10px] text-text-dim">
+                Apply at {playhead.toFixed(2)}s
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowPicker((v) => !v)}
+              className="rounded bg-accent/12 px-3 py-1.5 text-[12px] font-semibold text-accent hover:bg-accent/18"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+        {showPicker ? <TextPresetPicker current={null} onPick={pickPreset} /> : null}
+      </div>
+    )
+  }
+
+  const currentPreset =
+    textPresetForConfig(current) ??
+    TEXT_ANIMATION_PRESETS[0]!
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-md border border-border bg-panel-raised">
+        <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 p-2.5">
+          <div className="grid min-w-0 grid-cols-[minmax(72px,96px)_minmax(0,1fr)] items-center gap-2">
+            <TextAnimationThumb preset={currentPreset} active />
+            <div className="min-w-0">
+              <div className="truncate text-[12px] font-semibold text-text">
+                {currentPreset.label}
+              </div>
+              <div className="mt-0.5 truncate text-[10px] text-text-dim">
+                {textApplyLabel(current.applyTo)} · {current.mode === 'in' ? 'In' : 'Out'}
+              </div>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowPicker((v) => !v)}
+            className="h-8 rounded bg-accent/12 px-3 text-[11px] font-semibold text-accent hover:bg-accent/18"
+          >
+            Change
+          </button>
+        </div>
+        <div className="border-t border-border p-2.5">
+          <div className="grid grid-cols-2 rounded bg-panel p-0.5">
+            {(['in', 'out'] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => patch({ mode })}
+                className={[
+                  'h-8 rounded text-[12px] font-semibold',
+                  current.mode === mode
+                    ? 'bg-panel-raised text-text shadow-sm'
+                    : 'text-text-dim hover:text-text-muted',
+                ].join(' ')}
+              >
+                {mode === 'in' ? 'In' : 'Out'}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {showPicker ? <TextPresetPicker current={current.id} onPick={pickPreset} /> : null}
+
+      <ControlCard title="Effect">
+        {(current.id === 'blur' || current.id === 'blur-slide') ? (
+          <ParamRow label="Blur radius">
+            <NumberField
+              value={current.blurRadius}
+              onCommit={(blurRadius) => patch({ blurRadius })}
+              min={0}
+              max={128}
+              width="w-24"
+            />
+          </ParamRow>
+        ) : null}
+        {usesDirection(current.id) ? (
+          <ParamRow label="Direction">
+            <DirectionButtons
+              value={current.direction}
+              onChange={(direction) =>
+                patch(textDirectionPatch(current, direction))
+              }
+            />
+          </ParamRow>
+        ) : null}
+        {usesTravel(current.id) ? (
+          <ParamRow label="Travel distance">
+            <NumberField
+              value={Math.round(current.travelDistance * 100)}
+              onCommit={(pct) => patch({ travelDistance: pct / 100 })}
+              min={0}
+              max={300}
+              suffix="%"
+              width="w-24"
+            />
+          </ParamRow>
+        ) : null}
+        <ParamRow label="Duration">
+          <NumberField
+            value={Math.round(current.duration * 1000)}
+            onCommit={(ms) => patch({ duration: ms / 1000 })}
+            min={50}
+            suffix="ms"
+            width="w-24"
+          />
+        </ParamRow>
+        {current.id === 'gradient-reveal' ? (
+          <>
+            <ParamRow label="Start gradient">
+              <GradientTextField
+                key={`start-${gradientToText(current.startGradient)}`}
+                value={gradientToText(current.startGradient)}
+                onCommit={(value) => {
+                  const fill = parseGradientText(value)
+                  if (fill) patch({ startGradient: fill })
+                }}
+              />
+            </ParamRow>
+            <ParamRow label="End gradient">
+              <GradientTextField
+                key={`end-${gradientToText(current.endGradient)}`}
+                value={gradientToText(current.endGradient)}
+                onCommit={(value) => {
+                  const fill = parseGradientText(value)
+                  if (fill) patch({ endGradient: fill })
+                }}
+              />
+            </ParamRow>
+          </>
+        ) : null}
+        <ParamRow label="Acceleration">
+          <div className="grid max-w-full grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1">
+            <input
+              value={visibleEasingDraft}
+              onChange={(e) => updateEasingText(e.currentTarget.value)}
+              className="h-8 min-w-0 rounded bg-panel px-2 font-mono text-[11px] text-text outline-none ring-1 ring-transparent hover:ring-border focus:ring-2 focus:ring-accent/45"
+              title="Comma-separated cubic bezier values"
+            />
+            <button
+              type="button"
+              onClick={copyEasing}
+              className="h-8 rounded bg-panel px-2 text-[11px] text-text-muted hover:text-text"
+              title="Copy easing values"
+            >
+              {copiedEasing ? 'Copied' : 'Copy'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowEasing((v) => !v)}
+              aria-pressed={showEasing}
+              className={[
+                'grid h-8 w-8 place-items-center rounded bg-panel text-text-muted hover:text-text',
+                showEasing ? 'bg-accent/14 text-accent' : '',
+              ].join(' ')}
+              title="Show curve presets and graph editor"
+            >
+              <SlidersIcon />
+            </button>
+          </div>
+        </ParamRow>
+        {showEasing ? (
+          <>
+            <EasingPicker
+              title={null}
+              allowedPresetIds={[...TEXT_EASING_PRESETS]}
+              presetId={current.easingPresetId}
+              strength={current.easingStrength}
+              onChange={({ presetId, strength }) =>
+                patch({
+                  easingPresetId: presetId,
+                  easingStrength: strength,
+                  customEasing: undefined,
+                })
+              }
+            />
+            <GraphEditor />
+          </>
+        ) : null}
+      </ControlCard>
+
+      <ControlCard title="Text">
+        <ParamRow label="Apply effect to">
+          <SelectField<TextAnimationApplyTo>
+            value={current.applyTo}
+            options={[
+              ['letters', 'Letters'],
+              ['words', 'Words'],
+              ['lines', 'Lines'],
+              ['layer', 'Layer'],
+            ]}
+            onChange={(applyTo) => patch({ applyTo })}
+          />
+        </ParamRow>
+        <ParamRow label="Order">
+          <SelectField<TextAnimationOrder>
+            value={current.order}
+            options={[
+              ['forward', 'Forward'],
+              ['backward', 'Backward'],
+            ]}
+            onChange={(order) => patch({ order })}
+          />
+        </ParamRow>
+        <ParamRow label="Smoothing">
+          <SelectField<TextAnimationSmoothing>
+            value={current.smoothing}
+            options={[
+              ['none', 'None'],
+              ['soft', 'Soft'],
+              ['smooth', 'Smooth'],
+            ]}
+            onChange={(smoothing) => patch({ smoothing })}
+          />
+        </ParamRow>
+      </ControlCard>
+    </div>
+  )
+}
+
+function TextPresetPicker({
+  current,
+  onPick,
+}: {
+  current: TextAnimationId | null
+  onPick: (id: TextAnimationId) => void
+}) {
+  const categories = Array.from(new Set(TEXT_ANIMATION_PRESETS.map((p) => p.category)))
+  return (
+    <div className="max-h-[420px] overflow-auto border-b border-border bg-panel-raised p-3">
+      {categories.map((category) => (
+        <div key={category} className="mb-5 last:mb-0">
+          <div className="mb-2 text-[15px] font-bold text-text">{category}</div>
+          <div className="grid grid-cols-2 gap-2">
+            {TEXT_ANIMATION_PRESETS.filter((p) => p.category === category).map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                data-preview-on="1"
+                onClick={() => onPick(preset.id)}
+                className="group flex flex-col gap-1.5 rounded-md border border-border-strong/60 bg-panel-raised p-1.5 text-left transition-colors hover:border-border-strong hover:bg-panel"
+              >
+                <TextAnimationCardPreview preset={preset} selected={current === preset.id} />
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function TextAnimationCardPreview({
+  preset,
+  selected = false,
+}: {
+  preset: (typeof TEXT_ANIMATION_PRESETS)[number]
+  selected?: boolean
+}) {
+  return (
+    <>
+      <div
+        className={[
+          'hm-text-preset-stage h-14 w-full rounded-[5px] bg-panel',
+          selected ? 'ring-1 ring-accent/65' : '',
+        ].join(' ')}
+      >
+        <span className={`hm-text-preset-subject hm-text-preset-${preset.id}`}>
+          {Array.from(TEXT_ANIMATION_PREVIEW_WORD).map((char, index) => (
+            <span
+              key={`${preset.id}-${index}`}
+              className="hm-text-preview-letter"
+              style={{ '--i': index } as CSSProperties}
+            >
+              {char}
+            </span>
+          ))}
+        </span>
+      </div>
+      <span className="block px-1 pt-1 pb-0.5 text-[11px] text-text">
+        {preset.label}
+      </span>
+    </>
+  )
+}
+
+function TextAnimationThumb({
+  preset,
+  active = false,
+}: {
+  preset: (typeof TEXT_ANIMATION_PRESETS)[number]
+  active?: boolean
+}) {
+  return (
+    <div
+      className={[
+        'hm-text-preset-stage h-12 min-w-0 rounded-[5px] bg-panel',
+        active ? 'ring-1 ring-accent/55' : '',
+      ].join(' ')}
+    >
+      <span className={`hm-text-preset-subject hm-text-preset-${preset.id}`}>
+        {Array.from(TEXT_ANIMATION_PREVIEW_WORD).map((char, index) => (
+          <span
+            key={`${preset.id}-thumb-${index}`}
+            className="hm-text-preview-letter"
+            style={{ '--i': index } as CSSProperties}
+          >
+            {char}
+          </span>
+        ))}
+      </span>
+    </div>
+  )
+}
+
+function textApplyLabel(value: TextAnimationApplyTo): string {
+  if (value === 'letters') return 'Letters'
+  if (value === 'words') return 'Words'
+  if (value === 'lines') return 'Lines'
+  return 'Layer'
+}
+
+function ControlCard({
+  title,
+  children,
+}: {
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <div className="rounded-md border border-border bg-panel-raised">
+      <div className="border-b border-border px-2.5 py-2 text-[10px] font-semibold tracking-wider text-text-muted uppercase">
+        {title}
+      </div>
+      <div className="space-y-2.5 p-2.5">{children}</div>
+    </div>
+  )
+}
+
+function ParamRow({
+  label,
+  children,
+}: {
+  label: string
+  children: ReactNode
+}) {
+  return (
+    <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,auto)] items-center gap-3">
+      <div className="min-w-0 truncate text-[12px] text-text-dim">{label}</div>
+      <div className="min-w-0 justify-self-end">{children}</div>
+    </div>
+  )
+}
+
+function SelectField<T extends string>({
+  value,
+  options,
+  onChange,
+}: {
+  value: T
+  options: Array<[T, string]>
+  onChange: (next: T) => void
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.currentTarget.value as T)}
+      className="h-8 max-w-full rounded bg-panel px-2 text-[12px] text-text outline-none ring-1 ring-transparent hover:ring-border focus:ring-2 focus:ring-accent/45"
+    >
+      {options.map(([id, label]) => (
+        <option key={id} value={id}>
+          {label}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+function DirectionButtons({
+  value,
+  onChange,
+}: {
+  value: TextAnimationDirection
+  onChange: (next: TextAnimationDirection) => void
+}) {
+  const buttons: Array<[TextAnimationDirection, string]> = [
+    ['up', '↑'],
+    ['down', '↓'],
+    ['left', '←'],
+    ['right', '→'],
+  ]
+  return (
+    <div className="grid grid-cols-4 rounded bg-panel p-0.5">
+      {buttons.map(([id, label]) => (
+        <button
+          key={id}
+          type="button"
+          onClick={() => onChange(id)}
+          className={[
+            'h-8 w-8 rounded text-[17px]',
+            value === id ? 'bg-accent/14 text-accent' : 'text-text-dim hover:text-text',
+          ].join(' ')}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function GradientTextField({
+  value,
+  onCommit,
+}: {
+  value: string
+  onCommit: (next: string) => void
+}) {
+  const [draft, setDraft] = useState(value)
+  return (
+    <input
+      value={draft}
+      onChange={(e) => setDraft(e.currentTarget.value)}
+      onBlur={() => onCommit(draft)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          onCommit(draft)
+          e.currentTarget.blur()
+        }
+      }}
+      className="h-8 w-48 max-w-full rounded bg-panel px-2 font-mono text-[11px] text-text outline-none ring-1 ring-transparent hover:ring-border focus:ring-2 focus:ring-accent/45"
+      title="Comma-separated gradient colors"
+    />
+  )
+}
+
+function SlidersIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+    >
+      <path d="M2 4h3" />
+      <path d="M9 4h5" />
+      <path d="M7 2.5v3" />
+      <path d="M2 8h7" />
+      <path d="M13 8h1" />
+      <path d="M11 6.5v3" />
+      <path d="M2 12h2" />
+      <path d="M8 12h6" />
+      <path d="M6 10.5v3" />
+    </svg>
+  )
+}
+
+function usesDirection(id: TextAnimationId): boolean {
+  return (
+    id === 'slide-up' ||
+    id === 'slide-down' ||
+    id === 'slide-left' ||
+    id === 'slide-right' ||
+    id === 'mask-up' ||
+    id === 'mask-down' ||
+    id === 'blur-slide' ||
+    id === 'character-wave' ||
+    id === 'skew'
+  )
+}
+
+function usesTravel(id: TextAnimationId): boolean {
+  return (
+    id === 'slide-up' ||
+    id === 'slide-down' ||
+    id === 'slide-left' ||
+    id === 'slide-right' ||
+    id === 'mask-up' ||
+    id === 'mask-down' ||
+    id === 'blur-slide' ||
+    id === 'character-wave' ||
+    id === 'skew'
+  )
+}
+
+function textPresetForConfig(config: TextAnimationConfig) {
+  return (
+    TEXT_ANIMATION_PRESETS.find(
+      (preset) => preset.id === directionalTextAnimationId(config),
+    ) ?? TEXT_ANIMATION_PRESETS.find((preset) => preset.id === config.id)
+  )
+}
+
+function textDirectionPatch(
+  config: TextAnimationConfig,
+  direction: TextAnimationDirection,
+): Partial<TextAnimationConfig> {
+  const nextId = directionalTextAnimationId({ ...config, direction })
+  return nextId === config.id ? { direction } : { id: nextId, direction }
+}
+
+function directionalTextAnimationId(
+  config: Pick<TextAnimationConfig, 'id' | 'direction'>,
+): TextAnimationId {
+  if (
+    config.id === 'slide-up' ||
+    config.id === 'slide-down' ||
+    config.id === 'slide-left' ||
+    config.id === 'slide-right'
+  ) {
+    return `slide-${config.direction}` as TextAnimationId
+  }
+  if (config.id === 'mask-up' || config.id === 'mask-down') {
+    return config.direction === 'down' ? 'mask-down' : 'mask-up'
+  }
+  return config.id
+}
+
+function easingToText(config: TextAnimationConfig): string {
+  const curve = bezierOf(
+    config.easingPresetId === 'custom' && config.customEasing
+      ? config.customEasing
+      : findEasingPreset(config.easingPresetId).build(config.easingStrength),
+  )
+  return curve.map((n) => formatCurveNumber(n)).join(', ')
+}
+
+function gradientToText(fill: Fill | null | undefined): string {
+  if (!fill || fill.kind !== 'linear') return '#7c3aed, #06b6d4'
+  return fill.stops.map((stop) => stop.color).join(', ')
+}
+
+function parseGradientText(value: string): Fill | null {
+  const colors = value
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+  if (colors.length < 2) return null
+  const max = Math.max(1, colors.length - 1)
+  return {
+    kind: 'linear',
+    angle: 90,
+    stops: colors.map((color, index) => ({
+      color,
+      at: index / max,
+    })),
+  }
+}
+
+function isTextEasingOnlyPatch(patch: Partial<TextAnimationConfig>): boolean {
+  const keys = Object.keys(patch)
+  return (
+    keys.length > 0 &&
+    keys.every((key) =>
+      key === 'easingPresetId' ||
+      key === 'easingStrength' ||
+      key === 'customEasing' ||
+      key === 'acceleration'
+    )
+  )
+}
+
+function parseEasingText(
+  value: string,
+): Pick<TextAnimationConfig, 'easingPresetId' | 'easingStrength' | 'customEasing'> | null {
+  const parts = value
+    .split(',')
+    .map((part) => Number(part.trim()))
+    .filter((n) => Number.isFinite(n))
+  if (parts.length !== 4) return null
+  const [x1, y1, x2, y2] = parts
+  const clampedX1 = Math.max(0, Math.min(1, x1!))
+  const clampedX2 = Math.max(0, Math.min(1, x2!))
+  return {
+    easingPresetId: 'custom',
+    easingStrength: 50,
+    customEasing: { bezier: [clampedX1, y1!, clampedX2, y2!] },
+  }
+}
+
+function formatCurveNumber(n: number): string {
+  const rounded = Math.round(n * 1000) / 1000
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(3).replace(/0+$/, '').replace(/\.$/, '')
+}
+
+function PresetTabs({
+  value,
+  onChange,
+  inCount,
+  outCount,
+}: {
+  value: 'in' | 'out'
+  onChange: (next: 'in' | 'out') => void
+  inCount: number
+  outCount: number
+}) {
+  return (
+    <div className="grid grid-cols-2 rounded-md border border-border bg-panel p-0.5">
+      {([
+        ['in', `In (${inCount})`],
+        ['out', `Out (${outCount})`],
+      ] as const).map(([id, label]) => (
+        <button
+          key={id}
+          type="button"
+          onClick={() => onChange(id)}
+          className={[
+            'h-8 rounded text-[12px] font-semibold',
+            value === id
+              ? 'bg-panel-raised text-text shadow-sm'
+              : 'text-text-dim hover:text-text-muted',
+          ].join(' ')}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function PresetGrid({
   presets,
   onPick,
 }: {
-  title: string
   presets: { id: AnimPresetId; label: string }[]
   onPick: (id: AnimPresetId) => void
 }) {
   return (
-    <div>
-      <div className="mb-2 text-[10px] font-medium tracking-wider text-text-dim uppercase">
-        {title}
-      </div>
+    <div className="rounded-md border border-border bg-panel-raised p-2.5">
       <div className="grid grid-cols-2 gap-2">
         {presets.map((p) => (
           <PresetButton key={p.id} preset={p} onPick={onPick} />
@@ -267,7 +1183,7 @@ function StaggerControls({
   onDelayChange: (next: number) => void
 }) {
   return (
-    <div className="rounded border border-border bg-panel-raised p-2.5">
+    <div>
       <div className="flex items-center justify-between">
         <div className="text-[10px] font-medium tracking-wider text-text-dim uppercase">
           Stagger
@@ -323,12 +1239,6 @@ function StaggerControls({
           />
         </div>
       </div>
-      {on ? (
-        <div className="mt-2 text-[10px] leading-snug text-text-dim">
-          Presets apply to children when a single parent is selected,
-          otherwise to the selection itself. First layer first.
-        </div>
-      ) : null}
     </div>
   )
 }

--- a/src/ui/hooks/useAnimatedValues.ts
+++ b/src/ui/hooks/useAnimatedValues.ts
@@ -34,6 +34,7 @@ export interface AnimatedValue {
   opacity?: number
   cornerRadius?: number
   fill?: string
+  textProgress?: number
   focusDistance?: number
   focusX?: number
   focusY?: number


### PR DESCRIPTION
## Summary
- add text animation presets and text.progress track support
- render per-letter/word/line/layer text animation effects on canvas
- add animate-panel controls for text animation presets, easing, gradients, and progressive layer/text accordions

## Validation
- git diff --cached --check before commit
- focused lint/typecheck surfaced pre-existing Canvas/GraphEditor issues outside the staged text-animation diff