### PR TITLE
Fix text animation mode restamping

### DIFF
--- a/src/anim/textAnimations.ts
+++ b/src/anim/textAnimations.ts
@@ -179,7 +179,7 @@ export function stampTextAnimationKeyframes(
   config: TextAnimationConfig,
   text: string,
 ): void {
-  clearTextAnimationKeyframes(api, nodeId, config.mode)
+  clearTextAnimationKeyframes(api, nodeId)
   const start = config.startTime
   const end = start + config.duration + Math.max(0, textSegmentCount(text, config.applyTo) - 1) * config.delay
   const from = config.mode === 'in' ? 0 : 1
@@ -208,14 +208,10 @@ export function updateTextAnimationEasing(
 function clearTextAnimationKeyframes(
   api: SceneAPI,
   nodeId: NodeId,
-  mode: TextAnimationMode,
 ): void {
   for (const track of api.getTracksForNode(nodeId)) {
     if (track.propertyId !== 'text.progress') continue
-    const kept = track.keyframes.filter((keyframe) => keyframe.presetOrigin !== mode)
-    if (kept.length === track.keyframes.length) continue
-    if (kept.length === 0) api.deleteTrack(track.id)
-    else api.setTrack({ ...track, keyframes: kept })
+    api.deleteTrack(track.id)
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the text.progress track when restamping a text animation
- prevent stale In/Out progress keyframes from coexisting on one text animation track
- keeps In as reveal/appear and Out as exit/disappear

## Validation
- pnpm exec eslint src/anim/textAnimations.ts
- focused typecheck filter for src/anim/textAnimations.ts returned no matching errors
- git diff --check