### PR TITLE
Fix text animation in/out direction

### DIFF
--- a/src/anim/textAnimations.ts
+++ b/src/anim/textAnimations.ts
@@ -182,10 +182,8 @@ export function stampTextAnimationKeyframes(
   clearTextAnimationKeyframes(api, nodeId)
   const start = config.startTime
   const end = start + config.duration + Math.max(0, textSegmentCount(text, config.applyTo) - 1) * config.delay
-  const from = config.mode === 'in' ? 0 : 1
-  const to = config.mode === 'in' ? 1 : 0
-  addKeyframe(api, nodeId, 'text.progress', start, from, easingForText(config), config.mode)
-  addKeyframe(api, nodeId, 'text.progress', end, to, undefined, config.mode)
+  addKeyframe(api, nodeId, 'text.progress', start, 0, easingForText(config), config.mode)
+  addKeyframe(api, nodeId, 'text.progress', end, 1, undefined, config.mode)
 }
 
 export function updateTextAnimationEasing(

--- a/src/ui/Canvas.tsx
+++ b/src/ui/Canvas.tsx
@@ -4126,7 +4126,7 @@ function textAnimationSegmentStyle(
     : Math.max(0, Math.min(1, progress))
   const globalElapsed = timelineProgress === undefined
     ? playhead - config.startTime
-    : (config.mode === 'in' ? timelineProgress : 1 - timelineProgress) * totalSpan
+    : timelineProgress * totalSpan
   const raw = (globalElapsed - orderIndex * config.delay) / Math.max(0.05, config.duration)
   const u = Math.max(0, Math.min(1, raw))
   const eased = progress === undefined ? easeTextAnimation(u, config.acceleration) : u
@@ -4285,7 +4285,7 @@ function displayTextForSegment(
     : Math.max(0, Math.min(1, progress))
   const globalElapsed = timelineProgress === undefined
     ? playhead - config.startTime
-    : (config.mode === 'in' ? timelineProgress : 1 - timelineProgress) * totalSpan
+    : timelineProgress * totalSpan
   const u = Math.max(0, Math.min(1, (globalElapsed - orderIndex * config.delay) / Math.max(0.05, config.duration)))
   if ((config.mode === 'in' && u >= 0.85) || (config.mode === 'out' && u <= 0.15)) return text
   const glyphs = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#$%&'


### PR DESCRIPTION
## Summary
- make text.progress keyframes run 0 to 1 for both In and Out text animations
- render text animation progress directly so In reveals and Out exits

## Validation
- pnpm exec eslint src/anim/textAnimations.ts
- git diff --check
- pnpm build:dir

Note: full Canvas eslint/typecheck still report existing unrelated issues in Canvas.tsx.