### PR TITLE
Fix appear text animation direction

### DIFF
--- a/src/ui/Canvas.tsx
+++ b/src/ui/Canvas.tsx
@@ -4156,7 +4156,7 @@ function textAnimationSegmentStyle(
     config.id === 'typewriter'
   ) {
     opacity = config.id === 'appear' || config.id === 'typewriter'
-      ? amount < 0.5 ? 0 : 1
+      ? amount > 0.5 ? 0 : 1
       : 1 - amount
   }
   if (config.id.startsWith('slide') || config.id === 'blur-slide') {


### PR DESCRIPTION
## Summary
- flip the discrete visibility threshold for Appear and Typewriter text animations
- keep In hidden at the first keyframe and visible at the end; Out visible at the first keyframe and hidden at the end

## Validation
- git diff --check
- pnpm build:dir

Note: focused typecheck scan only reports the existing unrelated Canvas.tsx AudioChip issue.