### PR TITLE
Guard create_scene transform property docs

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -59,6 +59,29 @@ test('create_scene description lists supported camera property ids', () => {
   }
 })
 
+test('create_scene description lists supported transform property ids', () => {
+  const description = createSceneTool.description
+  if (typeof description !== 'string') {
+    throw new Error('create_scene description is missing')
+  }
+  for (const propertyId of [
+    'transform.x',
+    'transform.y',
+    'transform.z',
+    'transform.rotation',
+    'transform.rotationX',
+    'transform.rotationY',
+    'transform.scaleX',
+    'transform.scaleY',
+    'transform.anchorX',
+    'transform.anchorY',
+    'transform.anchorZ',
+  ]) {
+    const escapedPropertyId = propertyId.replaceAll('.', '\\.')
+    assert.match(description, new RegExp(`${escapedPropertyId}(?:,|\\.)`))
+  }
+})
+
 test('create_scene description lists supported layout property ids', () => {
   const description = createSceneTool.description
   if (typeof description !== 'string') {


### PR DESCRIPTION
## Summary\n- add a focused CLI MCP test that ensures create_scene documents supported transform property IDs\n- helps catch future drift between the agent-facing authoring docs and the typed PropertyId surface\n\n## Verification\n- pnpm --dir cli test