### PR TITLE
Support stacked text animations

### DIFF
--- a/src/anim/engine.ts
+++ b/src/anim/engine.ts
@@ -5,6 +5,7 @@ import type { SceneAPI } from '@/scene/doc'
 import { PROPERTIES } from '@/scene/props'
 import { lerpOklchStrings } from './color'
 import { evaluator, type EasingEvaluator } from './easing'
+import type { TextAnimationConfig } from './textAnimations'
 
 /**
  * Animation engine — the only thing in the codebase allowed to drive
@@ -74,6 +75,8 @@ export interface AnimatedValue {
   fill?: string
   /** 0→1 progress for text-specific animation effects. */
   textProgress?: number
+  /** Text effect config attached to the active text.progress track. */
+  textAnimation?: TextAnimationConfig
   focusDistance?: number
   focusX?: number
   focusY?: number
@@ -281,6 +284,10 @@ function applyTrack(
 ): void {
   const kfs = track.keyframes
   if (kfs.length === 0) return
+  if (track.propertyId === 'text.progress') {
+    applyTextProgressTrack(track, t, into, cache)
+    return
+  }
   // Boundary cases — single keyframe, or t outside range.
   let a = kfs[0]!
   let b = kfs[kfs.length - 1]!
@@ -335,6 +342,46 @@ function applyTrack(
     // Mixed or unsupported value shapes — step.
     writeProperty(track.propertyId, u < 1 ? av : bv, into)
   }
+}
+
+function applyTextProgressTrack(
+  track: Track,
+  t: number,
+  into: AnimatedValue,
+  cache: Map<string, EasingEvaluator>,
+): void {
+  const kfs = [...track.keyframes].sort((a, b) => a.time - b.time)
+  if (kfs.length < 2) return
+  const first = kfs[0]!
+  const last = kfs[kfs.length - 1]!
+  if (t < first.time || t > last.time) return
+
+  let a = first
+  let b = last
+  for (let i = 0; i < kfs.length - 1; i++) {
+    const k0 = kfs[i]!
+    const k1 = kfs[i + 1]!
+    if (t >= k0.time && t <= k1.time) {
+      a = k0
+      b = k1
+      break
+    }
+  }
+
+  const span = b.time - a.time
+  const rawU = span <= 0 ? 0 : (t - a.time) / span
+  const cacheKey = track.id + ':' + a.id
+  let easer = cache.get(cacheKey)
+  if (!easer) {
+    easer = evaluator(a.easingOut ?? track.defaultEasing)
+    cache.set(cacheKey, easer)
+  }
+  const u = easer(rawU)
+  const av = a.value
+  const bv = b.value
+  if (typeof av !== 'number' || typeof bv !== 'number') return
+  into.textProgress = av + (bv - av) * u
+  if (track.textAnimation) into.textAnimation = track.textAnimation
 }
 
 /**

--- a/src/anim/textAnimations.ts
+++ b/src/anim/textAnimations.ts
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Fill } from '@/scene/types'
-import { addKeyframe } from './tracks'
 import { findEasingPreset, type EasingPresetId } from './easingPresets'
 import type { SceneAPI } from '@/scene/doc'
-import type { EasingKind, NodeId } from '@/scene/types'
+import type { EasingKind, Keyframe, NodeId, Track, TrackId } from '@/scene/types'
 
 export type TextAnimationId =
   | 'appear'
@@ -143,6 +142,7 @@ export function applyTextAnimation(
   id: TextAnimationId,
   startTime: number,
   existing?: TextAnimationConfig | null,
+  options: { trackId?: TrackId; replaceAll?: boolean } = {},
 ): TextAnimationConfig {
   const defaults = textAnimationDefaults(id)
   const previous = existing ? normalizeTextAnimation(existing) : null
@@ -169,6 +169,7 @@ export function applyTextAnimation(
     nodeId,
     next,
     node?.kind === 'text' ? node.text : '',
+    options,
   )
   return next
 }
@@ -178,28 +179,43 @@ export function stampTextAnimationKeyframes(
   nodeId: NodeId,
   config: TextAnimationConfig,
   text: string,
-): void {
-  clearTextAnimationKeyframes(api, nodeId)
+  options: { trackId?: TrackId; replaceAll?: boolean } = {},
+): TrackId {
+  if (options.replaceAll) clearTextAnimationKeyframes(api, nodeId)
   const start = config.startTime
   const end = start + config.duration + Math.max(0, textSegmentCount(text, config.applyTo) - 1) * config.delay
-  addKeyframe(api, nodeId, 'text.progress', start, 0, easingForText(config), config.mode)
-  addKeyframe(api, nodeId, 'text.progress', end, 1, undefined, config.mode)
+  const trackId = options.trackId ?? genId()
+  const track: Track = {
+    id: trackId,
+    nodeId,
+    propertyId: 'text.progress',
+    defaultEasing: easingForText(config),
+    textAnimation: config,
+    keyframes: [
+      textKeyframe(start, 0, easingForText(config), config.mode),
+      textKeyframe(end, 1, undefined, config.mode),
+    ],
+  }
+  api.setTrack(track)
+  return trackId
 }
 
 export function updateTextAnimationEasing(
   api: SceneAPI,
   nodeId: NodeId,
   config: TextAnimationConfig,
+  trackId?: TrackId,
 ): void {
   const easing = easingForText(config)
   for (const track of api.getTracksForNode(nodeId)) {
     if (track.propertyId !== 'text.progress') continue
+    if (trackId && track.id !== trackId) continue
     const keyframes = track.keyframes.map((keyframe, index) => {
       const isLast = index === track.keyframes.length - 1
       if (keyframe.presetOrigin !== config.mode || isLast) return keyframe
       return { ...keyframe, easingOut: easing }
     })
-    api.setTrack({ ...track, defaultEasing: easing, keyframes })
+    api.setTrack({ ...track, defaultEasing: easing, textAnimation: config, keyframes })
   }
 }
 
@@ -218,6 +234,28 @@ function textSegmentCount(text: string, applyTo: TextAnimationApplyTo): number {
   if (applyTo === 'lines') return Math.max(1, text.split('\n').filter(Boolean).length)
   if (applyTo === 'words') return Math.max(1, text.split(/\s+/).filter(Boolean).length)
   return Math.max(1, Array.from(text).filter((char) => char !== ' ' && char !== '\n').length)
+}
+
+function textKeyframe(
+  time: number,
+  value: number,
+  easingOut?: EasingKind,
+  presetOrigin?: TextAnimationMode,
+): Keyframe {
+  return {
+    id: genId(),
+    time,
+    value,
+    ...(easingOut ? { easingOut } : {}),
+    ...(presetOrigin ? { presetOrigin } : {}),
+  }
+}
+
+function genId(): string {
+  return (
+    Math.random().toString(36).slice(2, 10) +
+    Math.random().toString(36).slice(2, 10)
+  )
 }
 
 function easingForText(config: TextAnimationConfig): EasingKind {

--- a/src/anim/tracks.ts
+++ b/src/anim/tracks.ts
@@ -59,7 +59,10 @@ export function ensureTrack(
 export function removeTrack(api: SceneAPI, trackId: TrackId): void {
   const track = api.getTrack(trackId)
   api.deleteTrack(trackId)
-  if (track?.propertyId === 'text.progress') {
+  if (
+    track?.propertyId === 'text.progress' &&
+    api.getTracksForNode(track.nodeId).every((candidate) => candidate.propertyId !== 'text.progress')
+  ) {
     api.setNodeProperty(track.nodeId, 'textAnimation', null)
   }
 }
@@ -151,7 +154,10 @@ export function removeKeyframe(
     // Empty track is dead weight. Text animations need a start and end
     // progress keyframe; with fewer than two, the effect is inactive.
     api.deleteTrack(trackId)
-    if (track.propertyId === 'text.progress') {
+    if (
+      track.propertyId === 'text.progress' &&
+      api.getTracksForNode(track.nodeId).every((candidate) => candidate.propertyId !== 'text.progress')
+    ) {
       api.setNodeProperty(track.nodeId, 'textAnimation', null)
     }
   } else {

--- a/src/scene/doc.ts
+++ b/src/scene/doc.ts
@@ -619,6 +619,7 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
     propertyId: y.get('propertyId') as PropertyId,
     keyframes: (y.get('keyframes') as Keyframe[]) ?? [],
     defaultEasing: (y.get('defaultEasing') as Track['defaultEasing']) ?? 'ease-in-out',
+    textAnimation: normalizeTextAnimation(y.get('textAnimation')),
   })
 
   // --- API implementation -----------------------------------------------
@@ -967,6 +968,7 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
         y.set('nodeId', track.nodeId)
         y.set('propertyId', track.propertyId)
         y.set('defaultEasing', track.defaultEasing)
+        y.set('textAnimation', normalizeTextAnimation(track.textAnimation) ?? null)
         // Keyframes are a plain array — swap wholesale. Fine for v1;
         // collaborators editing the same track keyframe list will
         // last-writer-wins. Split into nested Y.Array later if needed.

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -948,6 +948,8 @@ export interface Track {
   keyframes: Keyframe[]
   /** Fallback easing if a keyframe doesn't specify its own easingOut. */
   defaultEasing: EasingKind
+  /** Per-range text effect config for stacked text animation tracks. */
+  textAnimation?: import('@/anim/textAnimations').TextAnimationConfig | null
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ui/Canvas.tsx
+++ b/src/ui/Canvas.tsx
@@ -3907,7 +3907,7 @@ function TextGlyphs({
   const playhead = useUI((s) => s.playhead)
   const api = useSceneAPI()
   const isEditing = editingTextId === node.id
-  const textAnimation = normalizeTextAnimation(node.textAnimation)
+  const textAnimation = anim?.textAnimation ?? normalizeTextAnimation(node.textAnimation)
 
   // Common typography style block. Shared between read and edit modes
   // so the text doesn't shift visually when you press Enter to edit.

--- a/src/ui/PresetsPanel.tsx
+++ b/src/ui/PresetsPanel.tsx
@@ -401,6 +401,10 @@ function TextAnimationPanel() {
   const selection = useUI((s) => s.selection)
   const selectedTrackIds = useUI((s) => s.selectedTrackIds)
   const selectedKeyframes = useUI((s) => s.selectedKeyframes)
+  const staggerOn = useUI((s) => s.staggerOn)
+  const staggerDelay = useUI((s) => s.staggerDelay)
+  const setStaggerOn = useUI((s) => s.setStaggerOn)
+  const setStaggerDelay = useUI((s) => s.setStaggerDelay)
   const playhead = useUI((s) => s.playhead)
   const [showPicker, setShowPicker] = useState(false)
   const [showEasing, setShowEasing] = useState(false)
@@ -412,11 +416,11 @@ function TextAnimationPanel() {
     .filter((node): node is NonNullable<typeof node> & { kind: 'text' } => node?.kind === 'text')
   const primary = selectedTextNodes[0]
   const primaryTextAnimationTrack = primary
-    ? findTextAnimationTrack(api, primary.id, selectedTextTrackFilter)
+    ? findTextAnimationTrack(api, primary.id, selectedTextTrackFilter, playhead)
     : null
   const current = primaryTextAnimationTrack
     ? withTextTrackTiming(
-        normalizeTextAnimation(primary?.textAnimation),
+        normalizeTextAnimation(primaryTextAnimationTrack.textAnimation ?? primary?.textAnimation),
         primaryTextAnimationTrack,
         primary?.text ?? '',
       )
@@ -428,18 +432,20 @@ function TextAnimationPanel() {
   const patch = (next: Partial<TextAnimationConfig>) => {
     if (!current) return
     for (const node of selectedTextNodes) {
-      const base = normalizeTextAnimation(node.textAnimation) ?? current
+      const textTrack = findTextAnimationTrack(api, node.id, selectedTextTrackFilter, playhead)
+      const base = normalizeTextAnimation(textTrack?.textAnimation ?? node.textAnimation) ?? current
       const config = {
         ...base,
         ...next,
       }
-      const textTrack = findTextAnimationTrack(api, node.id, selectedTextTrackFilter)
       const timedConfig = withTextTrackTiming(config, textTrack, node.text, next) ?? config
       api.setNodeProperty(node.id, 'textAnimation', timedConfig)
       if (isTextEasingOnlyPatch(next)) {
-        updateTextAnimationEasing(api, node.id, timedConfig)
+        updateTextAnimationEasing(api, node.id, timedConfig, textTrack?.id)
       } else {
-        stampTextAnimationKeyframes(api, node.id, timedConfig, node.text)
+        stampTextAnimationKeyframes(api, node.id, timedConfig, node.text, {
+          trackId: textTrack?.id,
+        })
       }
     }
   }
@@ -460,13 +466,19 @@ function TextAnimationPanel() {
   }
 
   const pickPreset = (id: TextAnimationId) => {
-    for (const node of selectedTextNodes) {
+    for (let i = 0; i < selectedTextNodes.length; i++) {
+      const node = selectedTextNodes[i]!
+      const textTrack = findTextAnimationTrack(api, node.id, selectedTextTrackFilter, playhead)
+      const startTime = textTrack
+        ? trackStartTime(textTrack)
+        : playhead + (staggerOn && selectedTextNodes.length > 1 ? i * staggerDelay : 0)
       applyTextAnimation(
         api,
         node.id,
         id,
-        playhead,
-        normalizeTextAnimation(node.textAnimation),
+        startTime,
+        normalizeTextAnimation(textTrack?.textAnimation ?? node.textAnimation),
+        { trackId: textTrack?.id },
       )
     }
     setShowPicker(false)
@@ -495,6 +507,13 @@ function TextAnimationPanel() {
           </div>
         </div>
         {showPicker ? <TextPresetPicker current={null} onPick={pickPreset} /> : null}
+        <TextStaggerControls
+          enabled={staggerOn}
+          delay={staggerDelay}
+          disabled={selectedTextNodes.length < 2}
+          onEnabledChange={setStaggerOn}
+          onDelayChange={setStaggerDelay}
+        />
       </div>
     )
   }
@@ -548,6 +567,13 @@ function TextAnimationPanel() {
       </div>
 
       {showPicker ? <TextPresetPicker current={current.id} onPick={pickPreset} /> : null}
+      <TextStaggerControls
+        enabled={staggerOn}
+        delay={staggerDelay}
+        disabled={selectedTextNodes.length < 2 || Boolean(primaryTextAnimationTrack)}
+        onEnabledChange={setStaggerOn}
+        onDelayChange={setStaggerDelay}
+      />
 
       <ControlCard title="Effect">
         {(current.id === 'blur' || current.id === 'blur-slide') ? (
@@ -768,6 +794,66 @@ function TextAnimationCardPreview({
         {preset.label}
       </span>
     </>
+  )
+}
+
+function TextStaggerControls({
+  enabled,
+  delay,
+  disabled,
+  onEnabledChange,
+  onDelayChange,
+}: {
+  enabled: boolean
+  delay: number
+  disabled: boolean
+  onEnabledChange: (enabled: boolean) => void
+  onDelayChange: (delay: number) => void
+}) {
+  return (
+    <div className="rounded-md border border-border bg-panel-raised p-2.5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[11px] font-semibold text-text">Stagger</div>
+          <div className="mt-0.5 text-[10px] text-text-dim">
+            Offset newly added text animations across selected layers.
+          </div>
+        </div>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => onEnabledChange(!enabled)}
+          className={[
+            'h-6 w-10 rounded-full border p-0.5 transition',
+            enabled && !disabled
+              ? 'border-accent bg-accent/20'
+              : 'border-border-strong bg-panel',
+            disabled ? 'cursor-not-allowed opacity-45' : '',
+          ].join(' ')}
+          aria-pressed={enabled}
+        >
+          <span
+            className={[
+              'block h-4 w-4 rounded-full bg-text-dim transition-transform',
+              enabled && !disabled ? 'translate-x-4 bg-accent' : '',
+            ].join(' ')}
+          />
+        </button>
+      </div>
+      {enabled && !disabled ? (
+        <div className="mt-2 flex items-center justify-between gap-3">
+          <span className="text-[10px] uppercase tracking-wide text-text-dim">Delay</span>
+          <NumberField
+            value={delay}
+            onCommit={(next) => onDelayChange(Math.max(0, next))}
+            min={0}
+            step={0.05}
+            suffix="s"
+            width="w-24"
+          />
+        </div>
+      ) : null}
+    </div>
   )
 }
 
@@ -1068,6 +1154,7 @@ function findTextAnimationTrack(
   api: SceneAPI,
   nodeId: NodeId,
   trackFilter?: ReadonlySet<string>,
+  playhead?: number,
 ): ReturnType<typeof listTracksForNode>[number] | null {
   const tracks = listTracksForNode(api, nodeId).filter(
     (track) => track.propertyId === 'text.progress' && track.keyframes.length >= 2,
@@ -1076,7 +1163,26 @@ function findTextAnimationTrack(
     const selected = tracks.find((track) => trackFilter.has(track.id))
     if (selected) return selected
   }
+  if (playhead !== undefined) {
+    return tracks.find((track) => trackContainsTime(track, playhead)) ?? null
+  }
   return tracks[0] ?? null
+}
+
+function trackContainsTime(
+  track: ReturnType<typeof listTracksForNode>[number],
+  time: number,
+): boolean {
+  if (track.keyframes.length < 2) return false
+  const sorted = [...track.keyframes].sort((a, b) => a.time - b.time)
+  const start = sorted[0]!.time
+  const end = sorted[sorted.length - 1]!.time
+  return time >= start - 0.01 && time <= end + 0.01
+}
+
+function trackStartTime(track: ReturnType<typeof listTracksForNode>[number]): number {
+  if (track.keyframes.length === 0) return 0
+  return Math.min(...track.keyframes.map((keyframe) => keyframe.time))
 }
 
 function withTextTrackTiming(

--- a/src/ui/hooks/useAnimatedValues.ts
+++ b/src/ui/hooks/useAnimatedValues.ts
@@ -3,6 +3,7 @@
 import { useSyncExternalStore } from 'react'
 import type { NodeId } from '@/scene'
 import { getAnimEngine } from '@/anim'
+import type { TextAnimationConfig } from '@/anim'
 
 /**
  * Per-node animated value bundle produced by the anim engine each tick.
@@ -35,6 +36,7 @@ export interface AnimatedValue {
   cornerRadius?: number
   fill?: string
   textProgress?: number
+  textAnimation?: TextAnimationConfig
   focusDistance?: number
   focusX?: number
   focusY?: number

--- a/src/ui/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/hooks/useKeyboardShortcuts.ts
@@ -695,6 +695,7 @@ interface ClipboardNode {
     propertyId: string
     defaultEasing: unknown
     keyframes: unknown[]
+    textAnimation?: unknown
   }>
   /** When set, paste creates a linked instance instead of a detached clone. */
   componentId?: NodeId
@@ -726,6 +727,7 @@ function serializeSubtree(
     propertyId: t.propertyId,
     defaultEasing: t.defaultEasing,
     keyframes: t.keyframes,
+    ...(t.textAnimation ? { textAnimation: t.textAnimation } : {}),
   }))
   const children: ClipboardNode[] = []
   for (const child of api.getChildren(nodeId)) {
@@ -781,6 +783,7 @@ function pasteSubtree(
         ...(k as { id: string; time: number; value: unknown }),
         id: genTrackId(),
       })) as never,
+      ...(track.textAnimation ? { textAnimation: track.textAnimation as never } : {}),
     })
   }
   for (const child of item.children) {


### PR DESCRIPTION
## Summary
- allow multiple text.progress tracks per text layer, each with its own text animation config
- edit the selected/active text animation range when the playhead is inside it, otherwise add a new range at the playhead
- keep text animation tracks active only while the playhead is inside their keyframe range so stacked ranges do not fight each other
- add text animation stagger controls for applying the same text animation across multiple selected text layers
- persist/copy per-track text animation configs

## Validation
- pnpm exec eslint src/anim/textAnimations.ts src/anim/tracks.ts src/anim/engine.ts src/scene/doc.ts src/scene/types.ts src/ui/PresetsPanel.tsx src/ui/hooks/useAnimatedValues.ts src/ui/hooks/useKeyboardShortcuts.ts
- git diff --check
- pnpm build:dir

Note: full typecheck still reports existing unrelated Canvas.tsx issues at 2307, 2310, and 4379.