### PR TITLE
docs(cli): align camera focal length guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,7 @@ Camera constraint: Hyper Motion currently supports only one camera node
 per scene. Keep that camera as a scene-level node with `parent: null`,
 set `activeCameraId` to its id, and do not include the camera id in any
 frame or artboard `children` list. When designing scenes, default that
-camera to `focalLength: 50` unless the user explicitly requests a
+camera to `focalLength: 1000` unless the user explicitly requests a
 different camera/lens feel.
 
 Layout constraint: when agents design scenes, use auto-layout by

--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -26,6 +26,7 @@ test('create_scene description lists supported appearance property ids', () => {
     const escapedPropertyId = propertyId.replaceAll('.', '\\.')
     assert.match(description, new RegExp(`${escapedPropertyId}(?:,|\\.)`))
   }
+  assert.match(description, /default focalLength to 1000/)
 })
 
 test('create_scene description lists supported camera property ids', () => {

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -75,7 +75,7 @@ export const createSceneTool: Tool = {
     "depthOfField, focusWorldX/Y/Z, focusTargetNodeId, focusDistance, focusRadius, focusFalloff, aperture, iso, blurLevel, " +
     "blurQuality, and showFocusPlane. Hyper Motion currently supports only one camera node per scene; " +
     "keep it scene-level with parent: null, set activeCameraId to that camera id, do not list it in any frame/artboard children, " +
-    "and default focalLength to 50 unless the user explicitly requests a different camera/lens feel.\n" +
+    "and default focalLength to 1000 unless the user explicitly requests a different camera/lens feel.\n" +
     "Property IDs you can keyframe: transform.x, transform.y, transform.z, transform.rotation, " +
     "transform.rotationX, transform.rotationY, transform.scaleX, transform.scaleY, " +
     "transform.anchorX, transform.anchorY, transform.anchorZ, " +


### PR DESCRIPTION
## Summary\n- update agent-facing camera focal length guidance to match the builder default\n- add a CLI MCP description assertion so the default stays documented\n\n## Tests\n- pnpm test (cli)