### PR TITLE
Tighten CLI override JSON types

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -814,6 +814,58 @@ test('buildSceneBytes preserves authored component timelines and interactions', 
   ])
 })
 
+test('buildSceneBytes preserves authored component and instance overrides', () => {
+  const scene = sampleScene()
+  scene.nodes = {
+    component: {
+      id: 'component',
+      kind: 'component',
+      parent: null,
+      children: [],
+      size: { width: 320, height: 180 },
+      layout: { mode: 'none' },
+      variantOverrides: [
+        {
+          match: { state: 'pressed' },
+          overrides: {
+            label: { text: 'Pressed' },
+            icon: { visible: false },
+          },
+        },
+      ],
+    },
+    instance: {
+      id: 'instance',
+      kind: 'instance',
+      parent: null,
+      children: [],
+      size: { width: 320, height: 180 },
+      componentId: 'component',
+      overrides: {
+        label: { text: 'Launch' },
+        icon: { color: '#2563eb' },
+      },
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(nodes.component.variantOverrides, [
+    {
+      match: { state: 'pressed' },
+      overrides: {
+        label: { text: 'Pressed' },
+        icon: { visible: false },
+      },
+    },
+  ])
+  assert.deepEqual(nodes.instance.overrides, {
+    label: { text: 'Launch' },
+    icon: { color: '#2563eb' },
+  })
+})
+
 test('buildSceneBytes writes explicit instance metadata defaults', () => {
   const scene = sampleScene()
   scene.nodes = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -167,7 +167,7 @@ export interface NodeJson {
   interactions?: InteractionJson[]
   componentId?: string
   selection?: Record<string, string>
-  overrides?: Record<string, Record<string, unknown>>
+  overrides?: Record<string, JsonObject>
   clipsContent?: boolean
   layoutGuides?: LayoutGuideJson[]
   // kind-specific
@@ -313,7 +313,7 @@ export type VariantSelectionJson = Record<string, string>
 
 export interface VariantOverrideJson {
   match: VariantSelectionJson
-  overrides: Record<string, Record<string, unknown>>
+  overrides: Record<string, JsonObject>
 }
 
 export type ComponentPropertyTypeJson =


### PR DESCRIPTION
## Summary
- Type component variant overrides and instance overrides as JSON object maps in the CLI scene schema
- Add a round-trip test for authored component and instance overrides

## Tests
- pnpm test (in cli/)