### PR TITLE
Resolve text targets from selected tracks

### DIFF
--- a/src/ui/PresetsPanel.tsx
+++ b/src/ui/PresetsPanel.tsx
@@ -1169,7 +1169,7 @@ function textNodesFromSelectionOrTimeline(
     const node = api.getNode(id)
     if (node?.kind !== 'text') continue
     const hasSelectedTextTrack = listTracksForNode(api, id).some(
-      (track) => track.propertyId === 'text.progress' && trackFilter.has(track.id),
+      (track) => trackFilter.has(track.id),
     )
     if (hasSelectedTextTrack) byId.set(node.id, node)
   }


### PR DESCRIPTION
## Summary
- treat selected timeline tracks/keyframe sets on text layers as text animation targets
- allow the Text Animation panel to add/change effects when selected keyframe sets are layer-animation tracks on text nodes

## Validation
- pnpm exec eslint src/ui/PresetsPanel.tsx
- pnpm typecheck 2>&1 | rg "src/ui/PresetsPanel.tsx"
- git diff --check
- pnpm build:dir