### PR TITLE
Show editable text animation state

### DIFF
--- a/src/anim/engine.ts
+++ b/src/anim/engine.ts
@@ -354,7 +354,21 @@ function applyTextProgressTrack(
   if (kfs.length < 2) return
   const first = kfs[0]!
   const last = kfs[kfs.length - 1]!
-  if (t < first.time || t > last.time) return
+  const mode = track.textAnimation?.mode
+  if (t < first.time) {
+    if (mode === 'in' && typeof first.value === 'number') {
+      into.textProgress = first.value
+      into.textAnimation = track.textAnimation
+    }
+    return
+  }
+  if (t > last.time) {
+    if (mode === 'out' && typeof last.value === 'number') {
+      into.textProgress = last.value
+      into.textAnimation = track.textAnimation
+    }
+    return
+  }
 
   let a = first
   let b = last

--- a/src/anim/textAnimations.ts
+++ b/src/anim/textAnimations.ts
@@ -184,7 +184,10 @@ export function stampTextAnimationKeyframes(
   if (options.replaceAll) clearTextAnimationKeyframes(api, nodeId)
   const start = config.startTime
   const end = start + config.duration + Math.max(0, textSegmentCount(text, config.applyTo) - 1) * config.delay
-  const trackId = options.trackId ?? genId()
+  const trackId =
+    options.trackId ??
+    findTextAnimationTrackAtStart(api, nodeId, start) ??
+    genId()
   const track: Track = {
     id: trackId,
     nodeId,
@@ -198,6 +201,20 @@ export function stampTextAnimationKeyframes(
   }
   api.setTrack(track)
   return trackId
+}
+
+function findTextAnimationTrackAtStart(
+  api: SceneAPI,
+  nodeId: NodeId,
+  startTime: number,
+): TrackId | null {
+  for (const track of api.getTracksForNode(nodeId)) {
+    if (track.propertyId !== 'text.progress') continue
+    if (track.keyframes.length < 2) continue
+    const start = Math.min(...track.keyframes.map((keyframe) => keyframe.time))
+    if (Math.abs(start - startTime) <= 0.01) return track.id
+  }
+  return null
 }
 
 export function updateTextAnimationEasing(

--- a/src/index.css
+++ b/src/index.css
@@ -41,6 +41,10 @@
   --color-segment-bar: oklch(0.40 0.08 250);
   --color-segment-bar-ring: oklch(0.30 0.10 250);
   --color-segment-bar-hover: oklch(0.48 0.10 250);
+  --color-group-bar: #224a71;
+  --color-group-bar-active: #0091ff;
+  --color-group-bar-ring: #1b4165;
+  --color-group-bar-marker: #00a1ff;
   --color-playhead: oklch(0.70 0.20 250);
 
   --font-sans: "Geist Mono", ui-monospace, "SF Mono", "Menlo",
@@ -82,6 +86,10 @@
   --color-segment-bar: oklch(0.40 0.08 250);
   --color-segment-bar-ring: oklch(0.30 0.10 250);
   --color-segment-bar-hover: oklch(0.48 0.10 250);
+  --color-group-bar: #224a71;
+  --color-group-bar-active: #0091ff;
+  --color-group-bar-ring: #1b4165;
+  --color-group-bar-marker: #00a1ff;
   --color-playhead: oklch(0.70 0.20 250);
   --color-checker: rgba(255, 255, 255, 0.05);
   /* Floating-dock shadow. Two layers: a tight near-shadow that
@@ -114,6 +122,10 @@
   --color-segment-bar: oklch(0.86 0.08 250);
   --color-segment-bar-ring: oklch(0.72 0.12 250);
   --color-segment-bar-hover: oklch(0.80 0.10 250);
+  --color-group-bar: oklch(0.84 0.075 250);
+  --color-group-bar-active: oklch(0.62 0.21 250);
+  --color-group-bar-ring: oklch(0.76 0.10 250);
+  --color-group-bar-marker: oklch(0.58 0.22 250);
   --color-playhead: oklch(0.55 0.22 250);
   --color-checker: rgba(0, 0, 0, 0.04);
   /* Light theme: three softer layers instead of two heavy ones.
@@ -145,6 +157,10 @@
     --color-segment-bar: oklch(0.86 0.08 250);
     --color-segment-bar-ring: oklch(0.72 0.12 250);
     --color-segment-bar-hover: oklch(0.80 0.10 250);
+    --color-group-bar: oklch(0.84 0.075 250);
+    --color-group-bar-active: oklch(0.62 0.21 250);
+    --color-group-bar-ring: oklch(0.76 0.10 250);
+    --color-group-bar-marker: oklch(0.58 0.22 250);
     --color-playhead: oklch(0.55 0.22 250);
     --color-checker: rgba(0, 0, 0, 0.04);
     --shadow-dock:

--- a/src/scene/doc.ts
+++ b/src/scene/doc.ts
@@ -36,7 +36,10 @@ import { normalizeTextAnimation } from '@/anim/textAnimations'
  * data, splitting into per-group Y.Maps is the upgrade path.
  */
 export interface UiStateSlab {
-  trackGroups: Record<string, { trackIds: string[]; collapsed: boolean }>
+  trackGroups: Record<
+    string,
+    { trackIds: string[]; collapsed: boolean; name?: string }
+  >
   kfGroups: Record<string, string[]>
   kfGroupCollapsed: Record<string, boolean>
 }

--- a/src/state/groupActions.ts
+++ b/src/state/groupActions.ts
@@ -96,6 +96,22 @@ export function ungroupTracks(api: SceneAPI, trackIds: string[]): void {
   api.setUiState({ trackGroups: next })
 }
 
+/** Remove only these tracks from any track group they belong to. */
+export function removeTracksFromGroups(
+  api: SceneAPI,
+  trackIds: string[],
+): void {
+  if (trackIds.length === 0) return
+  const ui = api.getUiState()
+  const ids = new Set(trackIds)
+  const next: typeof ui.trackGroups = {}
+  for (const [gid, g] of Object.entries(ui.trackGroups)) {
+    const filtered = g.trackIds.filter((trackId) => !ids.has(trackId))
+    if (filtered.length >= 2) next[gid] = { ...g, trackIds: filtered }
+  }
+  api.setUiState({ trackGroups: next })
+}
+
 /** Flip a track group's collapsed flag. */
 export function toggleTrackGroupCollapsed(
   api: SceneAPI,

--- a/src/state/groupActions.ts
+++ b/src/state/groupActions.ts
@@ -58,10 +58,20 @@ export function addTracksToGroup(
   groupId: string,
   trackIds: string[],
 ): void {
+  insertTracksIntoGroup(api, groupId, trackIds)
+}
+
+export function insertTracksIntoGroup(
+  api: SceneAPI,
+  groupId: string,
+  trackIds: string[],
+  index?: number,
+): void {
   const ui = api.getUiState()
   const target = ui.trackGroups[groupId]
   if (!target) return
-  const incoming = new Set(trackIds)
+  const incomingIds = [...new Set(trackIds)]
+  const incoming = new Set(incomingIds)
   // Pull each incoming track out of any prior group so it lands in
   // exactly one place. Drop any group that ends up below 2 members.
   const next: typeof ui.trackGroups = {}
@@ -70,16 +80,19 @@ export function addTracksToGroup(
     const filtered = g.trackIds.filter((t) => !incoming.has(t))
     if (filtered.length >= 2) next[gid] = { ...g, trackIds: filtered }
   }
-  // Build the target's new track list: keep existing members,
-  // append new ones in caller-provided order, dedupe.
-  const seen = new Set(target.trackIds)
-  const merged = [...target.trackIds]
-  for (const tid of trackIds) {
-    if (!seen.has(tid)) {
-      merged.push(tid)
-      seen.add(tid)
-    }
-  }
+  // Build the target's new track list: remove any incoming tracks
+  // first, then insert them at the requested position. This supports
+  // both "move into this group here" and "reorder inside the group".
+  const base = target.trackIds.filter((trackId) => !incoming.has(trackId))
+  const insertionIndex =
+    typeof index === 'number'
+      ? Math.max(0, Math.min(base.length, index))
+      : base.length
+  const merged = [
+    ...base.slice(0, insertionIndex),
+    ...incomingIds,
+    ...base.slice(insertionIndex),
+  ]
   next[groupId] = { ...target, trackIds: merged }
   api.setUiState({ trackGroups: next })
 }

--- a/src/state/groupActions.ts
+++ b/src/state/groupActions.ts
@@ -112,6 +112,26 @@ export function toggleTrackGroupCollapsed(
   })
 }
 
+/** Rename a track group. Empty names clear the custom title. */
+export function renameTrackGroup(
+  api: SceneAPI,
+  groupId: string,
+  name: string,
+): void {
+  const ui = api.getUiState()
+  const g = ui.trackGroups[groupId]
+  if (!g) return
+  const trimmed = name.trim()
+  const { name: _name, ...rest } = g
+  void _name
+  api.setUiState({
+    trackGroups: {
+      ...ui.trackGroups,
+      [groupId]: trimmed ? { ...rest, name: trimmed } : rest,
+    },
+  })
+}
+
 /** Bundle the given keyframe keys into a new kf group. Auto-collapsed. */
 export function groupKeyframes(api: SceneAPI, keys: string[]): void {
   if (keys.length < 2) return

--- a/src/state/groupActions.ts
+++ b/src/state/groupActions.ts
@@ -83,11 +83,18 @@ export function insertTracksIntoGroup(
   // Build the target's new track list: remove any incoming tracks
   // first, then insert them at the requested position. This supports
   // both "move into this group here" and "reorder inside the group".
-  const base = target.trackIds.filter((trackId) => !incoming.has(trackId))
-  const insertionIndex =
+  const rawInsertionIndex =
     typeof index === 'number'
-      ? Math.max(0, Math.min(base.length, index))
-      : base.length
+      ? Math.max(0, Math.min(target.trackIds.length, index))
+      : target.trackIds.length
+  const removedBeforeInsertion = target.trackIds
+    .slice(0, rawInsertionIndex)
+    .filter((trackId) => incoming.has(trackId)).length
+  const base = target.trackIds.filter((trackId) => !incoming.has(trackId))
+  const insertionIndex = Math.max(
+    0,
+    Math.min(base.length, rawInsertionIndex - removedBeforeInsertion),
+  )
   const merged = [
     ...base.slice(0, insertionIndex),
     ...incomingIds,

--- a/src/state/groupActions.ts
+++ b/src/state/groupActions.ts
@@ -149,6 +149,27 @@ export function ungroupKeyframes(api: SceneAPI, keys: string[]): void {
   })
 }
 
+/** Dissolve keyframe groups by id. Useful when the UI is rendering the
+ * group itself, rather than acting from a keyframe selection. */
+export function ungroupKeyframeGroups(
+  api: SceneAPI,
+  groupIds: string[],
+): void {
+  const ui = api.getUiState()
+  const ids = new Set(groupIds)
+  const nextGroups: typeof ui.kfGroups = {}
+  const nextCollapsed: typeof ui.kfGroupCollapsed = {}
+  for (const [gid, members] of Object.entries(ui.kfGroups)) {
+    if (ids.has(gid)) continue
+    nextGroups[gid] = members
+    if (ui.kfGroupCollapsed[gid]) nextCollapsed[gid] = true
+  }
+  api.setUiState({
+    kfGroups: nextGroups,
+    kfGroupCollapsed: nextCollapsed,
+  })
+}
+
 /** Flip a keyframe group's collapsed flag. */
 export function toggleKfGroupCollapsed(
   api: SceneAPI,

--- a/src/ui/Canvas.tsx
+++ b/src/ui/Canvas.tsx
@@ -42,6 +42,7 @@ import {
 import {
   recordKeyframesForPatch,
   stampToActiveTracksForPatch,
+  listTracksForNode,
   normalizeTextAnimation,
 } from '@/anim'
 import type { TextAnimationConfig } from '@/anim'
@@ -3907,7 +3908,13 @@ function TextGlyphs({
   const playhead = useUI((s) => s.playhead)
   const api = useSceneAPI()
   const isEditing = editingTextId === node.id
-  const textAnimation = anim?.textAnimation ?? normalizeTextAnimation(node.textAnimation)
+  const hasTextAnimationTracks = listTracksForNode(api, node.id).some(
+    (track) =>
+      track.propertyId === 'text.progress' && track.keyframes.length >= 2,
+  )
+  const textAnimation =
+    anim?.textAnimation ??
+    (hasTextAnimationTracks ? null : normalizeTextAnimation(node.textAnimation))
 
   // Common typography style block. Shared between read and edit modes
   // so the text doesn't shift visually when you press Enter to edit.
@@ -4050,6 +4057,13 @@ function renderTextAnimationSegments(
   sharedStyle: CSSProperties,
   progress?: number,
 ) {
+  if (config.id === 'tracking') {
+    return (
+      <span style={trackingTextStyle(config, playhead, progress, sharedStyle)}>
+        {text}
+      </span>
+    )
+  }
   const segments = splitTextAnimationSegments(text, config.applyTo)
   const orderedCount = Math.max(1, segments.filter((s) => s.animate).length)
   let animateIndex = 0
@@ -4082,6 +4096,36 @@ function renderTextAnimationSegments(
       </span>
     )
   })
+}
+
+function trackingTextStyle(
+  config: TextAnimationConfig,
+  playhead: number,
+  progress: number | undefined,
+  sharedStyle: CSSProperties,
+): CSSProperties {
+  const timelineProgress =
+    progress === undefined ? undefined : Math.max(0, Math.min(1, progress))
+  const globalElapsed =
+    timelineProgress === undefined
+      ? playhead - config.startTime
+      : timelineProgress * config.duration
+  const raw = globalElapsed / Math.max(0.05, config.duration)
+  const u = Math.max(0, Math.min(1, raw))
+  const eased = progress === undefined ? easeTextAnimation(u, config.acceleration) : u
+  const exit = config.mode === 'out'
+  const amount = exit ? eased : 1 - eased
+  const extraTrackingPx = amount * 10
+  const authoredTracking =
+    typeof sharedStyle.letterSpacing === 'number' ? sharedStyle.letterSpacing : 0
+
+  return {
+    display: 'inline',
+    whiteSpace: 'inherit',
+    letterSpacing: authoredTracking + extraTrackingPx,
+    opacity: 1 - amount,
+    willChange: 'letter-spacing, opacity',
+  }
 }
 
 function splitTextAnimationSegments(

--- a/src/ui/PresetsPanel.tsx
+++ b/src/ui/PresetsPanel.tsx
@@ -16,6 +16,7 @@ import {
   applyTextAnimation,
   normalizeTextAnimation,
   stampTextAnimationKeyframes,
+  textAnimationDefaults,
   updateTextAnimationEasing,
 } from '@/anim'
 import type {
@@ -204,13 +205,10 @@ export function PresetsPanel() {
   const visibleLayerPresets = layerPresetTab === 'in' ? ins : outs
   const primaryTextNode = selectedTextNodes[0]
   const primaryTextTrack = primaryTextNode
-    ? api
-        .getTracksForNode(primaryTextNode.id)
-        .find((track) => track.propertyId === 'text.progress' && track.keyframes.length >= 2)
+    ? findTextAnimationTrack(api, primaryTextNode.id, trackFilter, playhead)
     : null
-  const primaryTextConfig = primaryTextTrack
-    ? normalizeTextAnimation(primaryTextNode?.textAnimation)
-    : null
+  const primaryTextConfig =
+    normalizeTextAnimation(primaryTextTrack?.textAnimation ?? primaryTextNode?.textAnimation)
   const primaryTextPreset = primaryTextConfig
     ? textPresetForConfig(primaryTextConfig)
     : null
@@ -422,13 +420,26 @@ function TextAnimationPanel() {
   const primaryTextAnimationTrack = primary
     ? findTextAnimationTrack(api, primary.id, selectedTextTrackFilter, playhead)
     : null
-  const current = primaryTextAnimationTrack
+  const primarySelectedTimelineTrack = primary
+    ? findSelectedTimelineTrack(api, primary.id, selectedTextTrackFilter)
+    : null
+  const primaryResolvedTextTrack =
+    primaryTextAnimationTrack ??
+    (primary && primarySelectedTimelineTrack
+      ? findTextAnimationTrackMatchingRange(api, primary.id, primarySelectedTimelineTrack)
+      : null)
+  const primaryTextAnimationConfig = normalizeTextAnimation(primary?.textAnimation)
+  const current = primaryResolvedTextTrack
     ? withTextTrackTiming(
-        normalizeTextAnimation(primaryTextAnimationTrack.textAnimation ?? primary?.textAnimation),
-        primaryTextAnimationTrack,
+        normalizeTextAnimation(primaryResolvedTextTrack.textAnimation ?? primary?.textAnimation),
+        primaryResolvedTextTrack,
         primary?.text ?? '',
       )
-    : null
+    : withTextTrackTiming(
+        primaryTextAnimationConfig,
+        primarySelectedTimelineTrack,
+        primary?.text ?? '',
+      )
   const currentEasingText = current ? easingToText(current) : ''
   const visibleEasingDraft =
     easingDraft.source === currentEasingText ? easingDraft.value : currentEasingText
@@ -436,13 +447,19 @@ function TextAnimationPanel() {
   const patch = (next: Partial<TextAnimationConfig>) => {
     if (!current) return
     for (const node of selectedTextNodes) {
-      const textTrack = findTextAnimationTrack(api, node.id, selectedTextTrackFilter, playhead)
+      const selectedTimelineTrack = findSelectedTimelineTrack(api, node.id, selectedTextTrackFilter)
+      const textTrack =
+        findTextAnimationTrack(api, node.id, selectedTextTrackFilter, playhead) ??
+        (selectedTimelineTrack
+          ? findTextAnimationTrackMatchingRange(api, node.id, selectedTimelineTrack)
+          : null)
       const base = normalizeTextAnimation(textTrack?.textAnimation ?? node.textAnimation) ?? current
       const config = {
         ...base,
         ...next,
       }
-      const timedConfig = withTextTrackTiming(config, textTrack, node.text, next) ?? config
+      const timingTrack = textTrack ?? selectedTimelineTrack
+      const timedConfig = withTextTrackTiming(config, timingTrack, node.text, next) ?? config
       api.setNodeProperty(node.id, 'textAnimation', timedConfig)
       if (isTextEasingOnlyPatch(next)) {
         updateTextAnimationEasing(api, node.id, timedConfig, textTrack?.id)
@@ -470,20 +487,57 @@ function TextAnimationPanel() {
   }
 
   const pickPreset = (id: TextAnimationId) => {
+    const applied = new Set<NodeId>()
     for (let i = 0; i < selectedTextNodes.length; i++) {
       const node = selectedTextNodes[i]!
-      const textTrack = findTextAnimationTrack(api, node.id, selectedTextTrackFilter, playhead)
-      const startTime = textTrack
-        ? trackStartTime(textTrack)
+      if (applied.has(node.id)) continue
+      applied.add(node.id)
+      const selectedTimelineTrack = findSelectedTimelineTrack(api, node.id, selectedTextTrackFilter)
+      const textTrack =
+        findTextAnimationTrack(api, node.id, selectedTextTrackFilter, playhead) ??
+        (selectedTimelineTrack
+          ? findTextAnimationTrackMatchingRange(api, node.id, selectedTimelineTrack)
+          : null)
+      const timingTrack = textTrack ?? selectedTimelineTrack
+      const startTime = timingTrack
+        ? trackStartTime(timingTrack)
         : playhead + (staggerOn && selectedTextNodes.length > 1 ? i * staggerDelay : 0)
-      applyTextAnimation(
-        api,
-        node.id,
-        id,
-        startTime,
-        normalizeTextAnimation(textTrack?.textAnimation ?? node.textAnimation),
-        { trackId: textTrack?.id },
-      )
+      if (!textTrack && selectedTimelineTrack) {
+        const previous = normalizeTextAnimation(node.textAnimation)
+        const defaults = textAnimationDefaults(id)
+        const next: TextAnimationConfig = {
+          ...defaults,
+          ...(previous
+            ? {
+                mode: previous.mode,
+                applyTo: previous.applyTo,
+                order: previous.order,
+                delay: previous.delay,
+                smoothing: previous.smoothing,
+                easingPresetId: previous.easingPresetId,
+                easingStrength: previous.easingStrength,
+                customEasing: previous.customEasing,
+              }
+            : {}),
+          startTime,
+        }
+        const timedConfig = withTextTrackTiming(
+          next,
+          selectedTimelineTrack,
+          node.text,
+        ) ?? next
+        api.setNodeProperty(node.id, 'textAnimation', timedConfig)
+        stampTextAnimationKeyframes(api, node.id, timedConfig, node.text)
+      } else {
+        applyTextAnimation(
+          api,
+          node.id,
+          id,
+          startTime,
+          normalizeTextAnimation(textTrack?.textAnimation ?? node.textAnimation),
+          { trackId: textTrack?.id },
+        )
+      }
     }
     setShowPicker(false)
   }
@@ -1195,20 +1249,62 @@ function findTextAnimationTrack(
   return tracks[0] ?? null
 }
 
+function findSelectedTimelineTrack(
+  api: SceneAPI,
+  nodeId: NodeId,
+  trackFilter?: ReadonlySet<string>,
+): ReturnType<typeof listTracksForNode>[number] | null {
+  if (!trackFilter) return null
+  return (
+    listTracksForNode(api, nodeId).find((track) => trackFilter.has(track.id)) ??
+    null
+  )
+}
+
+function findTextAnimationTrackMatchingRange(
+  api: SceneAPI,
+  nodeId: NodeId,
+  reference: ReturnType<typeof listTracksForNode>[number],
+): ReturnType<typeof listTracksForNode>[number] | null {
+  const referenceRange = trackRange(reference)
+  if (!referenceRange) return null
+  return (
+    listTracksForNode(api, nodeId)
+      .filter((track) => track.propertyId === 'text.progress' && track.keyframes.length >= 2)
+      .find((track) => {
+        const range = trackRange(track)
+        return (
+          !!range &&
+          Math.abs(range.start - referenceRange.start) <= 0.02 &&
+          Math.abs(range.end - referenceRange.end) <= 0.02
+        )
+      }) ?? null
+  )
+}
+
 function trackContainsTime(
   track: ReturnType<typeof listTracksForNode>[number],
   time: number,
 ): boolean {
-  if (track.keyframes.length < 2) return false
-  const sorted = [...track.keyframes].sort((a, b) => a.time - b.time)
-  const start = sorted[0]!.time
-  const end = sorted[sorted.length - 1]!.time
+  const range = trackRange(track)
+  if (!range) return false
+  const { start, end } = range
   return time >= start - 0.01 && time <= end + 0.01
 }
 
 function trackStartTime(track: ReturnType<typeof listTracksForNode>[number]): number {
-  if (track.keyframes.length === 0) return 0
-  return Math.min(...track.keyframes.map((keyframe) => keyframe.time))
+  return trackRange(track)?.start ?? 0
+}
+
+function trackRange(
+  track: ReturnType<typeof listTracksForNode>[number],
+): { start: number; end: number } | null {
+  if (track.keyframes.length === 0) return null
+  const times = track.keyframes.map((keyframe) => keyframe.time)
+  return {
+    start: Math.min(...times),
+    end: Math.max(...times),
+  }
 }
 
 function withTextTrackTiming(

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -28,6 +28,35 @@ import { importAudioFile } from '@/ui/importMedia'
  * one-line helper because it's used from half a dozen call sites.
  */
 const kfKey = (trackId: string, kfId: string) => `${trackId}:${kfId}`
+const TRACK_IDS_DRAG_TYPE = 'application/x-hypermotion-track-ids'
+
+function setDraggedTrackIds(e: React.DragEvent, trackIds: string[]): void {
+  const ids = [...new Set(trackIds)].filter(Boolean)
+  if (ids.length === 0) return
+  e.dataTransfer.effectAllowed = 'move'
+  e.dataTransfer.setData(TRACK_IDS_DRAG_TYPE, JSON.stringify(ids))
+  e.dataTransfer.setData('text/plain', ids.join(','))
+}
+
+function getDraggedTrackIds(e: React.DragEvent): string[] {
+  const raw = e.dataTransfer.getData(TRACK_IDS_DRAG_TYPE)
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed)
+      ? parsed.filter((id): id is string => typeof id === 'string')
+      : []
+  } catch {
+    return []
+  }
+}
+
+function dragTrackIdsFor(trackId: string): string[] {
+  const selected = useUI.getState().selectedTrackIds
+  return selected.includes(trackId) && selected.length > 0
+    ? selected
+    : [trackId]
+}
 
 /**
  * Timeline.
@@ -326,6 +355,21 @@ export function Timeline() {
       return false
     },
     [trackGroupsDict],
+  )
+  const addDroppedTracksToGroup = useCallback(
+    (groupId: string, trackIds: string[]) => {
+      const group = api.getUiState().trackGroups[groupId]
+      if (!group) return
+      const memberSet = new Set(group.trackIds)
+      const toAdd = [...new Set(trackIds)].filter(
+        (trackId) => !memberSet.has(trackId) && api.getTrack(trackId),
+      )
+      if (toAdd.length === 0) return
+      addTracksToGroupHelper(api, groupId, toAdd)
+      setSelectedTrackIds([...group.trackIds, ...toAdd])
+      clearKfs()
+    },
+    [api, clearKfs, setSelectedTrackIds],
   )
 
   useEffect(() => {
@@ -1725,6 +1769,13 @@ export function Timeline() {
                         })
                       }
                       aria-selected={isSelected}
+                      draggable
+                      onDragStart={(e) => {
+                        const ids = isSelected
+                          ? selectedAnimatedLayerTrackIds()
+                          : group.tracks.map((track) => track.id)
+                        setDraggedTrackIds(e, ids)
+                      }}
                       className={
                         'flex h-6 cursor-pointer items-center border-t border-border/50 px-3 ' +
                         (isSelected
@@ -1881,9 +1932,9 @@ export function Timeline() {
                               tg.memberTracks.map((t) => t.id),
                             )
                           }
-                          onRename={(name) =>
-                            renameTrackGroupHelper(api, tg.groupId, name)
-                          }
+                      onRename={(name) =>
+                        renameTrackGroupHelper(api, tg.groupId, name)
+                      }
                           selectedLayerTracksToAdd={
                             selectedLayerTracksToAdd.length
                           }
@@ -1894,11 +1945,14 @@ export function Timeline() {
                               selectedLayerTracksToAdd,
                             )
                           }
-                          onRemoveTracksFromGroup={(trackIds) =>
-                            removeTracksFromGroupsHelper(api, trackIds)
-                          }
-                          openContextMenu={openContextMenu}
-                        />
+                      onRemoveTracksFromGroup={(trackIds) =>
+                        removeTracksFromGroupsHelper(api, trackIds)
+                      }
+                      onDropTracks={(trackIds) =>
+                        addDroppedTracksToGroup(tg.groupId, trackIds)
+                      }
+                      openContextMenu={openContextMenu}
+                    />
                       )
                     })()
                   ))}
@@ -2223,6 +2277,9 @@ export function Timeline() {
                         layerRelated={tg.memberTracks.some((t) =>
                           selectedNodeSet.has(t.nodeId),
                         )}
+                        onDropTracks={(trackIds) =>
+                          addDroppedTracksToGroup(tg.groupId, trackIds)
+                        }
                         onContextMenu={(e, g) => {
                           e.preventDefault()
                           e.stopPropagation()
@@ -2638,6 +2695,8 @@ function TrackLabel({
   const isTextAnimationTrack = track.propertyId === 'text.progress'
   return (
     <div
+      draggable
+      onDragStart={(e) => setDraggedTrackIds(e, dragTrackIdsFor(track.id))}
       onClick={(e) => {
         // Shift / Cmd / Ctrl click maintains a MULTI-track selection
         // for Cmd+G grouping. Plain click sets the single-track focus
@@ -3285,6 +3344,8 @@ function SegmentRow({
           <div
             data-segment-bar="1"
             data-timeline-selection-surface="1"
+            draggable
+            onDragStart={(e) => setDraggedTrackIds(e, dragTrackIdsFor(track.id))}
             onPointerDown={onBarPointerDown}
             onContextMenu={onBarContextMenu}
             title={`${first.time.toFixed(2)}s → ${last.time.toFixed(2)}s — drag to shift, right-click for options`}
@@ -3296,6 +3357,8 @@ function SegmentRow({
           />
         ) : (
           <div
+            draggable
+            onDragStart={(e) => setDraggedTrackIds(e, dragTrackIdsFor(track.id))}
             className={beadClassName}
             style={{ left: first.time * PX_PER_SECOND }}
           />
@@ -3623,6 +3686,7 @@ function TrackGroupLeftRow({
   selectedLayerTracksToAdd,
   onAddSelectedLayers,
   onRemoveTracksFromGroup,
+  onDropTracks,
   openContextMenu,
 }: {
   group: ResolvedTrackGroup
@@ -3635,6 +3699,7 @@ function TrackGroupLeftRow({
   selectedLayerTracksToAdd: number
   onAddSelectedLayers: () => void
   onRemoveTracksFromGroup: (trackIds: string[]) => void
+  onDropTracks: (trackIds: string[]) => void
   openContextMenu: (menu: import('@/state/ui').ContextMenuState) => void
 }) {
   const collapsed = group.collapsed
@@ -3691,6 +3756,18 @@ function TrackGroupLeftRow({
               { label: 'Ungroup (⌘⇧G)', danger: true, onClick: onUngroup },
             ],
           })
+        }}
+        onDragOver={(e) => {
+          if (!e.dataTransfer.types.includes(TRACK_IDS_DRAG_TYPE)) return
+          e.preventDefault()
+          e.dataTransfer.dropEffect = 'move'
+        }}
+        onDrop={(e) => {
+          const ids = getDraggedTrackIds(e)
+          if (ids.length === 0) return
+          e.preventDefault()
+          e.stopPropagation()
+          onDropTracks(ids)
         }}
         title={
           collapsed
@@ -3823,6 +3900,7 @@ function TrackGroupRightRow({
   duration,
   api,
   layerRelated = false,
+  onDropTracks,
   onContextMenu,
 }: {
   group: ResolvedTrackGroup
@@ -3830,6 +3908,7 @@ function TrackGroupRightRow({
   duration: number
   api: SceneAPI
   layerRelated?: boolean
+  onDropTracks: (trackIds: string[]) => void
   /** Right-click on the span bar — parent builds the menu so it can
    *  reach the live track selection and the openContextMenu handle. */
   onContextMenu?: (e: React.MouseEvent, group: ResolvedTrackGroup) => void
@@ -3950,6 +4029,18 @@ function TrackGroupRightRow({
           layerRelated ? 'bg-accent-soft/45' : 'bg-accent-soft/30',
         ].join(' ')}
         style={{ width: totalWidth }}
+        onDragOver={(e) => {
+          if (!e.dataTransfer.types.includes(TRACK_IDS_DRAG_TYPE)) return
+          e.preventDefault()
+          e.dataTransfer.dropEffect = 'move'
+        }}
+        onDrop={(e) => {
+          const ids = getDraggedTrackIds(e)
+          if (ids.length === 0) return
+          e.preventDefault()
+          e.stopPropagation()
+          onDropTracks(ids)
+        }}
         onContextMenu={(e) => onContextMenu?.(e, group)}
       >
         {hasSpan && (

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -13,6 +13,7 @@ import {
   toggleKfGroupCollapsed as toggleKfGroupCollapsedHelper,
   groupTracks as groupTracksHelper,
   ungroupTracks as ungroupTracksHelper,
+  removeTracksFromGroups as removeTracksFromGroupsHelper,
   addTracksToGroup as addTracksToGroupHelper,
   toggleTrackGroupCollapsed as toggleTrackGroupCollapsedHelper,
   renameTrackGroup as renameTrackGroupHelper,
@@ -298,6 +299,35 @@ export function Timeline() {
     setSelectedKfs((prev) => (prev.size === 0 ? prev : new Set()))
   }, [])
 
+  const getTrackIdsForNodes = useCallback(
+    (nodeIds: string[]) => {
+      const out: string[] = []
+      for (const nodeId of nodeIds) {
+        for (const track of api.getTracksForNode(nodeId)) {
+          out.push(track.id)
+        }
+      }
+      return out
+    },
+    [api],
+  )
+
+  const selectedAnimatedLayerTrackIds = useCallback(
+    () => getTrackIdsForNodes(useUI.getState().selection),
+    [getTrackIdsForNodes],
+  )
+
+  const tracksInsideAnyGroup = useCallback(
+    (trackIds: string[]) => {
+      const ids = new Set(trackIds)
+      for (const group of Object.values(trackGroupsDict)) {
+        if (group.trackIds.some((trackId) => ids.has(trackId))) return true
+      }
+      return false
+    },
+    [trackGroupsDict],
+  )
+
   useEffect(() => {
     const onPointerDown = (e: PointerEvent) => {
       const target = e.target as HTMLElement | null
@@ -463,6 +493,17 @@ export function Timeline() {
           }
           return
         }
+        const selectedLayerTracks = selectedAnimatedLayerTrackIds()
+        if (selectedLayerTracks.length > 0 && e.shiftKey) {
+          removeTracksFromGroupsHelper(api, selectedLayerTracks)
+          return
+        }
+        if (selectedLayerTracks.length >= 2) {
+          if (!tryMergeIntoExisting(selectedLayerTracks)) {
+            groupTracksHelper(api, selectedLayerTracks)
+          }
+          return
+        }
         if (selectedKfs.size === 0) return
         const keys = Array.from(selectedKfs)
         // Ungroup should dissolve the actual selected keyframe groups,
@@ -497,7 +538,7 @@ export function Timeline() {
     }
     window.addEventListener('keydown', onKey, true)
     return () => window.removeEventListener('keydown', onKey, true)
-  }, [selectedKfs])
+  }, [api, selectedAnimatedLayerTrackIds, selectedKfs])
 
   // Group lookup map: keyframe key → group id. Rebuilt when the
   // groups dict changes. Used by KeyframeDiamond to (a) decide
@@ -587,9 +628,27 @@ export function Timeline() {
   ) => {
     e.preventDefault()
     e.stopPropagation()
+    const nodeTrackIds =
+      target.kind === 'node' ? getTrackIdsForNodes([target.nodeId]) : []
+    const trackIsGrouped =
+      target.kind === 'track' || target.kind === 'keyframe'
+        ? tracksInsideAnyGroup([target.track.id])
+        : false
+    const nodeHasGroupedTracks =
+      target.kind === 'node' ? tracksInsideAnyGroup(nodeTrackIds) : false
     const items =
       target.kind === 'keyframe'
         ? [
+            ...(trackIsGrouped
+              ? [
+                  {
+                    label: 'Remove track from group',
+                    onClick: () =>
+                      removeTracksFromGroupsHelper(api, [target.track.id]),
+                  },
+                  { kind: 'separator' as const },
+                ]
+              : []),
             {
               label: `Delete keyframe @ ${target.time.toFixed(2)}s`,
               danger: true,
@@ -605,6 +664,16 @@ export function Timeline() {
           ]
         : target.kind === 'track'
           ? [
+              ...(trackIsGrouped
+                ? [
+                    {
+                      label: 'Remove track from group',
+                      onClick: () =>
+                        removeTracksFromGroupsHelper(api, [target.track.id]),
+                    },
+                    { kind: 'separator' as const },
+                  ]
+                : []),
               {
                 label: `Delete track (${humanProperty(target.track.propertyId)})`,
                 danger: true,
@@ -612,6 +681,16 @@ export function Timeline() {
               },
             ]
           : [
+              ...(nodeHasGroupedTracks
+                ? [
+                    {
+                      label: `Remove "${target.nodeName}" from group`,
+                      onClick: () =>
+                        removeTracksFromGroupsHelper(api, nodeTrackIds),
+                    },
+                    { kind: 'separator' as const },
+                  ]
+                : []),
               {
                 label: `Delete all animation on "${target.nodeName}"`,
                 danger: true,
@@ -1773,29 +1852,55 @@ export function Timeline() {
                       ungroup. When expanded, the constituent tracks
                       render indented underneath. */}
                   {hostedTrackGroups.map((tg) => (
-                    <TrackGroupLeftRow
-                      key={tg.groupId}
-                      group={tg}
-                      nodeKind={group.nodeKind}
-                      layerRelated={tg.memberTracks.some((t) =>
-                        selectedNodeSet.has(t.nodeId),
-                      )}
-                      onToggle={() => toggleTrackGroupCollapsed(tg.groupId)}
-                      onSelectMembers={() =>
-                        setSelectedTrackIds(
-                          tg.memberTracks.map((t) => t.id),
+                    (() => {
+                      const memberSet = new Set(
+                        tg.memberTracks.map((t) => t.id),
+                      )
+                      const selectedLayerTracksToAdd =
+                        selectedAnimatedLayerTrackIds().filter(
+                          (trackId) => !memberSet.has(trackId),
                         )
-                      }
-                      onUngroup={() =>
-                        ungroupTracksAction(
-                          tg.memberTracks.map((t) => t.id),
-                        )
-                      }
-                      onRename={(name) =>
-                        renameTrackGroupHelper(api, tg.groupId, name)
-                      }
-                      openContextMenu={openContextMenu}
-                    />
+                      return (
+                        <TrackGroupLeftRow
+                          key={tg.groupId}
+                          group={tg}
+                          nodeKind={group.nodeKind}
+                          layerRelated={tg.memberTracks.some((t) =>
+                            selectedNodeSet.has(t.nodeId),
+                          )}
+                          onToggle={() =>
+                            toggleTrackGroupCollapsed(tg.groupId)
+                          }
+                          onSelectMembers={() =>
+                            setSelectedTrackIds(
+                              tg.memberTracks.map((t) => t.id),
+                            )
+                          }
+                          onUngroup={() =>
+                            ungroupTracksAction(
+                              tg.memberTracks.map((t) => t.id),
+                            )
+                          }
+                          onRename={(name) =>
+                            renameTrackGroupHelper(api, tg.groupId, name)
+                          }
+                          selectedLayerTracksToAdd={
+                            selectedLayerTracksToAdd.length
+                          }
+                          onAddSelectedLayers={() =>
+                            addTracksToGroupHelper(
+                              api,
+                              tg.groupId,
+                              selectedLayerTracksToAdd,
+                            )
+                          }
+                          onRemoveTracksFromGroup={(trackIds) =>
+                            removeTracksFromGroupsHelper(api, trackIds)
+                          }
+                          openContextMenu={openContextMenu}
+                        />
+                      )
+                    })()
                   ))}
                   {visibleTracks.map((t) => (
                     <TrackLabel
@@ -2142,8 +2247,27 @@ export function Timeline() {
                           const toAdd = Array.from(inferred).filter(
                             (t) => !memberSet.has(t),
                           )
+                          const selectedLayerTracksToAdd =
+                            selectedAnimatedLayerTrackIds().filter(
+                              (trackId) => !memberSet.has(trackId),
+                            )
                           const items: import('@/state/ui').ContextMenuItem[] =
                             []
+                          if (selectedLayerTracksToAdd.length > 0) {
+                            items.push({
+                              label:
+                                selectedLayerTracksToAdd.length === 1
+                                  ? 'Add selected animated layer to this group'
+                                  : `Add ${selectedLayerTracksToAdd.length} selected animated layer tracks to this group`,
+                              onClick: () =>
+                                addTracksToGroupHelper(
+                                  api,
+                                  g.groupId,
+                                  selectedLayerTracksToAdd,
+                                ),
+                            })
+                            items.push({ kind: 'separator' })
+                          }
                           if (toAdd.length > 0) {
                             items.push({
                               label:
@@ -3496,6 +3620,9 @@ function TrackGroupLeftRow({
   onSelectMembers,
   onUngroup,
   onRename,
+  selectedLayerTracksToAdd,
+  onAddSelectedLayers,
+  onRemoveTracksFromGroup,
   openContextMenu,
 }: {
   group: ResolvedTrackGroup
@@ -3505,6 +3632,9 @@ function TrackGroupLeftRow({
   onSelectMembers: () => void
   onUngroup: () => void
   onRename: (name: string) => void
+  selectedLayerTracksToAdd: number
+  onAddSelectedLayers: () => void
+  onRemoveTracksFromGroup: (trackIds: string[]) => void
   openContextMenu: (menu: import('@/state/ui').ContextMenuState) => void
 }) {
   const collapsed = group.collapsed
@@ -3546,6 +3676,17 @@ function TrackGroupLeftRow({
                 label: 'Rename group',
                 onClick: () => setEditingName(true),
               },
+              ...(selectedLayerTracksToAdd > 0
+                ? [
+                    {
+                      label:
+                        selectedLayerTracksToAdd === 1
+                          ? 'Add selected animated layer to group'
+                          : `Add ${selectedLayerTracksToAdd} selected animated layer tracks to group`,
+                      onClick: onAddSelectedLayers,
+                    },
+                  ]
+                : []),
               { kind: 'separator' as const },
               { label: 'Ungroup (⌘⇧G)', danger: true, onClick: onUngroup },
             ],
@@ -3635,6 +3776,11 @@ function TrackGroupLeftRow({
                 x: e.clientX,
                 y: e.clientY,
                 items: [
+                  {
+                    label: 'Remove track from group',
+                    onClick: () => onRemoveTracksFromGroup([t.id]),
+                  },
+                  { kind: 'separator' as const },
                   {
                     label: 'Ungroup (⌘⇧G)',
                     danger: true,

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -3650,7 +3650,6 @@ function TrackGroupRightRow({
   const fill = highlighted
     ? 'var(--color-group-bar-active)'
     : 'var(--color-group-bar)'
-  const markerFill = highlighted ? 'white' : 'var(--color-group-bar-marker)'
 
   // Flatten all member-track keyframes into a single list. Snapshot
   // taken at drag-start (inside the handlers) so concurrent scene
@@ -3783,19 +3782,6 @@ function TrackGroupRightRow({
             >
               <span className="absolute top-1/2 right-1 h-2.5 w-0.5 -translate-y-1/2 rounded-full bg-white mix-blend-overlay" />
             </div>
-            <span className="pointer-events-none absolute top-[2px] left-1/2 grid size-3 -translate-x-1/2 place-items-center">
-              <span
-                className={[
-                  'block size-[8.5px] rotate-45 rounded-[2px]',
-                  highlighted ? 'mix-blend-overlay' : '',
-                ].join(' ')}
-                style={{
-                  background: markerFill,
-                  boxShadow:
-                    '0 0 0 0 color-mix(in oklab, var(--color-group-bar-ring) 60%, transparent)',
-                }}
-              />
-            </span>
           </div>
         )}
       </div>
@@ -4203,10 +4189,6 @@ function GroupSpanBar({
       : rightSelected
         ? 'linear-gradient(to right, var(--color-group-bar), var(--color-group-bar-active))'
         : 'var(--color-group-bar)'
-  const markerFill =
-    highlighted || leftSelected || rightSelected
-      ? 'white'
-      : 'var(--color-group-bar-marker)'
 
   /**
    * Scale handler factory. `side` picks the dragged edge, the
@@ -4341,21 +4323,6 @@ function GroupSpanBar({
       >
         <span className="absolute top-1/2 right-1 h-2.5 w-0.5 -translate-y-1/2 rounded-full bg-white mix-blend-overlay" />
       </div>
-      <span className="pointer-events-none absolute top-[2px] left-1/2 grid size-3 -translate-x-1/2 place-items-center">
-        <span
-          className={[
-            'block size-[8.5px] rotate-45 rounded-[2px]',
-            highlighted || leftSelected || rightSelected
-              ? 'mix-blend-overlay'
-              : '',
-          ].join(' ')}
-          style={{
-            background: markerFill,
-            boxShadow:
-              '0 0 0 0 color-mix(in oklab, var(--color-group-bar-ring) 60%, transparent)',
-          }}
-        />
-      </span>
     </div>
   )
 }

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -2393,7 +2393,7 @@ export function Timeline() {
                         }}
                       />
                       {!tg.collapsed &&
-                        tg.memberTracks.map((t) => (
+                        tg.memberTracks.map((t, index) => (
                           <SegmentRow
                             key={t.id}
                             track={t}
@@ -2413,6 +2413,13 @@ export function Timeline() {
                               smoothSeekPlayhead(time)
                             }}
                             onFocus={() => focusTrackForEditing(group.nodeId)}
+                            onDropTrackIds={(trackIds, placement) =>
+                              addDroppedTracksToGroup(
+                                tg.groupId,
+                                trackIds,
+                                index + (placement === 'after' ? 1 : 0),
+                              )
+                            }
                             onBarContextMenu={(e) =>
                               openTimelineMenu(e, { kind: 'track', track: t })
                             }
@@ -3150,6 +3157,7 @@ function SegmentRow({
   onFocus,
   onBarContextMenu,
   onKeyframeContextMenu,
+  onDropTrackIds,
 }: {
   track: Track
   duration: number
@@ -3177,6 +3185,7 @@ function SegmentRow({
     e: React.MouseEvent,
     kf: Track['keyframes'][number],
   ) => void
+  onDropTrackIds?: (trackIds: string[], placement: 'before' | 'after') => void
 }) {
   const rowRef = useRef<HTMLDivElement>(null)
 
@@ -3372,6 +3381,24 @@ function SegmentRow({
     <div
       ref={rowRef}
       onPointerDown={onRowPointerDown}
+      onDragOver={(e) => {
+        if (!onDropTrackIds) return
+        if (!e.dataTransfer.types.includes(TRACK_IDS_DRAG_TYPE)) return
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'move'
+      }}
+      onDrop={(e) => {
+        if (!onDropTrackIds) return
+        const ids = getDraggedTrackIds(e)
+        if (ids.length === 0) return
+        e.preventDefault()
+        e.stopPropagation()
+        const rect = e.currentTarget.getBoundingClientRect()
+        onDropTrackIds(
+          ids,
+          e.clientY > rect.top + rect.height / 2 ? 'after' : 'before',
+        )
+      }}
       className={
         'relative h-6 border-t border-border/30 ' +
         (nodeSelected

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -15,6 +15,7 @@ import {
   ungroupTracks as ungroupTracksHelper,
   removeTracksFromGroups as removeTracksFromGroupsHelper,
   addTracksToGroup as addTracksToGroupHelper,
+  insertTracksIntoGroup as insertTracksIntoGroupHelper,
   toggleTrackGroupCollapsed as toggleTrackGroupCollapsedHelper,
   renameTrackGroup as renameTrackGroupHelper,
 } from '@/state/groupActions'
@@ -357,16 +358,22 @@ export function Timeline() {
     [trackGroupsDict],
   )
   const addDroppedTracksToGroup = useCallback(
-    (groupId: string, trackIds: string[]) => {
+    (groupId: string, trackIds: string[], index?: number) => {
       const group = api.getUiState().trackGroups[groupId]
       if (!group) return
       const memberSet = new Set(group.trackIds)
       const toAdd = [...new Set(trackIds)].filter(
-        (trackId) => !memberSet.has(trackId) && api.getTrack(trackId),
+        (trackId) =>
+          (typeof index === 'number' || !memberSet.has(trackId)) &&
+          api.getTrack(trackId),
       )
       if (toAdd.length === 0) return
-      addTracksToGroupHelper(api, groupId, toAdd)
-      setSelectedTrackIds([...group.trackIds, ...toAdd])
+      insertTracksIntoGroupHelper(api, groupId, toAdd, index)
+      const next = api.getUiState().trackGroups[groupId]?.trackIds ?? [
+        ...group.trackIds,
+        ...toAdd,
+      ]
+      setSelectedTrackIds(next)
       clearKfs()
     },
     [api, clearKfs, setSelectedTrackIds],
@@ -891,8 +898,7 @@ export function Timeline() {
    *     node in tracksByNode order that contributes a member
    *   - label — for composed: the host node's name; for sequence:
    *     "Sequence"
-   *   - memberTracks — Track[] in render order (same order they
-   *     appear in tracksByNode)
+   *   - memberTracks — Track[] in the group's stored order
    *   - collapsed
    *
    * Only groups whose members still resolve to live tracks render —
@@ -911,18 +917,29 @@ export function Timeline() {
       collapsed: boolean
     }
     const out: Resolved[] = []
+    const trackById = new Map<string, Track>()
+    const nodeOrder = new Map<string, number>()
+    for (let i = 0; i < tracksByNode.length; i++) {
+      const ng = tracksByNode[i]!
+      nodeOrder.set(ng.nodeId, i)
+      for (const track of ng.tracks) trackById.set(track.id, track)
+    }
     for (const [groupId, g] of Object.entries(trackGroupsDict)) {
-      const memberSet = new Set(g.trackIds)
       const memberTracks: Track[] = []
-      let hostNodeId: string | null = null
       const memberNodes = new Set<string>()
-      for (const ng of tracksByNode) {
-        for (const t of ng.tracks) {
-          if (memberSet.has(t.id)) {
-            if (hostNodeId === null) hostNodeId = ng.nodeId
-            memberTracks.push(t)
-            memberNodes.add(ng.nodeId)
-          }
+      for (const trackId of g.trackIds) {
+        const track = trackById.get(trackId)
+        if (!track) continue
+        memberTracks.push(track)
+        memberNodes.add(track.nodeId)
+      }
+      let hostNodeId: string | null = null
+      let bestOrder = Infinity
+      for (const nodeId of memberNodes) {
+        const order = nodeOrder.get(nodeId) ?? Infinity
+        if (order < bestOrder) {
+          bestOrder = order
+          hostNodeId = nodeId
         }
       }
       if (memberTracks.length < 2 || !hostNodeId) continue
@@ -1948,11 +1965,18 @@ export function Timeline() {
                       onRemoveTracksFromGroup={(trackIds) =>
                         removeTracksFromGroupsHelper(api, trackIds)
                       }
-                      onDropTracks={(trackIds) =>
-                        addDroppedTracksToGroup(tg.groupId, trackIds)
-                      }
-                      openContextMenu={openContextMenu}
-                    />
+                          onDropTracks={(trackIds) =>
+                            addDroppedTracksToGroup(tg.groupId, trackIds)
+                          }
+                          onDropTracksAtIndex={(trackIds, index) =>
+                            addDroppedTracksToGroup(
+                              tg.groupId,
+                              trackIds,
+                              index,
+                            )
+                          }
+                          openContextMenu={openContextMenu}
+                        />
                       )
                     })()
                   ))}
@@ -2667,6 +2691,7 @@ function TrackLabel({
   layerName,
   onFocus,
   onContextMenu,
+  onDropTrackIds,
 }: {
   track: Track
   /** Used to disambiguate property labels (e.g. cameras read scaleX as "Scale"). */
@@ -2683,6 +2708,7 @@ function TrackLabel({
   layerName?: string
   onFocus: () => void
   onContextMenu: (e: React.MouseEvent) => void
+  onDropTrackIds?: (trackIds: string[], placement: 'before' | 'after') => void
 }) {
   const api = useSceneAPI()
   const selectedTrackId = useUI((s) => s.selectedTrackId)
@@ -2697,6 +2723,24 @@ function TrackLabel({
     <div
       draggable
       onDragStart={(e) => setDraggedTrackIds(e, dragTrackIdsFor(track.id))}
+      onDragOver={(e) => {
+        if (!onDropTrackIds) return
+        if (!e.dataTransfer.types.includes(TRACK_IDS_DRAG_TYPE)) return
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'move'
+      }}
+      onDrop={(e) => {
+        if (!onDropTrackIds) return
+        const ids = getDraggedTrackIds(e)
+        if (ids.length === 0) return
+        e.preventDefault()
+        e.stopPropagation()
+        const rect = e.currentTarget.getBoundingClientRect()
+        onDropTrackIds(
+          ids,
+          e.clientY > rect.top + rect.height / 2 ? 'after' : 'before',
+        )
+      }}
       onClick={(e) => {
         // Shift / Cmd / Ctrl click maintains a MULTI-track selection
         // for Cmd+G grouping. Plain click sets the single-track focus
@@ -3687,6 +3731,7 @@ function TrackGroupLeftRow({
   onAddSelectedLayers,
   onRemoveTracksFromGroup,
   onDropTracks,
+  onDropTracksAtIndex,
   openContextMenu,
 }: {
   group: ResolvedTrackGroup
@@ -3700,6 +3745,7 @@ function TrackGroupLeftRow({
   onAddSelectedLayers: () => void
   onRemoveTracksFromGroup: (trackIds: string[]) => void
   onDropTracks: (trackIds: string[]) => void
+  onDropTracksAtIndex: (trackIds: string[], index: number) => void
   openContextMenu: (menu: import('@/state/ui').ContextMenuState) => void
 }) {
   const collapsed = group.collapsed
@@ -3827,7 +3873,7 @@ function TrackGroupLeftRow({
       {/* Children render only when expanded — indented underneath
           so the bundling reads visually like a folder. */}
       {!collapsed &&
-        group.memberTracks.map((t) => (
+        group.memberTracks.map((t, index) => (
           <TrackLabel
             key={t.id}
             track={t}
@@ -3846,6 +3892,12 @@ function TrackGroupLeftRow({
             onFocus={() => {
               /* selection of the layer happens via the parent shell */
             }}
+            onDropTrackIds={(trackIds, placement) =>
+              onDropTracksAtIndex(
+                trackIds,
+                index + (placement === 'after' ? 1 : 0),
+              )
+            }
             onContextMenu={(e) => {
               e.preventDefault()
               e.stopPropagation()

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -15,6 +15,7 @@ import {
   ungroupTracks as ungroupTracksHelper,
   addTracksToGroup as addTracksToGroupHelper,
   toggleTrackGroupCollapsed as toggleTrackGroupCollapsedHelper,
+  renameTrackGroup as renameTrackGroupHelper,
 } from '@/state/groupActions'
 import { importAudioFile } from '@/ui/importMedia'
 
@@ -805,11 +806,12 @@ export function Timeline() {
       const isComposed = memberNodes.size === 1
       const hostNode =
         api.getNode(hostNodeId)?.name ?? memberTracks[0]?.nodeId ?? 'Group'
+      const customName = typeof g.name === 'string' ? g.name.trim() : ''
       out.push({
         groupId,
         kind: isComposed ? 'composed' : 'sequence',
         hostNodeId,
-        label: isComposed ? hostNode : 'Sequence',
+        label: customName || (isComposed ? hostNode : 'Sequence'),
         memberTracks,
         collapsed: g.collapsed,
       })
@@ -1789,6 +1791,9 @@ export function Timeline() {
                           tg.memberTracks.map((t) => t.id),
                         )
                       }
+                      onRename={(name) =>
+                        renameTrackGroupHelper(api, tg.groupId, name)
+                      }
                       openContextMenu={openContextMenu}
                     />
                   ))}
@@ -2156,6 +2161,18 @@ export function Timeline() {
                               : 'Collapse group',
                             onClick: () =>
                               toggleTrackGroupCollapsed(g.groupId),
+                          })
+                          items.push({
+                            label: 'Rename group',
+                            onClick: () => {
+                              const next = window.prompt(
+                                'Rename group',
+                                g.label,
+                              )
+                              if (next !== null) {
+                                renameTrackGroupHelper(api, g.groupId, next)
+                              }
+                            },
                           })
                           items.push({
                             label: 'Ungroup',
@@ -3478,6 +3495,7 @@ function TrackGroupLeftRow({
   onToggle,
   onSelectMembers,
   onUngroup,
+  onRename,
   openContextMenu,
 }: {
   group: ResolvedTrackGroup
@@ -3486,15 +3504,29 @@ function TrackGroupLeftRow({
   onToggle: () => void
   onSelectMembers: () => void
   onUngroup: () => void
+  onRename: (name: string) => void
   openContextMenu: (menu: import('@/state/ui').ContextMenuState) => void
 }) {
   const collapsed = group.collapsed
   const api = useSceneAPI()
+  const [editingName, setEditingName] = useState(false)
+  const [draftName, setDraftName] = useState(group.label)
+  useEffect(() => {
+    if (!editingName) setDraftName(group.label)
+  }, [editingName, group.label])
+  const commitRename = () => {
+    setEditingName(false)
+    onRename(draftName)
+  }
   return (
     <>
       <div
         onClick={onSelectMembers}
-        onDoubleClick={onToggle}
+        onDoubleClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          setEditingName(true)
+        }}
         onContextMenu={(e) => {
           e.preventDefault()
           e.stopPropagation()
@@ -3509,6 +3541,10 @@ function TrackGroupLeftRow({
               {
                 label: 'Select member tracks',
                 onClick: onSelectMembers,
+              },
+              {
+                label: 'Rename group',
+                onClick: () => setEditingName(true),
               },
               { kind: 'separator' as const },
               { label: 'Ungroup (⌘⇧G)', danger: true, onClick: onUngroup },
@@ -3541,12 +3577,34 @@ function TrackGroupLeftRow({
         ) : (
           <SequenceGlyph />
         )}
-        <span className="truncate text-[11px] font-medium">
-          {group.label}
-          <span className="ml-1 text-text-dim">
-            · {group.kind === 'composed' ? 'Composed' : 'Sequence'}
+        {editingName ? (
+          <input
+            autoFocus
+            value={draftName}
+            onChange={(e) => setDraftName(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitRename()
+              if (e.key === 'Escape') {
+                setDraftName(group.label)
+                setEditingName(false)
+              }
+            }}
+            className="min-w-0 flex-1 rounded border border-accent/40 bg-panel px-1 text-[11px] font-medium text-text outline-none"
+          />
+        ) : (
+          <span
+            className="truncate text-[11px] font-medium"
+            title="Double-click to rename"
+          >
+            {group.label}
+            <span className="ml-1 text-text-dim">
+              · {group.kind === 'composed' ? 'Composed' : 'Sequence'}
+            </span>
           </span>
-        </span>
+        )}
       </div>
       {/* Children render only when expanded — indented underneath
           so the bundling reads visually like a folder. */}

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -8,6 +8,7 @@ import type { SceneNode, Section, Track } from '@/scene'
 import type { SceneAPI } from '@/scene/doc'
 import {
   groupKeyframes as groupKeyframesHelper,
+  ungroupKeyframeGroups as ungroupKeyframeGroupsHelper,
   ungroupKeyframes as ungroupKeyframesHelper,
   toggleKfGroupCollapsed as toggleKfGroupCollapsedHelper,
   groupTracks as groupTracksHelper,
@@ -463,6 +464,14 @@ export function Timeline() {
         }
         if (selectedKfs.size === 0) return
         const keys = Array.from(selectedKfs)
+        // Ungroup should dissolve the actual selected keyframe groups,
+        // even when that group spans multiple tracks. The grouping path
+        // can still infer track intent from multi-track keyframe picks.
+        if (e.shiftKey) {
+          ungroupKeyframesHelper(api, keys)
+          return
+        }
+
         // Pull unique track ids from the selected kf keys
         // (`trackId:kfId` shape). One track → keyframe grouping.
         // Multiple tracks → infer the track-group intent and route
@@ -475,16 +484,12 @@ export function Timeline() {
         }
         if (tracksFromKfs.size >= 2) {
           const ids = Array.from(tracksFromKfs)
-          if (e.shiftKey) {
-            ungroupTracksHelper(api, ids)
-          } else if (!tryMergeIntoExisting(ids)) {
+          if (!tryMergeIntoExisting(ids)) {
             groupTracksHelper(api, ids)
           }
           return
         }
-        if (e.shiftKey) {
-          ungroupKeyframesHelper(api, keys)
-        } else if (selectedKfs.size >= 2) {
+        if (selectedKfs.size >= 2) {
           groupKeyframesHelper(api, keys)
         }
       }
@@ -744,6 +749,12 @@ export function Timeline() {
     () => tracksByNode.flatMap((g) => g.tracks),
     [tracksByNode],
   )
+  const selectedNodeSet = useMemo(() => new Set(selection), [selection])
+  const trackNodeById = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const track of flatTracks) m.set(track.id, track.nodeId)
+    return m
+  }, [flatTracks])
 
   /**
    * Resolve every persistent track-group into a render shape.
@@ -1654,6 +1665,9 @@ export function Timeline() {
                   )}
                   {hostedGroups.map((g) => {
                     const isActive = activeGroupId === g.groupId
+                    const layerRelated = g.members.some((m) =>
+                      selectedNodeSet.has(trackNodeById.get(m.trackId) ?? ''),
+                    )
                     const collapsed = !!kfGroupCollapsedDict[g.groupId]
                     const memberKeys = g.members.map((m) =>
                       kfKey(m.trackId, m.kfId),
@@ -1708,7 +1722,9 @@ export function Timeline() {
                                 label: 'Ungroup (⌘⇧G)',
                                 danger: true,
                                 onClick: () =>
-                                  ungroupKeyframesHelper(api, memberKeys),
+                                  ungroupKeyframeGroupsHelper(api, [
+                                    g.groupId,
+                                  ]),
                               },
                             ],
                           })
@@ -1717,6 +1733,8 @@ export function Timeline() {
                           'flex h-6 cursor-pointer items-center gap-1.5 border-t border-border/50 px-3 pl-3 text-accent',
                           isActive
                             ? 'bg-accent-soft/60 hover:bg-accent-soft/80'
+                            : layerRelated
+                              ? 'bg-accent-soft/45 hover:bg-accent-soft/65'
                             : 'bg-accent-soft/30 hover:bg-accent-soft/50',
                         ].join(' ')}
                         title={
@@ -1757,6 +1775,9 @@ export function Timeline() {
                       key={tg.groupId}
                       group={tg}
                       nodeKind={group.nodeKind}
+                      layerRelated={tg.memberTracks.some((t) =>
+                        selectedNodeSet.has(t.nodeId),
+                      )}
                       onToggle={() => toggleTrackGroupCollapsed(tg.groupId)}
                       onSelectMembers={() =>
                         setSelectedTrackIds(
@@ -2011,6 +2032,9 @@ export function Timeline() {
                   )}
                   {hostedGroups.map((g) => {
                     const isActive = activeGroupId === g.groupId
+                    const layerRelated = g.members.some((m) =>
+                      selectedNodeSet.has(trackNodeById.get(m.trackId) ?? ''),
+                    )
                     const memberKeys = g.members.map((m) =>
                       kfKey(m.trackId, m.kfId),
                     )
@@ -2044,14 +2068,20 @@ export function Timeline() {
                                 label: 'Ungroup (⌘⇧G)',
                                 danger: true,
                                 onClick: () =>
-                                  ungroupKeyframesHelper(api, memberKeys),
+                                  ungroupKeyframeGroupsHelper(api, [
+                                    g.groupId,
+                                  ]),
                               },
                             ],
                           })
                         }}
                         className={[
                           'relative h-6 border-t border-border/50',
-                          isActive ? 'bg-accent-soft/50' : 'bg-accent-soft/20',
+                          isActive
+                            ? 'bg-accent-soft/50'
+                            : layerRelated
+                              ? 'bg-accent-soft/35'
+                              : 'bg-accent-soft/20',
                         ].join(' ')}
                         style={{ width: totalWidth }}
                       >
@@ -2060,6 +2090,7 @@ export function Timeline() {
                           duration={duration}
                           api={api}
                           selectedKfs={selectedKfs}
+                          layerRelated={layerRelated}
                           replaceKfs={replaceKfs}
                         />
                       </div>
@@ -2079,6 +2110,9 @@ export function Timeline() {
                         totalWidth={totalWidth}
                         duration={duration}
                         api={api}
+                        layerRelated={tg.memberTracks.some((t) =>
+                          selectedNodeSet.has(t.nodeId),
+                        )}
                         onContextMenu={(e, g) => {
                           e.preventDefault()
                           e.stopPropagation()
@@ -2098,7 +2132,8 @@ export function Timeline() {
                           }
                           // Anything already in this group is a
                           // no-op — filter to genuinely new tracks.
-                          const memberSet = new Set(g.trackIds)
+                          const groupTrackIds = g.memberTracks.map((t) => t.id)
+                          const memberSet = new Set(groupTrackIds)
                           const toAdd = Array.from(inferred).filter(
                             (t) => !memberSet.has(t),
                           )
@@ -2126,7 +2161,7 @@ export function Timeline() {
                             label: 'Ungroup',
                             danger: true,
                             onClick: () =>
-                              ungroupTracksHelper(api, g.trackIds),
+                              ungroupTracksHelper(api, groupTrackIds),
                           })
                           openContextMenu({
                             x: e.clientX,
@@ -2925,6 +2960,12 @@ function SegmentRow({
   const first = kfs[0]
   const last = kfs[kfs.length - 1]
   const hasSpan = kfs.length >= 2 && first && last && last.time > first.time
+  const segmentClassName = nodeSelected
+    ? 'absolute top-1/2 h-1.5 -translate-y-1/2 cursor-grab rounded-full bg-accent ring-1 ring-accent/70 shadow-[0_0_0_2px_var(--color-accent-soft)] hover:brightness-110'
+    : 'absolute top-1/2 h-1.5 -translate-y-1/2 cursor-grab rounded-full bg-segment-bar/70 ring-1 ring-segment-bar-ring/60 hover:bg-segment-bar-hover'
+  const beadClassName = nodeSelected
+    ? 'absolute top-1/2 h-1.5 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-accent shadow-[0_0_0_2px_var(--color-accent-soft)]'
+    : 'absolute top-1/2 h-1.5 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-segment-bar-hover'
 
   const onBarPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!first || !last) return
@@ -3106,7 +3147,7 @@ function SegmentRow({
             onPointerDown={onBarPointerDown}
             onContextMenu={onBarContextMenu}
             title={`${first.time.toFixed(2)}s → ${last.time.toFixed(2)}s — drag to shift, right-click for options`}
-            className="absolute top-1/2 h-1.5 -translate-y-1/2 cursor-grab rounded-full bg-segment-bar/70 ring-1 ring-segment-bar-ring/60 hover:bg-segment-bar-hover"
+            className={segmentClassName}
             style={{
               left: first.time * PX_PER_SECOND,
               width: (last.time - first.time) * PX_PER_SECOND,
@@ -3114,7 +3155,7 @@ function SegmentRow({
           />
         ) : (
           <div
-            className="absolute top-1/2 h-1.5 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-segment-bar-hover"
+            className={beadClassName}
             style={{ left: first.time * PX_PER_SECOND }}
           />
         )
@@ -3433,6 +3474,7 @@ type ResolvedTrackGroup = {
 function TrackGroupLeftRow({
   group,
   nodeKind,
+  layerRelated = false,
   onToggle,
   onSelectMembers,
   onUngroup,
@@ -3440,6 +3482,7 @@ function TrackGroupLeftRow({
 }: {
   group: ResolvedTrackGroup
   nodeKind?: string
+  layerRelated?: boolean
   onToggle: () => void
   onSelectMembers: () => void
   onUngroup: () => void
@@ -3477,7 +3520,10 @@ function TrackGroupLeftRow({
             ? 'Click to select members · double-click to expand · right-click for more'
             : 'Click to select members · double-click to collapse · right-click for more'
         }
-        className="flex h-6 cursor-pointer items-center gap-1.5 border-t border-border/50 bg-accent-soft/50 px-3 pl-2 text-accent hover:bg-accent-soft/70"
+        className={[
+          'flex h-6 cursor-pointer items-center gap-1.5 border-t border-border/50 px-3 pl-2 text-accent hover:bg-accent-soft/70',
+          layerRelated ? 'bg-accent-soft/65' : 'bg-accent-soft/50',
+        ].join(' ')}
       >
         <button
           type="button"
@@ -3572,12 +3618,14 @@ function TrackGroupRightRow({
   totalWidth,
   duration,
   api,
+  layerRelated = false,
   onContextMenu,
 }: {
   group: ResolvedTrackGroup
   totalWidth: number
   duration: number
   api: SceneAPI
+  layerRelated?: boolean
   /** Right-click on the span bar — parent builds the menu so it can
    *  reach the live track selection and the openContextMenu handle. */
   onContextMenu?: (e: React.MouseEvent, group: ResolvedTrackGroup) => void
@@ -3598,10 +3646,11 @@ function TrackGroupRightRow({
   const allSelected =
     group.memberTracks.length > 0 &&
     group.memberTracks.every((track) => selectedTrackIds.includes(track.id))
-  const fillClass = allSelected ? 'bg-[#0091ff]' : 'bg-[#224a71]'
-  const markerClass = allSelected
-    ? 'bg-white mix-blend-overlay'
-    : 'bg-[#00a1ff]'
+  const highlighted = allSelected || layerRelated
+  const fill = highlighted
+    ? 'var(--color-group-bar-active)'
+    : 'var(--color-group-bar)'
+  const markerFill = highlighted ? 'white' : 'var(--color-group-bar-marker)'
 
   // Flatten all member-track keyframes into a single list. Snapshot
   // taken at drag-start (inside the handlers) so concurrent scene
@@ -3693,7 +3742,10 @@ function TrackGroupRightRow({
   return (
     <>
       <div
-        className="relative h-6 border-t border-border/50 bg-accent-soft/30"
+        className={[
+          'relative h-6 border-t border-border/50',
+          layerRelated ? 'bg-accent-soft/45' : 'bg-accent-soft/30',
+        ].join(' ')}
         style={{ width: totalWidth }}
         onContextMenu={(e) => onContextMenu?.(e, group)}
       >
@@ -3703,11 +3755,14 @@ function TrackGroupRightRow({
             onPointerDown={onBodyPointerDown}
             onContextMenu={(e) => onContextMenu?.(e, group)}
             title={`${start.toFixed(2)}s – ${end.toFixed(2)}s · drag body to shift, edges to scale, right-click for options`}
-            className={[
-              'group absolute top-1/2 h-4 -translate-y-1/2 cursor-grab rounded-[4px] shadow-[0_0_0_0_#002e5d] ring-1 ring-[#1b4165] hover:brightness-110 active:cursor-grabbing',
-              fillClass,
-            ].join(' ')}
-            style={{ left, width: Math.max(2, width) }}
+            className="group absolute top-1/2 h-4 -translate-y-1/2 cursor-grab rounded-[4px] ring-1 hover:brightness-110 active:cursor-grabbing"
+            style={{
+              left,
+              width: Math.max(2, width),
+              background: fill,
+              boxShadow: '0 0 0 0 color-mix(in oklab, var(--color-group-bar-ring) 60%, transparent)',
+              '--tw-ring-color': 'var(--color-group-bar-ring)',
+            } as React.CSSProperties}
           >
             {/* Edge scale handles. 8px wide, slightly extending past
                 the bar so they're easy to grab. data-groupHandle on
@@ -3731,9 +3786,14 @@ function TrackGroupRightRow({
             <span className="pointer-events-none absolute top-[2px] left-1/2 grid size-3 -translate-x-1/2 place-items-center">
               <span
                 className={[
-                  'block size-[8.5px] rotate-45 rounded-[2px] shadow-[0_0_0_0_#002e5d]',
-                  markerClass,
+                  'block size-[8.5px] rotate-45 rounded-[2px]',
+                  highlighted ? 'mix-blend-overlay' : '',
                 ].join(' ')}
+                style={{
+                  background: markerFill,
+                  boxShadow:
+                    '0 0 0 0 color-mix(in oklab, var(--color-group-bar-ring) 60%, transparent)',
+                }}
               />
             </span>
           </div>
@@ -4105,6 +4165,7 @@ function GroupSpanBar({
   duration,
   api,
   selectedKfs,
+  layerRelated = false,
   replaceKfs,
 }: {
   group: {
@@ -4116,6 +4177,7 @@ function GroupSpanBar({
   duration: number
   api: SceneAPI
   selectedKfs: Set<string>
+  layerRelated?: boolean
   replaceKfs: (keys: string[]) => void
 }) {
   const span = group.end - group.start
@@ -4133,16 +4195,18 @@ function GroupSpanBar({
       Math.abs(m.time - group.end) < 0.001 &&
       selectedKfs.has(kfKey(m.trackId, m.kfId)),
   )
-  const fillClass = allSelected
-    ? 'bg-[#0091ff]'
+  const highlighted = allSelected || layerRelated
+  const fill = highlighted
+    ? 'var(--color-group-bar-active)'
     : leftSelected
-      ? 'bg-gradient-to-r from-[#0091ff] to-[#224a71]'
+      ? 'linear-gradient(to right, var(--color-group-bar-active), var(--color-group-bar))'
       : rightSelected
-        ? 'bg-gradient-to-r from-[#224a71] to-[#0091ff]'
-        : 'bg-[#224a71]'
-  const markerClass = allSelected || leftSelected || rightSelected
-    ? 'bg-white mix-blend-overlay'
-    : 'bg-[#00a1ff]'
+        ? 'linear-gradient(to right, var(--color-group-bar), var(--color-group-bar-active))'
+        : 'var(--color-group-bar)'
+  const markerFill =
+    highlighted || leftSelected || rightSelected
+      ? 'white'
+      : 'var(--color-group-bar-marker)'
 
   /**
    * Scale handler factory. `side` picks the dragged edge, the
@@ -4248,11 +4312,18 @@ function GroupSpanBar({
       data-timeline-selection-surface="1"
       onPointerDown={onBodyPointerDown}
       title={`Group of ${group.members.length} keyframes — drag to shift, drag edges to scale`}
-      className={[
-        'absolute z-20 h-4 cursor-grab rounded-[4px] shadow-[0_0_0_0_#002e5d] ring-1 ring-[#1b4165] hover:brightness-110',
-        fillClass,
-      ].join(' ')}
-      style={{ left, top: 4, width }}
+      className="absolute z-20 h-4 cursor-grab rounded-[4px] ring-1 hover:brightness-110"
+      style={
+        {
+          left,
+          top: 4,
+          width,
+          background: fill,
+          boxShadow:
+            '0 0 0 0 color-mix(in oklab, var(--color-group-bar-ring) 60%, transparent)',
+          '--tw-ring-color': 'var(--color-group-bar-ring)',
+        } as React.CSSProperties
+      }
     >
       <div
         data-group-handle="left"
@@ -4273,9 +4344,16 @@ function GroupSpanBar({
       <span className="pointer-events-none absolute top-[2px] left-1/2 grid size-3 -translate-x-1/2 place-items-center">
         <span
           className={[
-            'block size-[8.5px] rotate-45 rounded-[2px] shadow-[0_0_0_0_#002e5d]',
-            markerClass,
+            'block size-[8.5px] rotate-45 rounded-[2px]',
+            highlighted || leftSelected || rightSelected
+              ? 'mix-blend-overlay'
+              : '',
           ].join(' ')}
+          style={{
+            background: markerFill,
+            boxShadow:
+              '0 0 0 0 color-mix(in oklab, var(--color-group-bar-ring) 60%, transparent)',
+          }}
         />
       </span>
     </div>

--- a/src/ui/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/hooks/useKeyboardShortcuts.ts
@@ -9,6 +9,7 @@ import type {
   NodeId,
   Node as SceneNode,
   PropertyId,
+  Track,
 } from '@/scene'
 import { useUI, type Tool } from '@/state/ui'
 import {
@@ -16,7 +17,7 @@ import {
   instantiateComponent,
   wrapInAutoLayout,
 } from '@/ui/actions'
-import { addKeyframe, removeTrack } from '@/anim'
+import { addKeyframe, removeTrack, type TextAnimationConfig } from '@/anim'
 
 /**
  * Global keyboard shortcuts.
@@ -193,6 +194,10 @@ export function useKeyboardShortcuts() {
       // input still works for ordinary text copy (events from text
       // inputs are already filtered out earlier in the handler).
       if (meta && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'c') {
+        if (copySelectedTextAnimations(api)) {
+          e.preventDefault()
+          return
+        }
         if (copySelectedKeyframes(api)) {
           e.preventDefault()
           return
@@ -203,6 +208,8 @@ export function useKeyboardShortcuts() {
         clipboard = sel
           .map((id) => serializeSubtree(api, id))
           .filter((x): x is ClipboardNode => x !== null)
+        keyframeClipboard = []
+        textAnimationClipboard = []
         return
       }
 
@@ -210,6 +217,10 @@ export function useKeyboardShortcuts() {
       // because the underlying nodes are gone; Cmd+V restores them
       // (under root by default, see paste below).
       if (meta && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'x') {
+        if (cutSelectedTextAnimations(api)) {
+          e.preventDefault()
+          return
+        }
         if (copySelectedKeyframes(api)) {
           e.preventDefault()
           return
@@ -220,6 +231,8 @@ export function useKeyboardShortcuts() {
         clipboard = sel
           .map((id) => serializeSubtree(api, id))
           .filter((x): x is ClipboardNode => x !== null)
+        keyframeClipboard = []
+        textAnimationClipboard = []
         for (const id of sel) {
           // Skip root + camera — deleting the artboard or active
           // camera mid-cut leaves the scene in a bad state.
@@ -239,6 +252,10 @@ export function useKeyboardShortcuts() {
       //     you have a frame selected and hit Cmd+V).
       //   - Otherwise the scene root (paste at the top level).
       if (meta && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'v') {
+        if (pasteTextAnimationsAtPlayhead(api)) {
+          e.preventDefault()
+          return
+        }
         if (pasteKeyframesAtPlayhead(api)) {
           e.preventDefault()
           return
@@ -714,6 +731,22 @@ interface ClipboardKeyframe {
 
 let keyframeClipboard: ClipboardKeyframe[] = []
 
+interface ClipboardTextAnimation {
+  sourceTrackId: string
+  nodeId: NodeId
+  start: number
+  defaultEasing: EasingKind
+  textAnimation: TextAnimationConfig
+  keyframes: Array<{
+    time: number
+    value: KeyframeValue
+    easingOut?: EasingKind
+    presetOrigin?: 'in' | 'out'
+  }>
+}
+
+let textAnimationClipboard: ClipboardTextAnimation[] = []
+
 function serializeSubtree(
   api: ReturnType<typeof useSceneAPI>,
   nodeId: NodeId,
@@ -792,6 +825,160 @@ function pasteSubtree(
   return newId
 }
 
+function copySelectedTextAnimations(
+  api: ReturnType<typeof useSceneAPI>,
+): boolean {
+  const tracks = collectSelectedTextAnimationTracks(api)
+  if (tracks.length === 0) return false
+
+  textAnimationClipboard = tracks.map((track) => {
+    const start = Math.min(...track.keyframes.map((keyframe) => keyframe.time))
+    return {
+      sourceTrackId: track.id,
+      nodeId: track.nodeId,
+      start,
+      defaultEasing: track.defaultEasing,
+      textAnimation: cloneTextAnimation(track.textAnimation!),
+      keyframes: track.keyframes.map((keyframe) => ({
+        time: keyframe.time,
+        value: keyframe.value,
+        ...(keyframe.easingOut ? { easingOut: keyframe.easingOut } : {}),
+        ...(keyframe.presetOrigin
+          ? { presetOrigin: keyframe.presetOrigin }
+          : {}),
+      })),
+    }
+  })
+  keyframeClipboard = []
+  clipboard = []
+  return textAnimationClipboard.length > 0
+}
+
+function cutSelectedTextAnimations(api: ReturnType<typeof useSceneAPI>): boolean {
+  if (!copySelectedTextAnimations(api)) return false
+  const sourceTrackIds = textAnimationClipboard.map((item) => item.sourceTrackId)
+  api.doc.transact(() => {
+    for (const trackId of sourceTrackIds) removeTrack(api, trackId)
+  })
+  useUI.getState().setSelectedKeyframes([])
+  useUI.getState().setSelectedTrackIds([])
+  useUI.getState().setSelectedTrackId(null)
+  return true
+}
+
+function pasteTextAnimationsAtPlayhead(
+  api: ReturnType<typeof useSceneAPI>,
+): boolean {
+  if (textAnimationClipboard.length === 0) return false
+
+  const selection = useUI.getState().selection
+  const targets = selection.filter((nodeId) => api.getNode(nodeId)?.kind === 'text')
+  if (targets.length === 0) return false
+
+  const earliest = Math.min(...textAnimationClipboard.map((item) => item.start))
+  const playhead = useUI.getState().playhead
+  const pastedKeys: string[] = []
+  const pastedTrackIds: string[] = []
+
+  api.doc.transact(() => {
+    for (const targetNodeId of targets) {
+      for (const item of textAnimationClipboard) {
+        const nextStart = Math.max(0, playhead + item.start - earliest)
+        const shift = nextStart - item.start
+        const config: TextAnimationConfig = {
+          ...cloneTextAnimation(item.textAnimation),
+          startTime: Math.max(0, item.textAnimation.startTime + shift),
+        }
+        const trackId =
+          findTextAnimationTrackAtStart(api, targetNodeId, nextStart) ??
+          genTrackId()
+        const keyframes = item.keyframes
+          .map((keyframe) => ({
+            id: genTrackId(),
+            time: Math.max(0, keyframe.time + shift),
+            value: keyframe.value,
+            ...(keyframe.easingOut
+              ? { easingOut: keyframe.easingOut }
+              : {}),
+            ...(keyframe.presetOrigin
+              ? { presetOrigin: keyframe.presetOrigin }
+              : {}),
+          }))
+          .sort((a, b) => a.time - b.time)
+
+        api.setNodeProperty(targetNodeId, 'textAnimation', config)
+        api.setTrack({
+          id: trackId,
+          nodeId: targetNodeId,
+          propertyId: 'text.progress',
+          defaultEasing: item.defaultEasing,
+          textAnimation: config,
+          keyframes,
+        })
+        pastedTrackIds.push(trackId)
+        for (const keyframe of keyframes) {
+          pastedKeys.push(`${trackId}:${keyframe.id}`)
+        }
+      }
+    }
+  })
+
+  if (pastedKeys.length === 0) return false
+  useUI.getState().setSelectedKeyframes(pastedKeys)
+  useUI.getState().setSelectedTrackIds([...new Set(pastedTrackIds)])
+  useUI.getState().setSelectedTrackId(null)
+  return true
+}
+
+function collectSelectedTextAnimationTracks(
+  api: ReturnType<typeof useSceneAPI>,
+): Track[] {
+  const ui = useUI.getState()
+  const trackIds = new Set<string>(ui.selectedTrackIds)
+  for (const key of ui.selectedKeyframes) {
+    const sep = key.indexOf(':')
+    if (sep > 0) trackIds.add(key.slice(0, sep))
+  }
+
+  const tracks: Track[] = []
+  for (const trackId of trackIds) {
+    const track = api.getTrack(trackId)
+    if (
+      !track ||
+      track.propertyId !== 'text.progress' ||
+      !track.textAnimation ||
+      track.keyframes.length < 2
+    ) {
+      continue
+    }
+    tracks.push(track)
+  }
+
+  return tracks.sort((a, b) => {
+    const aStart = Math.min(...a.keyframes.map((keyframe) => keyframe.time))
+    const bStart = Math.min(...b.keyframes.map((keyframe) => keyframe.time))
+    return aStart - bStart
+  })
+}
+
+function findTextAnimationTrackAtStart(
+  api: ReturnType<typeof useSceneAPI>,
+  nodeId: NodeId,
+  startTime: number,
+): string | null {
+  for (const track of api.getTracksForNode(nodeId)) {
+    if (track.propertyId !== 'text.progress') continue
+    if (track.keyframes.length < 2) continue
+    const start = Math.min(...track.keyframes.map((keyframe) => keyframe.time))
+    if (Math.abs(start - startTime) <= 0.01) return track.id
+  }
+  return null
+}
+
+function cloneTextAnimation(config: TextAnimationConfig): TextAnimationConfig {
+  return JSON.parse(JSON.stringify(config)) as TextAnimationConfig
+}
+
 function copySelectedKeyframes(api: ReturnType<typeof useSceneAPI>): boolean {
   const keys = useUI.getState().selectedKeyframes
   if (keys.length === 0) return false
@@ -838,6 +1025,7 @@ function copySelectedKeyframes(api: ReturnType<typeof useSceneAPI>): boolean {
       ...(entry.easingOut ? { easingOut: entry.easingOut } : {}),
       ...(entry.presetOrigin ? { presetOrigin: entry.presetOrigin } : {}),
     }))
+  textAnimationClipboard = []
   return true
 }
 


### PR DESCRIPTION
## Summary
- resolve the Text Animation accordion summary and body from the same text animation source
- fall back to the selected text layer's stored text animation config when no active text.progress range is under the playhead
- avoid the contradictory state where the header shows an animation but the card says No text animation

## Validation
- pnpm exec eslint src/ui/PresetsPanel.tsx
- pnpm typecheck 2>&1 | rg "src/ui/PresetsPanel.tsx"
- git diff --check
- pnpm build:dir

Leaving this PR unmerged for visual review.