### PR TITLE
test(cli): cover MCP keyframe capabilities

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  handleGetCapabilities,
+  handleListKeyframeableProperties,
+} from './tools/capabilities.js'
+
+test('capability tools list the full supported keyframe property set', async () => {
+  const expected = [
+    'transform.anchorX',
+    'transform.anchorY',
+    'transform.anchorZ',
+    'camera.focusX',
+    'camera.focusY',
+    'camera.iso',
+    'appearance.cornerRadii',
+    'appearance.cornerRadii.tl',
+    'appearance.cornerRadii.tr',
+    'appearance.cornerRadii.br',
+    'appearance.cornerRadii.bl',
+    'appearance.fill',
+  ]
+
+  const capabilities = parseToolJson(await handleGetCapabilities())
+  const listed = parseToolJson(await handleListKeyframeableProperties())
+
+  for (const propertyId of expected) {
+    assert.ok(
+      capabilities.keyframeableProperties.includes(propertyId),
+      `get_capabilities omitted ${propertyId}`,
+    )
+    assert.ok(
+      listed.keyframeableProperties.includes(propertyId),
+      `list_keyframeable_properties omitted ${propertyId}`,
+    )
+  }
+})
+
+function parseToolJson(result: {
+  content: Array<{ type: 'text'; text: string }>
+}): { keyframeableProperties: string[] } {
+  return JSON.parse(result.content[0]?.text ?? '{}') as {
+    keyframeableProperties: string[]
+  }
+}

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js'
+import type { PropertyIdJson } from '../../scene/build.js'
 
 const KEYFRAMEABLE_PROPERTIES = [
   'transform.x',
@@ -11,6 +12,11 @@ const KEYFRAMEABLE_PROPERTIES = [
   'transform.rotationY',
   'transform.scaleX',
   'transform.scaleY',
+  'transform.anchorX',
+  'transform.anchorY',
+  'transform.anchorZ',
+  'camera.focusX',
+  'camera.focusY',
   'camera.focusWorldX',
   'camera.focusWorldY',
   'camera.focusWorldZ',
@@ -25,10 +31,17 @@ const KEYFRAMEABLE_PROPERTIES = [
   'camera.nearClip',
   'camera.farClip',
   'camera.aperture',
+  'camera.iso',
   'camera.blurLevel',
   'camera.blurQuality',
   'appearance.opacity',
   'appearance.cornerRadius',
+  'appearance.cornerRadii',
+  'appearance.cornerRadii.tl',
+  'appearance.cornerRadii.tr',
+  'appearance.cornerRadii.br',
+  'appearance.cornerRadii.bl',
+  'appearance.fill',
   'layout.gap',
   'layout.padding.top',
   'layout.padding.right',
@@ -38,7 +51,7 @@ const KEYFRAMEABLE_PROPERTIES = [
   'size.height',
   'layout.direction',
   'variant',
-]
+] satisfies PropertyIdJson[]
 
 export const getCapabilitiesTool: Tool = {
   name: 'get_capabilities',


### PR DESCRIPTION
## Summary\n- align MCP capability keyframe property list with the scene builder's supported PropertyIdJson values\n- add a focused MCP test for recently supported keyframe properties\n\n## Tests\n- pnpm --dir cli test