### PR TITLE
docs(cli): correct Linux locator strategy comment

### DIFF
--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -9,9 +9,9 @@
  *             then `~/Applications/...`. Future: query `mdfind`.
  *   Windows — Check `%ProgramFiles%\hyper-motion\hyper-motion.exe` and
  *             `%LOCALAPPDATA%\Programs\hyper-motion\hyper-motion.exe`.
- *   Linux   — Walk `~/.local/share/applications` for `.desktop` entries
- *             and check `/opt/hyper-motion` and AppImage in
- *             `~/Applications` / `~/.local/bin`.
+ *   Linux   — Check common binary/AppImage install locations:
+ *             `/opt/hyper-motion`, `/usr/bin`, `~/Applications`, and
+ *             `~/.local/bin`.
  *
  * Override path with `HYPERMOTION_APP_PATH` env var if installed somewhere
  * non-standard.


### PR DESCRIPTION
## Summary
- Correct the CLI desktop locator comment to match the current Linux search behavior.

## Verification
- pnpm --dir cli test

Note: root `pnpm lint` and `pnpm typecheck` currently fail on pre-existing app issues outside this comment-only change.