### PR TITLE
test: avoid opening app in create_scene count test

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -121,6 +121,7 @@ test('create_scene reports persisted layer and track counts', async () => {
   try {
     const result = await handleCreateScene({
       output: scenePath,
+      open: false,
       scene: {
         nodes: {
           aliasA: {


### PR DESCRIPTION
## Summary
- make the create_scene layer/track count test opt out of opening the desktop app
- keeps the unit test focused on persisted scene counts and avoids machine-dependent side effects

## Tests
- pnpm test (from cli/)