### PR TITLE
Add locator test for missing app path override

### DIFF
--- a/cli/src/electron/locator.test.ts
+++ b/cli/src/electron/locator.test.ts
@@ -26,3 +26,29 @@ test('locator returns an existing HYPERMOTION_APP_PATH override', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('locator rejects a missing HYPERMOTION_APP_PATH override', async () => {
+  const previousOverride = process.env.HYPERMOTION_APP_PATH
+  const previousConsoleError = console.error
+  const missingPath = path.join(os.tmpdir(), `hypermotion-missing-${process.pid}`)
+  const messages: unknown[] = []
+
+  try {
+    process.env.HYPERMOTION_APP_PATH = missingPath
+    console.error = (...args: unknown[]) => {
+      messages.push(...args)
+    }
+
+    assert.equal(await locateDesktopApp(), null)
+    assert.equal(messages.length, 1)
+    assert.match(String(messages[0]), /HYPERMOTION_APP_PATH is set/)
+    assert.match(String(messages[0]), new RegExp(missingPath.replaceAll('\\', '\\\\')))
+  } finally {
+    console.error = previousConsoleError
+    if (previousOverride === undefined) {
+      delete process.env.HYPERMOTION_APP_PATH
+    } else {
+      process.env.HYPERMOTION_APP_PATH = previousOverride
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add CLI locator coverage for a missing HYPERMOTION_APP_PATH override
- verify the locator returns null and surfaces the intended diagnostic without leaking env changes

## Tests
- pnpm --dir cli test