### PR TITLE
Share CLI keyframe property ids

### DIFF
--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -1,57 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js'
-import type { PropertyIdJson } from '../../scene/build.js'
-
-const KEYFRAMEABLE_PROPERTIES = [
-  'transform.x',
-  'transform.y',
-  'transform.z',
-  'transform.rotation',
-  'transform.rotationX',
-  'transform.rotationY',
-  'transform.scaleX',
-  'transform.scaleY',
-  'transform.anchorX',
-  'transform.anchorY',
-  'transform.anchorZ',
-  'camera.focusX',
-  'camera.focusY',
-  'camera.focusWorldX',
-  'camera.focusWorldY',
-  'camera.focusWorldZ',
-  'camera.focusDistance',
-  'camera.focusRadius',
-  'camera.focusFalloff',
-  'camera.pointOfInterestX',
-  'camera.pointOfInterestY',
-  'camera.pointOfInterestZ',
-  'camera.focalLength',
-  'camera.fieldOfView',
-  'camera.nearClip',
-  'camera.farClip',
-  'camera.aperture',
-  'camera.iso',
-  'camera.blurLevel',
-  'camera.blurQuality',
-  'appearance.opacity',
-  'appearance.cornerRadius',
-  'appearance.cornerRadii',
-  'appearance.cornerRadii.tl',
-  'appearance.cornerRadii.tr',
-  'appearance.cornerRadii.br',
-  'appearance.cornerRadii.bl',
-  'appearance.fill',
-  'layout.gap',
-  'layout.padding.top',
-  'layout.padding.right',
-  'layout.padding.bottom',
-  'layout.padding.left',
-  'size.width',
-  'size.height',
-  'layout.direction',
-  'variant',
-] satisfies PropertyIdJson[]
+import { PROPERTY_IDS } from '../../scene/build.js'
 
 export const getCapabilitiesTool: Tool = {
   name: 'get_capabilities',
@@ -90,12 +40,12 @@ export async function handleGetCapabilities() {
     queryTools: ['list_layers', 'get_layer', 'list_tracks', 'list_cameras'],
     renderFormats: ['mp4', 'webm', 'gif'],
     renderQualities: ['comp', '720p', '2k', '4k'],
-    keyframeableProperties: KEYFRAMEABLE_PROPERTIES,
+    keyframeableProperties: PROPERTY_IDS,
   })
 }
 
 export async function handleListKeyframeableProperties() {
-  return text({ keyframeableProperties: KEYFRAMEABLE_PROPERTIES })
+  return text({ keyframeableProperties: PROPERTY_IDS })
 }
 
 function text(value: unknown) {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -240,54 +240,57 @@ export interface AppearanceJson {
   effects?: JsonValue[]
 }
 
-export type PropertyIdJson =
-  | 'transform.x'
-  | 'transform.y'
-  | 'transform.z'
-  | 'transform.rotation'
-  | 'transform.rotationX'
-  | 'transform.rotationY'
-  | 'transform.scaleX'
-  | 'transform.scaleY'
-  | 'transform.anchorX'
-  | 'transform.anchorY'
-  | 'transform.anchorZ'
-  | 'camera.focusDistance'
-  | 'camera.focusX'
-  | 'camera.focusY'
-  | 'camera.focusWorldX'
-  | 'camera.focusWorldY'
-  | 'camera.focusWorldZ'
-  | 'camera.focusRadius'
-  | 'camera.focusFalloff'
-  | 'camera.pointOfInterestX'
-  | 'camera.pointOfInterestY'
-  | 'camera.pointOfInterestZ'
-  | 'camera.focalLength'
-  | 'camera.fieldOfView'
-  | 'camera.nearClip'
-  | 'camera.farClip'
-  | 'camera.aperture'
-  | 'camera.iso'
-  | 'camera.blurLevel'
-  | 'camera.blurQuality'
-  | 'appearance.opacity'
-  | 'appearance.cornerRadius'
-  | 'appearance.cornerRadii'
-  | 'appearance.cornerRadii.tl'
-  | 'appearance.cornerRadii.tr'
-  | 'appearance.cornerRadii.br'
-  | 'appearance.cornerRadii.bl'
-  | 'appearance.fill'
-  | 'layout.gap'
-  | 'layout.padding.top'
-  | 'layout.padding.right'
-  | 'layout.padding.bottom'
-  | 'layout.padding.left'
-  | 'layout.direction'
-  | 'size.width'
-  | 'size.height'
-  | 'variant'
+export const PROPERTY_IDS = [
+  'transform.x',
+  'transform.y',
+  'transform.z',
+  'transform.rotation',
+  'transform.rotationX',
+  'transform.rotationY',
+  'transform.scaleX',
+  'transform.scaleY',
+  'transform.anchorX',
+  'transform.anchorY',
+  'transform.anchorZ',
+  'camera.focusDistance',
+  'camera.focusX',
+  'camera.focusY',
+  'camera.focusWorldX',
+  'camera.focusWorldY',
+  'camera.focusWorldZ',
+  'camera.focusRadius',
+  'camera.focusFalloff',
+  'camera.pointOfInterestX',
+  'camera.pointOfInterestY',
+  'camera.pointOfInterestZ',
+  'camera.focalLength',
+  'camera.fieldOfView',
+  'camera.nearClip',
+  'camera.farClip',
+  'camera.aperture',
+  'camera.iso',
+  'camera.blurLevel',
+  'camera.blurQuality',
+  'appearance.opacity',
+  'appearance.cornerRadius',
+  'appearance.cornerRadii',
+  'appearance.cornerRadii.tl',
+  'appearance.cornerRadii.tr',
+  'appearance.cornerRadii.br',
+  'appearance.cornerRadii.bl',
+  'appearance.fill',
+  'layout.gap',
+  'layout.padding.top',
+  'layout.padding.right',
+  'layout.padding.bottom',
+  'layout.padding.left',
+  'layout.direction',
+  'size.width',
+  'size.height',
+  'variant',
+] as const
+
+export type PropertyIdJson = (typeof PROPERTY_IDS)[number]
 
 export type EasingJson =
   | 'linear'


### PR DESCRIPTION
## Summary
- export the CLI keyframe property id list from the scene schema module
- reuse that list in MCP capabilities responses to avoid a duplicate contract

## Verification
- pnpm --dir cli test

Note: top-level pnpm lint/typecheck currently fail on unrelated existing app issues from origin/main; this PR is CLI-only and was verified with the CLI package suite.