### PR TITLE
Document create_scene open default

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -104,6 +104,15 @@ test('create_scene description lists supported layout property ids', () => {
   }
 })
 
+test('create_scene input schema exposes the open default', () => {
+  const openProperty = createSceneTool.inputSchema.properties?.open as
+    | Record<string, unknown>
+    | undefined
+
+  assert.equal(openProperty?.type, 'boolean')
+  assert.equal(openProperty?.default, true)
+})
+
 test('create_scene reports invalid arguments as MCP errors', async () => {
   const result = await handleCreateScene({
     output: 42,

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -105,6 +105,7 @@ export const createSceneTool: Tool = {
       open: {
         type: 'boolean',
         description: 'Open the newly-created scene in the desktop app. Defaults to true.',
+        default: true,
       },
     },
     required: ['output', 'scene'],


### PR DESCRIPTION
## Summary\n- expose the create_scene MCP schema default for the open option\n- add a CLI unit test covering the schema metadata\n\n## Tests\n- pnpm test