### PR TITLE
Document render_scene fps schema bounds

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -2,7 +2,17 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { handleRenderScene } from './tools/renderScene.js'
+import { handleRenderScene, renderSceneTool } from './tools/renderScene.js'
+
+test('render_scene input schema exposes fps bounds', () => {
+  const fpsProperty = renderSceneTool.inputSchema.properties?.fps as
+    | Record<string, unknown>
+    | undefined
+
+  assert.equal(fpsProperty?.type, 'number')
+  assert.equal(fpsProperty?.minimum, 1)
+  assert.equal(fpsProperty?.maximum, 120)
+})
 
 test('render_scene reports invalid arguments as MCP errors', async () => {
   const result = await handleRenderScene({

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -58,7 +58,12 @@ export const renderSceneTool: Tool = {
         enum: ['comp', '720p', '2k', '4k'],
         description: 'Resolution preset. `comp` matches scene canvas size. Default: comp.',
       },
-      fps: { type: 'number', description: 'Frame rate (1–120). Default: 30.' },
+      fps: {
+        type: 'number',
+        minimum: 1,
+        maximum: 120,
+        description: 'Frame rate (1–120). Default: 30.',
+      },
       scene: {
         type: 'string',
         description:


### PR DESCRIPTION
## Summary\n- Expose explicit minimum/maximum FPS bounds in the render_scene MCP input schema\n- Add a focused CLI test covering the schema metadata\n\n## Tests\n- pnpm --dir cli test