### PR TITLE
Allow CLI patches to clear active camera

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import * as Y from 'yjs'
 import {
+  applyScenePatch,
   buildSceneBytes,
   readSceneSummary,
   type SceneJson,
@@ -403,6 +404,15 @@ test('buildSceneBytes preserves an explicitly cleared active camera', () => {
   const summary = readSceneSummary(buildSceneBytes(scene))
 
   assert.equal(summary.activeCameraId, null)
+})
+
+test('applyScenePatch can clear the active camera', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const patched = applyScenePatch(bytes, [
+    { op: 'setActiveCameraId', cameraId: null },
+  ])
+
+  assert.equal(readSceneSummary(patched).activeCameraId, null)
 })
 
 test('buildSceneBytes keys tracks by their declared ids', () => {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -444,7 +444,7 @@ export interface ScenePatch {
 export type PatchOperation =
   | { op: 'setMeta'; patch: Record<string, unknown> }
   | { op: 'setRoot'; nodeId: string }
-  | { op: 'setActiveCameraId'; cameraId: string }
+  | { op: 'setActiveCameraId'; cameraId: string | null }
   | { op: 'createNode'; node: NodeJson }
   | { op: 'deleteNode'; nodeId: string }
   | { op: 'setNode'; nodeId: string; patch: Record<string, unknown> }


### PR DESCRIPTION
## Summary
- widen the CLI scene patch type so setActiveCameraId can clear the camera with null
- add regression coverage for clearing activeCameraId through applyScenePatch

## Tests
- pnpm test