### PR TITLE
Add text progress to CLI keyframe properties

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -21,6 +21,7 @@ test('capability tools list the full supported keyframe property set', async () 
     'appearance.cornerRadii.br',
     'appearance.cornerRadii.bl',
     'appearance.fill',
+    'text.progress',
   ]
 
   const capabilities = parseToolJson(await handleGetCapabilities())

--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -22,6 +22,7 @@ test('create_scene description lists supported appearance property ids', () => {
     'appearance.cornerRadii.br',
     'appearance.cornerRadii.bl',
     'appearance.fill',
+    'text.progress',
   ]) {
     const escapedPropertyId = propertyId.replaceAll('.', '\\.')
     assert.match(description, new RegExp(`${escapedPropertyId}(?:,|\\.)`))

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -86,7 +86,7 @@ export const createSceneTool: Tool = {
     "camera.aperture, camera.iso, camera.blurLevel, camera.blurQuality, " +
     "appearance.opacity, appearance.cornerRadius, appearance.cornerRadii, " +
     "appearance.cornerRadii.tl, appearance.cornerRadii.tr, appearance.cornerRadii.br, " +
-    "appearance.cornerRadii.bl, appearance.fill, layout.gap, layout.padding.top, " +
+    "appearance.cornerRadii.bl, appearance.fill, text.progress, layout.gap, layout.padding.top, " +
     "layout.padding.right, layout.padding.bottom, layout.padding.left, size.width, size.height, " +
     "layout.direction, variant.\n\n" +
     "Include exactly one 'camera' kind node (parent: null) plus a 'frame' kind root (parent: null) for the " +

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -279,6 +279,7 @@ export const PROPERTY_IDS = [
   'appearance.cornerRadii.br',
   'appearance.cornerRadii.bl',
   'appearance.fill',
+  'text.progress',
   'layout.gap',
   'layout.padding.top',
   'layout.padding.right',


### PR DESCRIPTION
## Summary
- add text.progress to the CLI keyframeable property registry
- list text.progress in the create_scene MCP description
- cover the property in focused MCP capability/description tests

## Tests
- pnpm --dir cli test