### PR TITLE
test(cli): handle validate_scene MCP errors

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -22,12 +22,41 @@ export const validateSceneTool: Tool = {
 }
 
 export async function handleValidateScene(args: Record<string, unknown>) {
-  const parsed = ValidateInput.parse(args)
+  const parsed = ValidateInput.safeParse(args)
+  if (!parsed.success) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `validate_scene: invalid arguments — ${parsed.error.message}`,
+        },
+      ],
+    }
+  }
+
+  let bytes: Buffer
+  try {
+    bytes = fs.readFileSync(parsed.data.scene)
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `validate_scene: failed to read ${parsed.data.scene}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+    }
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(validateScene(new Uint8Array(fs.readFileSync(parsed.scene))), null, 2),
+        text: JSON.stringify(validateScene(new Uint8Array(bytes)), null, 2),
       },
     ],
   }

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { handleValidateScene } from './tools/validateScene.js'
+
+test('validate_scene reports invalid arguments as MCP errors', async () => {
+  const result = await handleValidateScene({ scene: 42 })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.match(text, /^validate_scene: invalid arguments/)
+})
+
+test('validate_scene reports missing files as MCP errors', async () => {
+  const result = await handleValidateScene({ scene: '/tmp/hypermotion-missing-scene.hype' })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.match(text, /^validate_scene: failed to read /)
+})


### PR DESCRIPTION
## Summary\n- Return MCP-shaped errors from validate_scene for invalid arguments\n- Return MCP-shaped errors when validate_scene cannot read the scene file\n- Add focused MCP tests for both cases\n\n## Tests\n- pnpm test (in cli/)