### PR TITLE
fix(cli): default workspaceOnly in scene patches

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -415,6 +415,25 @@ test('applyScenePatch can clear the active camera', () => {
   assert.equal(readSceneSummary(patched).activeCameraId, null)
 })
 
+test('applyScenePatch fills workspaceOnly default for created nodes', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const patched = applyScenePatch(bytes, [
+    {
+      op: 'createNode',
+      node: {
+        id: 'badge',
+        kind: 'rect',
+        parent: 'root',
+        size: { width: 24, height: 24 },
+      },
+    },
+  ])
+  const data = inspectScene(patched)
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.equal(nodes.badge.workspaceOnly, false)
+})
+
 test('buildSceneBytes keys tracks by their declared ids', () => {
   const scene = sampleScene()
   const sceneTracks = scene.tracks ?? {}

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -967,8 +967,9 @@ function nodeToYMap(node: NodeJson): Y.Map<unknown> {
   y.set('position', node.position ?? 'flow')
   y.set('isMask', node.isMask ?? false)
   y.set('componentSourceId', node.componentSourceId ?? null)
+  y.set('workspaceOnly', node.workspaceOnly ?? false)
   for (const [k, v] of Object.entries(node)) {
-    if (['id', 'kind', 'name', 'parent', 'children', 'transform', 'appearance', 'visible', 'locked', 'position', 'isMask', 'componentSourceId'].includes(k)) continue
+    if (['id', 'kind', 'name', 'parent', 'children', 'transform', 'appearance', 'visible', 'locked', 'position', 'isMask', 'componentSourceId', 'workspaceOnly'].includes(k)) continue
     y.set(k, v)
   }
   return y


### PR DESCRIPTION
## Summary\n- default workspaceOnly to false for nodes created via applyScenePatch\n- add regression coverage for patch-created node defaults\n\n## Tests\n- pnpm test (in cli/)