### PR TITLE
Tighten error boundary catch info type

### DIFF
--- a/src/ui/ErrorBoundary.tsx
+++ b/src/ui/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { Component, type ReactNode } from 'react'
+import { Component, type ErrorInfo, type ReactNode } from 'react'
 
 /**
  * Top-level error boundary. Without this, any thrown error during
@@ -21,10 +21,9 @@ export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
     return { error }
   }
 
-  componentDidCatch(error: Error, info: unknown): void {
+  componentDidCatch(error: Error, info: ErrorInfo): void {
     // Surface in the console too — easier to copy out of devtools
     // than the on-screen pre.
-    // eslint-disable-next-line no-console
     console.error('App error boundary caught:', error, info)
   }
 


### PR DESCRIPTION
## Summary
- type React error boundary catch info as ErrorInfo instead of unknown
- remove a stale eslint-disable directive from the same handler

## Verification
- pnpm exec eslint src/ui/ErrorBoundary.tsx
- pnpm exec tsc --ignoreConfig --noEmit --strict --jsx react-jsx --target es2023 --lib ES2023,DOM,DOM.Iterable --module esnext --moduleResolution bundler --verbatimModuleSyntax --skipLibCheck src/ui/ErrorBoundary.tsx

Note: full repo checks were attempted after installing dependencies from the existing lockfile, but current main has unrelated pre-existing typecheck/lint failures outside this touched file.