### PR TITLE
Validate track property ids

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -7,6 +7,7 @@ import {
   applyScenePatch,
   buildSceneBytes,
   readSceneSummary,
+  validateScene,
   type SceneJson,
 } from './build.js'
 
@@ -481,6 +482,25 @@ test('buildSceneBytes defaults omitted track easing to ease-in-out', () => {
   const tracks = data.tracks as Record<string, Record<string, unknown>>
 
   assert.equal(tracks['fade-title'].defaultEasing, 'ease-in-out')
+})
+
+test('validateScene rejects unsupported track property ids', () => {
+  const scene = sampleScene()
+  scene.tracks = {
+    invalid: {
+      id: 'invalid',
+      nodeId: 'title',
+      propertyId: 'appearance.missing',
+      keyframes: [],
+    },
+  } as unknown as SceneJson['tracks']
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'track invalid has unsupported propertyId: appearance.missing',
+  ])
 })
 
 test('buildSceneBytes preserves variant selection keyframe values', () => {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -844,9 +844,16 @@ export function validateScene(bytes: Uint8Array): {
     if (!Array.isArray(track.keyframes)) {
       errors.push(`track ${id} keyframes must be an array`)
     }
+    if (typeof track.propertyId !== 'string' || !isPropertyId(track.propertyId)) {
+      errors.push(`track ${id} has unsupported propertyId: ${String(track.propertyId)}`)
+    }
   }
 
   return { ok: errors.length === 0, errors, warnings }
+}
+
+function isPropertyId(value: string): value is PropertyIdJson {
+  return (PROPERTY_IDS as readonly string[]).includes(value)
 }
 
 export function applyScenePatch(bytes: Uint8Array, patch: ScenePatch | PatchOperation[]): Uint8Array {


### PR DESCRIPTION
## Summary
- reject unsupported track property ids during CLI scene validation
- cover the validation path with a focused scene unit test

## Tests
- pnpm --dir cli test