### PR TITLE
Validate scene root node kind

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -503,6 +503,16 @@ test('validateScene rejects unsupported track property ids', () => {
   ])
 })
 
+test('validateScene rejects non-frame root nodes', () => {
+  const scene = sampleScene()
+  scene.root = 'title'
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, ['scene.root is not a frame node: title'])
+})
+
 test('buildSceneBytes preserves variant selection keyframe values', () => {
   const scene = sampleScene()
   scene.tracks = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -815,6 +815,9 @@ export function validateScene(bytes: Uint8Array): {
 
   if (!root) errors.push('scene.root is missing')
   else if (!nodes[root]) errors.push(`scene.root points to missing node: ${root}`)
+  else if (asRecord(nodes[root]).kind !== 'frame') {
+    errors.push(`scene.root is not a frame node: ${root}`)
+  }
 
   if (!activeCameraId) warnings.push('scene.activeCameraId is missing')
   else if (!nodes[activeCameraId]) errors.push(`scene.activeCameraId points to missing node: ${activeCameraId}`)


### PR DESCRIPTION
## Summary\n- reject .hype scenes whose scene.root points at a non-frame node\n- add CLI scene-builder coverage for the validation error\n\n## Tests\n- pnpm test