### PR TITLE
chore(cli): share CLI version constant

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -27,8 +27,7 @@ import { inspectCommand } from './commands/inspect.js'
 import { patchCommand } from './commands/patch.js'
 import { openCommand } from './commands/open.js'
 import { validateCommand } from './commands/validate.js'
-
-const PKG_VERSION = '0.1.2'
+import { CLI_VERSION } from './version.js'
 
 const program = new Command()
 
@@ -39,7 +38,7 @@ program
       'and let AI coding agents (Claude Code, Codex) drive motion sequences ' +
       'programmatically.',
   )
-  .version(PKG_VERSION, '-v, --version', 'output the current version')
+  .version(CLI_VERSION, '-v, --version', 'output the current version')
 
 program.addCommand(renderCommand())
 program.addCommand(infoCommand())

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -3,8 +3,7 @@
 import { Command } from 'commander'
 import os from 'node:os'
 import { locateDesktopApp } from '../electron/locator.js'
-
-const CLI_VERSION = '0.1.2'
+import { CLI_VERSION } from '../version.js'
 
 export async function getDoctorReport() {
   const appPath = await locateDesktopApp()

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -53,9 +53,9 @@ import {
   listLayersTool,
   listTracksTool,
 } from './tools/queryScene.js'
+import { CLI_VERSION } from '../version.js'
 
 const SERVER_NAME = 'hypermotion'
-const SERVER_VERSION = '0.1.2'
 
 const TOOLS: Tool[] = [
   doctorTool,
@@ -76,7 +76,7 @@ const TOOLS: Tool[] = [
 
 export async function startMcpServer(): Promise<void> {
   const server = new Server(
-    { name: SERVER_NAME, version: SERVER_VERSION },
+    { name: SERVER_NAME, version: CLI_VERSION },
     { capabilities: { tools: {} } },
   )
 
@@ -137,5 +137,5 @@ export async function startMcpServer(): Promise<void> {
   await server.connect(transport)
 
   // stderr is fine — MCP uses stdout for protocol traffic, stderr for logs.
-  console.error(`[hypermotion-mcp] connected (${SERVER_NAME} ${SERVER_VERSION}, ${TOOLS.length} tools)`)
+  console.error(`[hypermotion-mcp] connected (${SERVER_NAME} ${CLI_VERSION}, ${TOOLS.length} tools)`)
 }

--- a/cli/src/version.ts
+++ b/cli/src/version.ts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const CLI_VERSION = '0.1.2'


### PR DESCRIPTION
## Summary
- Add a shared CLI version constant
- Use it for CLI --version, doctor output, and MCP server metadata/logging

## Tests
- pnpm --dir cli test