### PR TITLE
fix(cli): default patched text nodes

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -435,6 +435,33 @@ test('applyScenePatch fills workspaceOnly default for created nodes', () => {
   assert.equal(nodes.badge.workspaceOnly, false)
 })
 
+test('applyScenePatch fills text defaults for created nodes', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const patched = applyScenePatch(bytes, [
+    {
+      op: 'createNode',
+      node: {
+        id: 'caption',
+        kind: 'text',
+        parent: 'root',
+        text: 'Patched text',
+        size: { width: 320 },
+      },
+    },
+  ])
+  const data = inspectScene(patched)
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(nodes.caption.size, { width: 320, height: 'hug' })
+  assert.equal(nodes.caption.fontFamily, 'Inter')
+  assert.equal(nodes.caption.fontSize, 16)
+  assert.equal(nodes.caption.fontWeight, 400)
+  assert.equal(nodes.caption.lineHeight, 1.4)
+  assert.equal(nodes.caption.letterSpacing, 0)
+  assert.equal(nodes.caption.textAlign, 'start')
+  assert.equal(nodes.caption.color, '#0a0a0c')
+})
+
 test('buildSceneBytes keys tracks by their declared ids', () => {
   const scene = sampleScene()
   const sceneTracks = scene.tracks ?? {}

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -965,6 +965,21 @@ function applyPatchOperation(scene: Y.Map<unknown>, op: PatchOperation): void {
 
 function nodeToYMap(node: NodeJson): Y.Map<unknown> {
   const y = new Y.Map<unknown>()
+  const handledKeys = new Set([
+    'id',
+    'kind',
+    'name',
+    'parent',
+    'children',
+    'transform',
+    'appearance',
+    'visible',
+    'locked',
+    'position',
+    'isMask',
+    'componentSourceId',
+    'workspaceOnly',
+  ])
   y.set('id', node.id)
   y.set('kind', node.kind)
   y.set('name', node.name ?? defaultName(node.kind))
@@ -978,8 +993,33 @@ function nodeToYMap(node: NodeJson): Y.Map<unknown> {
   y.set('isMask', node.isMask ?? false)
   y.set('componentSourceId', node.componentSourceId ?? null)
   y.set('workspaceOnly', node.workspaceOnly ?? false)
+  if (node.kind === 'text') {
+    for (const key of [
+      'size',
+      'text',
+      'fontFamily',
+      'fontSize',
+      'fontWeight',
+      'lineHeight',
+      'letterSpacing',
+      'textAlign',
+      'color',
+    ]) {
+      handledKeys.add(key)
+    }
+    const defaultTextSize: SceneSize = { width: 'hug', height: 'hug' }
+    y.set('size', mergeWithDefaults(defaultTextSize, node.size))
+    y.set('text', node.text ?? 'Text')
+    y.set('fontFamily', node.fontFamily ?? 'Inter')
+    y.set('fontSize', node.fontSize ?? 16)
+    y.set('fontWeight', node.fontWeight ?? 400)
+    y.set('lineHeight', node.lineHeight ?? 1.4)
+    y.set('letterSpacing', node.letterSpacing ?? 0)
+    y.set('textAlign', node.textAlign ?? 'start')
+    y.set('color', node.color ?? '#0a0a0c')
+  }
   for (const [k, v] of Object.entries(node)) {
-    if (['id', 'kind', 'name', 'parent', 'children', 'transform', 'appearance', 'visible', 'locked', 'position', 'isMask', 'componentSourceId', 'workspaceOnly'].includes(k)) continue
+    if (handledKeys.has(k)) continue
     y.set(k, v)
   }
   return y


### PR DESCRIPTION
## Summary
- apply text-node defaults when CLI patch createNode authors a text layer
- add regression coverage for partial text size defaulting

## Tests
- pnpm test (cli)