### PR TITLE
Stabilize info_scene missing file test

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -1,20 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { handleInfoScene } from './tools/infoScene.js'
 
 test('info_scene reports missing files as MCP errors', async () => {
-  const missingScene = path.join(
-    '/tmp',
-    `hypermotion-missing-${Date.now()}.hype`,
-  )
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-missing-'))
+  const missingScene = path.join(dir, 'scene.hype')
 
-  const result = await handleInfoScene({ scene: missingScene })
+  try {
+    const result = await handleInfoScene({ scene: missingScene })
 
-  assert.equal(result.isError, true)
-  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-  assert.match(text, /^info_scene: failed to read /)
-  assert.match(text, /hypermotion-missing-/)
+    assert.equal(result.isError, true)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    assert.match(text, /^info_scene: failed to read /)
+    assert.match(text, /hypermotion-missing-/)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
## Summary\n- use a unique temporary directory for the missing-file MCP test\n- clean up the temp directory after the assertion\n\n## Tests\n- pnpm test