### PR TITLE
Add validate_scene MCP result type

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { z } from 'zod'
-import type { Tool } from '@modelcontextprotocol/sdk/types.js'
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
 import { validateScene } from '../../scene/build.js'
 
@@ -21,7 +21,9 @@ export const validateSceneTool: Tool = {
   },
 }
 
-export async function handleValidateScene(args: Record<string, unknown>) {
+export async function handleValidateScene(
+  args: Record<string, unknown>,
+): Promise<CallToolResult> {
   const parsed = ValidateInput.safeParse(args)
   if (!parsed.success) {
     return {


### PR DESCRIPTION
## Summary
- Add an explicit MCP CallToolResult return type to the validate_scene handler.
- Keep behavior unchanged while aligning the handler with neighboring MCP tools.

## Tests
- pnpm test (in cli/)