### PR TITLE
Validate scene node id keys

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -629,6 +629,21 @@ test('validateScene rejects non-frame root nodes', () => {
   assert.deepEqual(result.errors, ['scene.root is not a frame node: title'])
 })
 
+test('validateScene rejects node ids that do not match their map key', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const nodes = scene.get('nodes') as Y.Map<Y.Map<unknown>>
+  nodes.get('title')?.set('id', 'renamed-title')
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'node map key title does not match node id: renamed-title',
+  ])
+})
+
 test('buildSceneBytes preserves variant selection keyframe values', () => {
   const scene = sampleScene()
   scene.tracks = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -827,6 +827,7 @@ export function validateScene(bytes: Uint8Array): {
 
   for (const [id, raw] of Object.entries(nodes)) {
     const node = asRecord(raw)
+    if (node.id !== id) errors.push(`node map key ${id} does not match node id: ${String(node.id)}`)
     const parent = typeof node.parent === 'string' ? node.parent : null
     if (parent && !nodes[parent]) errors.push(`node ${id} has missing parent: ${parent}`)
     const children = Array.isArray(node.children) ? node.children : []


### PR DESCRIPTION
## Summary
- add a scene validation error when a node map key does not match the node's stored id
- cover the mismatch with a focused CLI scene validator regression test

## Verification
- PASS: pnpm --dir cli test
- BLOCKED/PRE-EXISTING: pnpm typecheck and pnpm lint trigger the root install approval flow for electron@33.4.11 in this environment; running the underlying binaries directly shows existing app-wide type/lint failures unrelated to this CLI validator change.