### PR TITLE
test(cli): cover render_scene schema presets

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -14,6 +14,18 @@ test('render_scene input schema exposes fps bounds', () => {
   assert.equal(fpsProperty?.maximum, 120)
 })
 
+test('render_scene input schema exposes render preset enums', () => {
+  const formatProperty = renderSceneTool.inputSchema.properties?.format as
+    | Record<string, unknown>
+    | undefined
+  const qualityProperty = renderSceneTool.inputSchema.properties?.quality as
+    | Record<string, unknown>
+    | undefined
+
+  assert.deepEqual(formatProperty?.enum, ['mp4', 'webm', 'gif'])
+  assert.deepEqual(qualityProperty?.enum, ['comp', '720p', '2k', '4k'])
+})
+
 test('render_scene reports invalid arguments as MCP errors', async () => {
   const result = await handleRenderScene({
     output: 'demo.mp4',


### PR DESCRIPTION
## Summary
- Add MCP schema coverage for render_scene format and quality preset enums.

## Verification
- pnpm test (in cli/)