### PR TITLE
Validate inverse scene parent links

### DIFF
--- a/cli/src/commands/validate.test.ts
+++ b/cli/src/commands/validate.test.ts
@@ -134,3 +134,51 @@ test('validate command rejects a non-camera active camera id', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('validate command rejects a parent link missing from children', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const previousExitCode = process.exitCode
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Validate Parent Link',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+          title: {
+            id: 'title',
+            kind: 'text',
+            parent: 'root',
+            text: 'Detached child',
+            fontFamily: 'Inter',
+            fontSize: 24,
+          },
+        },
+      }),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await validateCommand().exitOverride().parseAsync([scenePath], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^Scene is invalid$/m)
+    assert.match(stdout, /^error: node title parent root does not list it as a child$/m)
+    assert.equal(process.exitCode, 1)
+  } finally {
+    process.exitCode = previousExitCode
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -830,6 +830,12 @@ export function validateScene(bytes: Uint8Array): {
     if (node.id !== id) errors.push(`node map key ${id} does not match node id: ${String(node.id)}`)
     const parent = typeof node.parent === 'string' ? node.parent : null
     if (parent && !nodes[parent]) errors.push(`node ${id} has missing parent: ${parent}`)
+    else if (parent) {
+      const parentChildren = asRecord(nodes[parent]).children
+      if (!Array.isArray(parentChildren) || !parentChildren.includes(id)) {
+        errors.push(`node ${id} parent ${parent} does not list it as a child`)
+      }
+    }
     const children = Array.isArray(node.children) ? node.children : []
     for (const child of children) {
       if (typeof child !== 'string' || !nodes[child]) errors.push(`node ${id} has missing child: ${String(child)}`)


### PR DESCRIPTION
## Summary
- report a validation error when a node's parent does not list it in children
- add a CLI regression test for the inconsistent parent/children link

## Tests
- pnpm test