### PR TITLE
Tighten invalid property test typing

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -606,10 +606,11 @@ test('validateScene rejects unsupported track property ids', () => {
     invalid: {
       id: 'invalid',
       nodeId: 'title',
+      // @ts-expect-error Intentionally invalid to exercise runtime validation.
       propertyId: 'appearance.missing',
       keyframes: [],
     },
-  } as unknown as SceneJson['tracks']
+  }
 
   const result = validateScene(buildSceneBytes(scene))
 


### PR DESCRIPTION
## Summary
- replace a broad unknown cast in the invalid property validation test with a targeted @ts-expect-error
- keep the runtime validation coverage for unsupported scene track property IDs

## Tests
- pnpm test (from cli/)