### PR TITLE
test(cli): cover render scene path schema

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -26,6 +26,15 @@ test('render_scene input schema exposes render preset enums', () => {
   assert.deepEqual(qualityProperty?.enum, ['comp', '720p', '2k', '4k'])
 })
 
+test('render_scene input schema exposes the optional scene path', () => {
+  const sceneProperty = renderSceneTool.inputSchema.properties?.scene as
+    | Record<string, unknown>
+    | undefined
+
+  assert.equal(sceneProperty?.type, 'string')
+  assert.match(String(sceneProperty?.description), /\.hype scene file/)
+})
+
 test('render_scene reports invalid arguments as MCP errors', async () => {
   const result = await handleRenderScene({
     output: 'demo.mp4',


### PR DESCRIPTION
## Summary
- add a focused MCP schema test for the optional render_scene scene path

## Verification
- pnpm --dir cli test