### PR TITLE
Validate CLI track id consistency

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -645,6 +645,21 @@ test('validateScene rejects node ids that do not match their map key', () => {
   ])
 })
 
+test('validateScene rejects track ids that do not match their map key', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const tracks = scene.get('tracks') as Y.Map<Y.Map<unknown>>
+  tracks.get('fade-title')?.set('id', 'renamed-track')
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'track map key fade-title does not match track id: renamed-track',
+  ])
+})
+
 test('buildSceneBytes preserves variant selection keyframe values', () => {
   const scene = sampleScene()
   scene.tracks = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -847,6 +847,7 @@ export function validateScene(bytes: Uint8Array): {
 
   for (const [id, raw] of Object.entries(tracks)) {
     const track = asRecord(raw)
+    if (track.id !== id) errors.push(`track map key ${id} does not match track id: ${String(track.id)}`)
     const nodeId = track.nodeId
     if (typeof nodeId !== 'string' || !nodes[nodeId]) {
       errors.push(`track ${id} points to missing node: ${String(nodeId)}`)


### PR DESCRIPTION
## Summary
- validate saved track map keys against each track's declared id
- add focused coverage for mismatched persisted track ids

## Tests
- npm --prefix cli test