### PR TITLE
Normalize empty scene ids in CLI summaries

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -505,6 +505,15 @@ test('applyScenePatch can clear the active camera', () => {
   assert.equal(readSceneSummary(patched).activeCameraId, null)
 })
 
+test('readSceneSummary reports deleted root and active camera ids as null', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const withoutRoot = applyScenePatch(bytes, [{ op: 'deleteNode', nodeId: 'root' }])
+  const withoutCamera = applyScenePatch(bytes, [{ op: 'deleteNode', nodeId: 'camera' }])
+
+  assert.equal(readSceneSummary(withoutRoot).root, null)
+  assert.equal(readSceneSummary(withoutCamera).activeCameraId, null)
+})
+
 test('applyScenePatch fills workspaceOnly default for created nodes', () => {
   const bytes = buildSceneBytes(sampleScene())
   const patched = applyScenePatch(bytes, [

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -1139,13 +1139,17 @@ export function readSceneSummary(bytes: Uint8Array): SceneSummary {
 
   return {
     meta,
-    root: (scene.get('root') as string | undefined) ?? null,
-    activeCameraId: (scene.get('activeCameraId') as string | undefined) ?? null,
+    root: nonEmptySceneId(scene.get('root')),
+    activeCameraId: nonEmptySceneId(scene.get('activeCameraId')),
     layerCount: nodes?.size ?? 0,
     trackCount: tracks?.size ?? 0,
     sectionCount: sections?.size ?? 0,
     keyframeCount,
   }
+}
+
+function nonEmptySceneId(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
 }
 
 /**


### PR DESCRIPTION
## Summary
- normalize empty-string scene root and active camera ids to null in CLI summaries
- add regression coverage for delete-node cleanup paths

## Tests
- pnpm --dir cli test