### PR TITLE
Default patched shape node sizes

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -560,6 +560,24 @@ test('applyScenePatch fills text defaults for created nodes', () => {
   assert.equal(nodes.caption.color, '#0a0a0c')
 })
 
+test('applyScenePatch fills size defaults for created shape nodes', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const patched = applyScenePatch(bytes, [
+    {
+      op: 'createNode',
+      node: {
+        id: 'badge',
+        kind: 'rect',
+        parent: 'root',
+      },
+    },
+  ])
+  const data = inspectScene(patched)
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(nodes.badge.size, { width: 100, height: 100 })
+})
+
 test('buildSceneBytes keys tracks by their declared ids', () => {
   const scene = sampleScene()
   const sceneTracks = scene.tracks ?? {}

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -1026,6 +1026,10 @@ function nodeToYMap(node: NodeJson): Y.Map<unknown> {
     y.set('textAlign', node.textAlign ?? 'start')
     y.set('color', node.color ?? '#0a0a0c')
   }
+  if (node.kind === 'rect' || node.kind === 'ellipse' || node.kind === 'image') {
+    handledKeys.add('size')
+    y.set('size', mergeWithDefaults(DEFAULT_SIZE, node.size))
+  }
   for (const [k, v] of Object.entries(node)) {
     if (handledKeys.has(k)) continue
     y.set(k, v)


### PR DESCRIPTION
## Summary
- default size for rect, ellipse, and image nodes created through scene patches
- add regression coverage for minimal patched shape nodes

## Tests
- pnpm --dir cli test