### PR TITLE
Tighten CLI scene summary metadata types

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -88,6 +88,7 @@ test('buildSceneBytes creates a readable .hype summary', () => {
 
   assert.equal(summary.meta.name, 'Smoke test')
   assert.deepEqual(summary.meta.canvas, { width: 1280, height: 720 })
+  assert.equal(summary.meta.canvas?.width, 1280)
   assert.equal(summary.root, 'root')
   assert.equal(summary.activeCameraId, 'camera')
   assert.equal(summary.layerCount, 3)

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -462,16 +462,6 @@ type FlexDirection = 'row' | 'column'
 type FlexJustify = 'start' | 'center' | 'end' | 'space-between' | 'space-around'
 type FlexAlign = 'start' | 'center' | 'end' | 'stretch'
 
-export interface SceneSummary {
-  meta: Record<string, unknown>
-  root: string | null
-  activeCameraId: string | null
-  layerCount: number
-  trackCount: number
-  sectionCount: number
-  keyframeCount: number
-}
-
 type SceneTransform = NonNullable<NodeJson['transform']> & {
   anchorX: number
   anchorY: number
@@ -484,12 +474,27 @@ type SceneSize = Record<string, unknown> & {
   width: number | 'hug' | 'fill'
   height: number | 'hug' | 'fill'
 }
-interface SceneCanvas {
+export interface SceneCanvas {
   width: number
   height: number
 }
-type SceneMeta = Required<Omit<NonNullable<SceneJson['meta']>, 'canvas'>> & {
+export type SceneMeta = Required<Omit<NonNullable<SceneJson['meta']>, 'canvas'>> & {
   canvas: SceneCanvas
+}
+
+export type SceneSummaryMeta = Record<string, unknown> &
+  Partial<Omit<SceneMeta, 'canvas'>> & {
+    canvas?: Partial<SceneCanvas> & Record<string, unknown>
+  }
+
+export interface SceneSummary {
+  meta: SceneSummaryMeta
+  root: string | null
+  activeCameraId: string | null
+  layerCount: number
+  trackCount: number
+  sectionCount: number
+  keyframeCount: number
 }
 
 interface SceneAppearance {
@@ -1122,7 +1127,7 @@ export function readSceneSummary(bytes: Uint8Array): SceneSummary {
   const scene = doc.getMap<unknown>('scene')
 
   const metaMap = scene.get('meta') as Y.Map<unknown> | undefined
-  const meta: Record<string, unknown> = {}
+  const meta: SceneSummaryMeta = {}
   if (metaMap) {
     for (const [k, v] of metaMap.entries()) meta[k] = v
   }


### PR DESCRIPTION
## Summary
- add exported scene summary metadata types for CLI consumers
- keep summary metadata partial to support older or hand-built .hype files
- cover typed canvas access in the existing scene builder test

## Tests
- pnpm test