### PR TITLE
Advertise render fps schema as integer

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -9,7 +9,7 @@ test('render_scene input schema exposes fps bounds', () => {
     | Record<string, unknown>
     | undefined
 
-  assert.equal(fpsProperty?.type, 'number')
+  assert.equal(fpsProperty?.type, 'integer')
   assert.equal(fpsProperty?.minimum, 1)
   assert.equal(fpsProperty?.maximum, 120)
 })

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -59,7 +59,7 @@ export const renderSceneTool: Tool = {
         description: 'Resolution preset. `comp` matches scene canvas size. Default: comp.',
       },
       fps: {
-        type: 'number',
+        type: 'integer',
         minimum: 1,
         maximum: 120,
         description: 'Frame rate (1–120). Default: 30.',


### PR DESCRIPTION
## Summary
- update the render_scene MCP JSON schema to advertise fps as an integer
- align the schema unit test with the existing integer zod validation

## Tests
- pnpm --dir cli install --frozen-lockfile --ignore-scripts
- pnpm --dir cli test