### PR TITLE
Validate duplicate scene child references

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -675,6 +675,18 @@ test('validateScene rejects cameras nested under scene nodes', () => {
   ])
 })
 
+test('validateScene rejects duplicate child references', () => {
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  if (!root) throw new Error('missing sample root')
+  root.children = ['title', 'title']
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, ['node root lists duplicate child: title'])
+})
+
 test('validateScene rejects node ids that do not match their map key', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -845,11 +845,14 @@ export function validateScene(bytes: Uint8Array): {
       }
     }
     const children = Array.isArray(node.children) ? node.children : []
+    const seenChildren = new Set<string>()
     for (const child of children) {
       if (typeof child !== 'string' || !nodes[child]) errors.push(`node ${id} has missing child: ${String(child)}`)
+      else if (seenChildren.has(child)) errors.push(`node ${id} lists duplicate child: ${child}`)
       else if (asRecord(nodes[child]).parent !== id) {
         errors.push(`node ${id} lists child ${child}, but child's parent is ${String(asRecord(nodes[child]).parent)}`)
       }
+      if (typeof child === 'string') seenChildren.add(child)
     }
   }
 


### PR DESCRIPTION
## Summary
- reject duplicate child IDs during CLI scene validation
- add a focused validator regression test

## Tests
- pnpm test (in cli/)