### PR TITLE
Validate scene-level camera placement

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -658,6 +658,22 @@ test('validateScene rejects non-frame root nodes', () => {
   assert.deepEqual(result.errors, ['scene.root is not a frame node: title'])
 })
 
+test('validateScene rejects cameras nested under scene nodes', () => {
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  const camera = scene.nodes?.camera
+  if (!root || !camera) throw new Error('missing sample nodes')
+  root.children = ['title', 'camera']
+  camera.parent = 'root'
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'camera node camera must be scene-level with parent: null',
+  ])
+})
+
 test('validateScene rejects node ids that do not match their map key', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -834,6 +834,9 @@ export function validateScene(bytes: Uint8Array): {
     const node = asRecord(raw)
     if (node.id !== id) errors.push(`node map key ${id} does not match node id: ${String(node.id)}`)
     const parent = typeof node.parent === 'string' ? node.parent : null
+    if (node.kind === 'camera' && parent) {
+      errors.push(`camera node ${id} must be scene-level with parent: null`)
+    }
     if (parent && !nodes[parent]) errors.push(`node ${id} has missing parent: ${parent}`)
     else if (parent) {
       const parentChildren = asRecord(nodes[parent]).children


### PR DESCRIPTION
## Summary
- reject camera nodes nested under scene nodes during CLI scene validation
- add a focused validation regression test

## Verification
- pnpm --dir cli test
- ./node_modules/.bin/eslint cli/src/scene/build.ts cli/src/scene/build.test.ts

Note: root typecheck currently fails on existing app-wide TypeScript errors unrelated to this CLI validation change.