### PR TITLE
test: guard keyframe capability ids

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -14,6 +14,10 @@ test('capability tools list the full supported keyframe property set', async () 
 
   assert.deepEqual(capabilities.keyframeableProperties, PROPERTY_IDS)
   assert.deepEqual(listed.keyframeableProperties, PROPERTY_IDS)
+  assert.equal(
+    new Set(capabilities.keyframeableProperties).size,
+    PROPERTY_IDS.length,
+  )
 })
 
 function parseToolJson(result: {


### PR DESCRIPTION
## Summary\n- add a CLI MCP capability test assertion that keyframe property ids are unique\n\n## Verification\n- npm install --no-package-lock && npm test (from cli/)\n\nNote: root pnpm install was blocked in this environment by pnpm build approval for electron before any repo change.