### PR TITLE
Harden locator stderr test capture

### DIFF
--- a/cli/src/electron/locator.test.ts
+++ b/cli/src/electron/locator.test.ts
@@ -6,6 +6,7 @@ import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { locateDesktopApp } from './locator.js'
+import { captureStderr } from '../testUtils/stdout.js'
 
 test('locator returns an existing HYPERMOTION_APP_PATH override', async () => {
   const previousOverride = process.env.HYPERMOTION_APP_PATH
@@ -29,24 +30,19 @@ test('locator returns an existing HYPERMOTION_APP_PATH override', async () => {
 
 test('locator rejects a missing HYPERMOTION_APP_PATH override', async () => {
   const previousOverride = process.env.HYPERMOTION_APP_PATH
-  const previousConsoleError = console.error
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-missing-'))
   const missingPath = path.join(dir, 'hyper-motion')
-  const messages: unknown[] = []
 
   try {
     process.env.HYPERMOTION_APP_PATH = missingPath
-    console.error = (...args: unknown[]) => {
-      messages.push(...args)
-    }
 
-    assert.equal(await locateDesktopApp(), null)
-    assert.equal(messages.length, 1)
-    const message = String(messages[0])
-    assert.match(message, /HYPERMOTION_APP_PATH is set/)
-    assert.equal(message.includes(missingPath), true)
+    const stderr = await captureStderr(async () => {
+      assert.equal(await locateDesktopApp(), null)
+    })
+
+    assert.match(stderr, /HYPERMOTION_APP_PATH is set/)
+    assert.equal(stderr.includes(missingPath), true)
   } finally {
-    console.error = previousConsoleError
     if (previousOverride === undefined) {
       delete process.env.HYPERMOTION_APP_PATH
     } else {

--- a/cli/src/testUtils/stdout.ts
+++ b/cli/src/testUtils/stdout.ts
@@ -21,3 +21,25 @@ export async function captureStdout(run: () => Promise<void>): Promise<string> {
   }
   return stdout
 }
+
+export async function captureStderr(run: () => Promise<void>): Promise<string> {
+  let stderr = ''
+  const write = process.stderr.write
+  process.stderr.write = ((
+    chunk: Parameters<typeof process.stderr.write>[0],
+    encodingOrCallback?: Parameters<typeof process.stderr.write>[1],
+    callback?: Parameters<typeof process.stderr.write>[2],
+  ) => {
+    stderr += chunk.toString()
+    const done =
+      typeof encodingOrCallback === 'function' ? encodingOrCallback : callback
+    done?.()
+    return true
+  }) as typeof process.stderr.write
+  try {
+    await run()
+  } finally {
+    process.stderr.write = write
+  }
+  return stderr
+}


### PR DESCRIPTION
## Summary\n- add a CLI test helper for capturing stderr\n- update the locator missing-override test to assert emitted stderr without stubbing console.error\n\n## Verification\n- pnpm test (from cli/)\n