### PR TITLE
Validate scene root has no parent

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -659,6 +659,22 @@ test('validateScene rejects non-frame root nodes', () => {
   assert.deepEqual(result.errors, ['scene.root is not a frame node: title'])
 })
 
+test('validateScene rejects root nodes with parents', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const nodes = scene.get('nodes') as Y.Map<Y.Map<unknown>>
+  nodes.get('root')?.set('parent', 'title')
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'scene.root must be scene-level with parent: null: root',
+    'node root parent title does not list it as a child',
+  ])
+})
+
 test('validateScene rejects cameras nested under scene nodes', () => {
   const scene = sampleScene()
   const root = scene.nodes?.root

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -822,6 +822,8 @@ export function validateScene(bytes: Uint8Array): {
   else if (!nodes[root]) errors.push(`scene.root points to missing node: ${root}`)
   else if (asRecord(nodes[root]).kind !== 'frame') {
     errors.push(`scene.root is not a frame node: ${root}`)
+  } else if (typeof asRecord(nodes[root]).parent === 'string') {
+    errors.push(`scene.root must be scene-level with parent: null: ${root}`)
   }
 
   if (!activeCameraId) warnings.push('scene.activeCameraId is missing')


### PR DESCRIPTION
## Summary
- reject saved scenes where the root frame has a parent
- add focused CLI validation coverage for malformed persisted scenes

## Tests
- pnpm test