### PR TITLE
Preserve CLI text animation track config

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -97,6 +97,34 @@ test('buildSceneBytes creates a readable .hype summary', () => {
   assert.equal(summary.keyframeCount, 2)
 })
 
+test('buildSceneBytes preserves text animation track config', () => {
+  const scene = sampleScene()
+  const track = scene.tracks?.['fade-title']
+  if (!track) throw new Error('missing sample track')
+  track.propertyId = 'text.progress'
+  track.textAnimation = {
+    id: 'blur-slide',
+    mode: 'in',
+    applyTo: 'letters',
+    order: 'forward',
+    delay: 0.08,
+    smoothing: 'none',
+    duration: 0.6,
+    startTime: 0,
+    acceleration: 'slow-down',
+    easingPresetId: 'smooth',
+    easingStrength: 50,
+    direction: 'up',
+    travelDistance: 0.5,
+    blurRadius: 20,
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const tracks = data.tracks as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(tracks['fade-title']?.textAnimation, track.textAnimation)
+})
+
 test('buildSceneBytes fills default metadata for minimal scenes', () => {
   const bytes = buildSceneBytes({
     nodes: {
@@ -504,6 +532,45 @@ test('applyScenePatch can clear the active camera', () => {
   ])
 
   assert.equal(readSceneSummary(patched).activeCameraId, null)
+})
+
+test('applyScenePatch preserves text animation config on new tracks', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const textAnimation = {
+    id: 'blur-slide',
+    mode: 'in',
+    applyTo: 'words',
+    order: 'forward',
+    delay: 0.1,
+    smoothing: 'smooth',
+    duration: 0.7,
+    startTime: 0,
+    acceleration: 'slow-down',
+    easingPresetId: 'smooth',
+    easingStrength: 50,
+    direction: 'up',
+    travelDistance: 0.5,
+    blurRadius: 20,
+  }
+  const patched = applyScenePatch(bytes, [
+    {
+      op: 'setTrack',
+      track: {
+        id: 'text-progress',
+        nodeId: 'title',
+        propertyId: 'text.progress',
+        textAnimation,
+        keyframes: [
+          { id: 'k1', time: 0, value: 0 },
+          { id: 'k2', time: 1, value: 1 },
+        ],
+      },
+    },
+  ])
+  const data = inspectScene(patched)
+  const tracks = data.tracks as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(tracks['text-progress']?.textAnimation, textAnimation)
 })
 
 test('readSceneSummary reports deleted root and active camera ids as null', () => {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -222,6 +222,7 @@ export interface TrackJson {
   nodeId: string
   propertyId: PropertyIdJson
   defaultEasing?: EasingJson
+  textAnimation?: JsonObject | null
   keyframes?: KeyframeJson[]
 }
 
@@ -752,6 +753,7 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
     y.set('nodeId', track.nodeId)
     y.set('propertyId', track.propertyId)
     y.set('defaultEasing', track.defaultEasing ?? 'ease-in-out')
+    if (track.textAnimation !== undefined) y.set('textAnimation', track.textAnimation)
     y.set('keyframes', track.keyframes ?? [])
     tracks.set(track.id, y)
   }
@@ -968,6 +970,7 @@ function applyPatchOperation(scene: Y.Map<unknown>, op: PatchOperation): void {
       y.set('nodeId', op.track.nodeId)
       y.set('propertyId', op.track.propertyId)
       y.set('defaultEasing', op.track.defaultEasing ?? 'ease-in-out')
+      if (op.track.textAnimation !== undefined) y.set('textAnimation', op.track.textAnimation)
       y.set('keyframes', op.track.keyframes ?? [])
       tracks.set(op.track.id, y)
       return


### PR DESCRIPTION
## Summary\n- preserve optional textAnimation metadata when CLI-created scenes write tracks\n- preserve textAnimation metadata when patch_scene creates/replaces tracks\n- add focused CLI tests for both paths\n\n## Tests\n- pnpm --dir cli test