### PR TITLE
Tighten create_scene open default parsing

### DIFF
--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -44,7 +44,7 @@ const CreateInput = z.object({
     ),
   open: z
     .boolean()
-    .optional()
+    .default(true)
     .describe('Open the newly-created scene in the desktop app. Defaults to true.'),
 })
 
@@ -220,7 +220,7 @@ export async function handleCreateScene(
   const summary = readSceneSummary(bytes)
   const layers = summary.layerCount
   const tracks = summary.trackCount
-  const shouldOpen = parsed.data.open ?? true
+  const shouldOpen = parsed.data.open
   let opened = false
   let openNote = ''
   if (shouldOpen) {


### PR DESCRIPTION
## Summary
- Default the create_scene MCP open option in the parsed zod schema
- Read the parsed boolean directly instead of reapplying the default in handler code

## Tests
- pnpm test (in cli/)