### PR TITLE
docs(cli): make scope heading version-neutral

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -84,7 +84,7 @@ command = "hypermotion-mcp"
 Spawn `hypermotion-mcp` as a subprocess. The server speaks MCP over
 stdio per the [Model Context Protocol spec](https://modelcontextprotocol.io).
 
-## v0.1.2 scope
+## Current scope
 
 What works today:
 


### PR DESCRIPTION
## Summary\n- Rename the CLI README scope heading from a stale v0.1.2-specific label to a version-neutral heading.\n\n## Tests\n- pnpm run test (cli)