### PR TITLE
Validate section id map consistency

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -813,6 +813,27 @@ test('validateScene rejects track ids that do not match their map key', () => {
   ])
 })
 
+test('validateScene rejects section ids that do not match their map key', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const sections = scene.get('sections') as Y.Map<Record<string, unknown>>
+  sections.set('intro', {
+    id: 'renamed-section',
+    name: 'Intro',
+    color: '#2563eb',
+    start: 0,
+    end: 2.5,
+  })
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'section map key intro does not match section id: renamed-section',
+  ])
+})
+
 test('buildSceneBytes preserves variant selection keyframe values', () => {
   const scene = sampleScene()
   scene.tracks = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -830,6 +830,7 @@ export function validateScene(bytes: Uint8Array): {
   const warnings: string[] = []
   const nodes = asRecord(data.nodes)
   const tracks = asRecord(data.tracks)
+  const sections = asRecord(data.sections)
   const root = typeof data.root === 'string' ? data.root : ''
   const activeCameraId = typeof data.activeCameraId === 'string' ? data.activeCameraId : ''
 
@@ -889,6 +890,11 @@ export function validateScene(bytes: Uint8Array): {
     if (typeof track.propertyId !== 'string' || !isPropertyId(track.propertyId)) {
       errors.push(`track ${id} has unsupported propertyId: ${String(track.propertyId)}`)
     }
+  }
+
+  for (const [id, raw] of Object.entries(sections)) {
+    const section = asRecord(raw)
+    if (section.id !== id) errors.push(`section map key ${id} does not match section id: ${String(section.id)}`)
   }
 
   return { ok: errors.length === 0, errors, warnings }


### PR DESCRIPTION
## Summary
- Validate section map keys against each section's stored id, matching existing node and track consistency checks.
- Add a focused scene validation regression test for mismatched section ids.

## Tests
- CI=true corepack pnpm@9 --dir cli run build && node --test cli/dist/**/*.test.js