### PR TITLE
chore(cli): type doctor report

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -5,7 +5,28 @@ import os from 'node:os'
 import { locateDesktopApp } from '../electron/locator.js'
 import { CLI_VERSION } from '../version.js'
 
-export async function getDoctorReport() {
+export interface DoctorReport {
+  ok: boolean
+  cliVersion: string
+  platform: NodeJS.Platform
+  desktopApp: {
+    found: boolean
+    path: string | null
+  }
+  sceneFormat: {
+    extension: string
+    encoding: string
+  }
+  commands: string[]
+  mcpTools: string[]
+  render: {
+    formats: string[]
+    qualities: string[]
+    fileSceneInput: boolean
+  }
+}
+
+export async function getDoctorReport(): Promise<DoctorReport> {
   const appPath = await locateDesktopApp()
   return {
     ok: Boolean(appPath),


### PR DESCRIPTION
## Summary
- Add an explicit DoctorReport interface for the CLI/MCP doctor payload.
- Annotate getDoctorReport with the shared report return type.

## Tests
- pnpm test (in cli/)