### PR TITLE
chore(cli): prefix render scene missing file errors

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -61,7 +61,7 @@ test('render_scene reports missing scene files as MCP errors', async () => {
 
     assert.equal(result.isError, true)
     const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-    assert.equal(text, `Scene file not found: ${missingScene}`)
+    assert.equal(text, `render_scene: scene file not found: ${missingScene}`)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -102,7 +102,7 @@ export async function handleRenderScene(
       content: [
         {
           type: 'text' as const,
-          text: `Scene file not found: ${scenePath}`,
+          text: `render_scene: scene file not found: ${scenePath}`,
         },
       ],
     }


### PR DESCRIPTION
## Summary
- Prefix render_scene missing scene file errors with the tool name
- Update the focused MCP handler test expectation

## Tests
- pnpm test (in cli/)