### PR TITLE
test(cli): cover open_scene invalid arguments

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -5,7 +5,25 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
-import { handleOpenScene } from './tools/openScene.js'
+import { handleOpenScene, openSceneTool } from './tools/openScene.js'
+
+test('open_scene input schema exposes required scene path', () => {
+  assert.deepEqual(openSceneTool.inputSchema, {
+    type: 'object',
+    properties: {
+      scene: { type: 'string', description: 'Path to a .hype scene file.' },
+    },
+    required: ['scene'],
+  })
+})
+
+test('open_scene reports invalid arguments as MCP errors', async () => {
+  const result = await handleOpenScene({ scene: 42 })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.match(text, /^open_scene: invalid arguments/)
+})
 
 test('open_scene reports missing files as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-missing-'))

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -25,8 +25,20 @@ export const openSceneTool: Tool = {
 export async function handleOpenScene(
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
-  const parsed = OpenInput.parse(args)
-  const scenePath = path.resolve(parsed.scene)
+  const parsed = OpenInput.safeParse(args)
+  if (!parsed.success) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `open_scene: invalid arguments — ${parsed.error.message}`,
+        },
+      ],
+    }
+  }
+
+  const scenePath = path.resolve(parsed.data.scene)
   if (!fs.existsSync(scenePath)) {
     return {
       isError: true,


### PR DESCRIPTION
## Summary\n- Return structured MCP errors for invalid open_scene arguments\n- Cover open_scene input schema and invalid argument handling\n\n## Tests\n- pnpm install --frozen-lockfile --ignore-workspace (in cli/)\n- pnpm test (in cli/)