### PR TITLE
test(cli): cover MCP doctor tool

### DIFF
--- a/cli/src/mcp/doctor.test.ts
+++ b/cli/src/mcp/doctor.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { DoctorReport } from '../commands/doctor.js'
+import { doctorTool, handleDoctor } from './tools/doctor.js'
+
+test('doctor input schema accepts no arguments', () => {
+  assert.deepEqual(doctorTool.inputSchema, {
+    type: 'object',
+    properties: {},
+  })
+})
+
+test('doctor returns the report as MCP JSON content', async () => {
+  const previousAppPath = process.env.HYPERMOTION_APP_PATH
+  process.env.HYPERMOTION_APP_PATH = '/tmp/hypermotion-mcp-doctor-missing-app'
+
+  try {
+    const result = await handleDoctor()
+
+    assert.equal(result.isError, undefined)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    const report = JSON.parse(text) as DoctorReport
+
+    assert.equal(report.ok, false)
+    assert.equal(report.desktopApp.found, false)
+    assert.equal(report.desktopApp.path, null)
+    assert.ok(report.mcpTools.includes('doctor'))
+    assert.ok(report.commands.includes('doctor'))
+  } finally {
+    if (previousAppPath === undefined) {
+      delete process.env.HYPERMOTION_APP_PATH
+    } else {
+      process.env.HYPERMOTION_APP_PATH = previousAppPath
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add MCP doctor tool coverage for its no-argument schema
- verify the handler returns deterministic JSON report content when the desktop app path is missing

## Tests
- pnpm --dir cli test