### PR TITLE
Default patch-created image scene fields

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -646,6 +646,26 @@ test('applyScenePatch fills size defaults for created shape nodes', () => {
   assert.deepEqual(nodes.badge.size, { width: 100, height: 100 })
 })
 
+test('applyScenePatch fills image defaults for created nodes', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const patched = applyScenePatch(bytes, [
+    {
+      op: 'createNode',
+      node: {
+        id: 'thumbnail',
+        kind: 'image',
+        parent: 'root',
+      },
+    },
+  ])
+  const data = inspectScene(patched)
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(nodes.thumbnail.size, { width: 100, height: 100 })
+  assert.equal(nodes.thumbnail.src, '')
+  assert.equal(nodes.thumbnail.fit, 'cover')
+})
+
 test('buildSceneBytes keys tracks by their declared ids', () => {
   const scene = sampleScene()
   const sceneTracks = scene.tracks ?? {}

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -1066,6 +1066,14 @@ function nodeToYMap(node: NodeJson): Y.Map<unknown> {
     handledKeys.add('size')
     y.set('size', mergeWithDefaults(DEFAULT_SIZE, node.size))
   }
+  if (node.kind === 'image') {
+    handledKeys.add('src')
+    handledKeys.add('fit')
+    handledKeys.add('importWarning')
+    y.set('src', node.src ?? '')
+    y.set('fit', node.fit ?? 'cover')
+    if (node.importWarning !== undefined) y.set('importWarning', node.importWarning)
+  }
   for (const [k, v] of Object.entries(node)) {
     if (handledKeys.has(k)) continue
     y.set(k, v)


### PR DESCRIPTION
## Summary
- default patch-created image nodes to an empty src and cover fit
- add a focused regression test for image defaults in applyScenePatch

## Tests
- pnpm install --frozen-lockfile && pnpm test (in cli/)