### PR TITLE
Use SDK result type for capability tools

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -2,6 +2,7 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import {
   handleGetCapabilities,
   handleListKeyframeableProperties,
@@ -21,10 +22,14 @@ test('capability tools list the full supported keyframe property set', async () 
   )
 })
 
-function parseToolJson(result: {
-  content: Array<{ type: 'text'; text: string }>
-}): { keyframeableProperties: string[]; nodeKinds?: string[] } {
-  const parsed: unknown = JSON.parse(result.content[0]?.text ?? '{}')
+function parseToolJson(result: CallToolResult): {
+  keyframeableProperties: string[]
+  nodeKinds?: string[]
+} {
+  const item = result.content[0]
+  assert.equal(item?.type, 'text')
+
+  const parsed: unknown = JSON.parse(item.text)
   assert.equal(typeof parsed, 'object')
   assert.notEqual(parsed, null)
 

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js'
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import { NODE_KINDS, PROPERTY_IDS } from '../../scene/build.js'
-
-type McpTextResult = {
-  content: Array<{ type: 'text'; text: string }>
-}
 
 export const getCapabilitiesTool: Tool = {
   name: 'get_capabilities',
@@ -19,7 +15,7 @@ export const listKeyframeablePropertiesTool: Tool = {
   inputSchema: { type: 'object', properties: {} },
 }
 
-export async function handleGetCapabilities(): Promise<McpTextResult> {
+export async function handleGetCapabilities(): Promise<CallToolResult> {
   return text({
     sceneExtension: '.hype',
     nodeKinds: NODE_KINDS,
@@ -48,11 +44,11 @@ export async function handleGetCapabilities(): Promise<McpTextResult> {
   })
 }
 
-export async function handleListKeyframeableProperties(): Promise<McpTextResult> {
+export async function handleListKeyframeableProperties(): Promise<CallToolResult> {
   return text({ keyframeableProperties: PROPERTY_IDS })
 }
 
-function text(value: unknown): McpTextResult {
+function text(value: unknown): CallToolResult {
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }],
   }


### PR DESCRIPTION
## Summary\n- Replace the local MCP text result shape in capability tools with the SDK CallToolResult type\n- Update the capability test helper to assert text content before parsing\n\n## Tests\n- pnpm --dir cli test