### PR TITLE
Add typed text animation scene config

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -9,6 +9,7 @@ import {
   readSceneSummary,
   validateScene,
   type SceneJson,
+  type TextAnimationJson,
 } from './build.js'
 
 function sampleScene(): SceneJson {
@@ -536,7 +537,7 @@ test('applyScenePatch can clear the active camera', () => {
 
 test('applyScenePatch preserves text animation config on new tracks', () => {
   const bytes = buildSceneBytes(sampleScene())
-  const textAnimation = {
+  const textAnimation: TextAnimationJson = {
     id: 'blur-slide',
     mode: 'in',
     applyTo: 'words',

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -235,8 +235,25 @@ export interface TrackJson {
   nodeId: string
   propertyId: PropertyIdJson
   defaultEasing?: EasingJson
-  textAnimation?: JsonObject | null
+  textAnimation?: TextAnimationJson | null
   keyframes?: KeyframeJson[]
+}
+
+export interface TextAnimationJson {
+  id: string
+  mode: 'in' | 'out'
+  applyTo: 'letters' | 'words' | 'lines'
+  order: 'forward' | 'reverse' | 'random'
+  delay: number
+  smoothing: 'none' | 'smooth'
+  duration: number
+  startTime: number
+  acceleration: 'linear' | 'speed-up' | 'slow-down'
+  easingPresetId: string
+  easingStrength: number
+  direction: 'up' | 'down' | 'left' | 'right'
+  travelDistance: number
+  blurRadius: number
 }
 
 export interface AppearanceJson {


### PR DESCRIPTION
## Summary
- add an explicit CLI SceneJson type for text animation track config
- annotate the existing patch-scene test fixture with that type

## Tests
- pnpm test