### PR TITLE
test(cli): cover create_scene scene input schema

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -125,6 +125,14 @@ test('create_scene input schema exposes the open default', () => {
   assert.equal(openProperty?.default, true)
 })
 
+test('create_scene input schema exposes string and object scene inputs', () => {
+  const sceneProperty = createSceneTool.inputSchema.properties?.scene as
+    | Record<string, unknown>
+    | undefined
+
+  assert.deepEqual(sceneProperty?.anyOf, [{ type: 'string' }, { type: 'object' }])
+})
+
 test('create_scene reports invalid arguments as MCP errors', async () => {
   const result = await handleCreateScene({
     output: 42,

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -99,6 +99,7 @@ export const createSceneTool: Tool = {
         description: 'Absolute path to write the .hype file to.',
       },
       scene: {
+        anyOf: [{ type: 'string' }, { type: 'object' }],
         description:
           'The scene to build. Either a JSON string or an inline object matching SceneJson.',
       },


### PR DESCRIPTION
## Summary\n- expose the accepted string/object variants in the create_scene MCP input schema\n- add a focused test to keep the schema metadata in sync\n\n## Verification\n- pnpm --dir cli test