### PR TITLE
test(cli): cover non-camera active camera validation

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -735,6 +735,18 @@ test('validateScene rejects non-frame root nodes', () => {
   assert.deepEqual(result.errors, ['scene.root is not a frame node: title'])
 })
 
+test('validateScene rejects non-camera active camera ids', () => {
+  const scene = sampleScene()
+  scene.activeCameraId = 'title'
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'scene.activeCameraId is not a camera node: title',
+  ])
+})
+
 test('validateScene rejects unsupported node kinds', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))


### PR DESCRIPTION
## Summary
- Add CLI scene builder coverage for activeCameraId pointing at a non-camera node.
- Verifies the existing validateScene error branch for this invalid scene shape.

## Tests
- pnpm test (in cli/)