### PR TITLE
test: capture doctor stderr diagnostics

### DIFF
--- a/cli/src/commands/doctor.test.ts
+++ b/cli/src/commands/doctor.test.ts
@@ -2,6 +2,7 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { captureStderr } from '../testUtils/stdout.js'
 import { getDoctorReport } from './doctor.js'
 
 test('doctor report lists supported commands and MCP tools once', async () => {
@@ -9,8 +10,15 @@ test('doctor report lists supported commands and MCP tools once', async () => {
   process.env.HYPERMOTION_APP_PATH = '/tmp/hypermotion-doctor-missing-app'
 
   try {
-    const report = await getDoctorReport()
+    const state: { report?: Awaited<ReturnType<typeof getDoctorReport>> } = {}
+    const stderr = await captureStderr(async () => {
+      state.report = await getDoctorReport()
+    })
 
+    assert.match(stderr, /HYPERMOTION_APP_PATH is set/)
+    const { report } = state
+    if (report === undefined) throw new Error('doctor report was not produced')
+    assert.equal(report.ok, false)
     assert.equal(new Set(report.commands).size, report.commands.length)
     assert.equal(new Set(report.mcpTools).size, report.mcpTools.length)
     assert.ok(report.commands.includes('doctor'))

--- a/cli/src/mcp/doctor.test.ts
+++ b/cli/src/mcp/doctor.test.ts
@@ -3,6 +3,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import type { DoctorReport } from '../commands/doctor.js'
+import { captureStderr } from '../testUtils/stdout.js'
 import { doctorTool, handleDoctor } from './tools/doctor.js'
 
 test('doctor input schema accepts no arguments', () => {
@@ -17,8 +18,14 @@ test('doctor returns the report as MCP JSON content', async () => {
   process.env.HYPERMOTION_APP_PATH = '/tmp/hypermotion-mcp-doctor-missing-app'
 
   try {
-    const result = await handleDoctor()
+    const state: { result?: Awaited<ReturnType<typeof handleDoctor>> } = {}
+    const stderr = await captureStderr(async () => {
+      state.result = await handleDoctor()
+    })
 
+    assert.match(stderr, /HYPERMOTION_APP_PATH is set/)
+    const { result } = state
+    if (result === undefined) throw new Error('doctor result was not produced')
     assert.equal(result.isError, undefined)
     const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
     const report = JSON.parse(text) as DoctorReport


### PR DESCRIPTION
## Summary\n- Capture expected missing-app stderr in CLI doctor tests\n- Assert the diagnostic is emitted without leaking it into successful test output\n\n## Tests\n- pnpm --dir cli test