### PR TITLE
test: cover patched text animation defaults

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -574,6 +574,42 @@ test('applyScenePatch preserves text animation config on new tracks', () => {
   assert.deepEqual(tracks['text-progress']?.textAnimation, textAnimation)
 })
 
+test('applyScenePatch defaults omitted text animation keyframes to empty', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const textAnimation: TextAnimationJson = {
+    id: 'fade-words',
+    mode: 'in',
+    applyTo: 'words',
+    order: 'forward',
+    delay: 0.08,
+    smoothing: 'smooth',
+    duration: 0.5,
+    startTime: 0,
+    acceleration: 'linear',
+    easingPresetId: 'smooth',
+    easingStrength: 50,
+    direction: 'up',
+    travelDistance: 0.4,
+    blurRadius: 12,
+  }
+  const patched = applyScenePatch(bytes, [
+    {
+      op: 'setTrack',
+      track: {
+        id: 'text-progress',
+        nodeId: 'title',
+        propertyId: 'text.progress',
+        textAnimation,
+      },
+    },
+  ])
+  const data = inspectScene(patched)
+  const tracks = data.tracks as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(tracks['text-progress']?.keyframes, [])
+  assert.deepEqual(tracks['text-progress']?.textAnimation, textAnimation)
+})
+
 test('readSceneSummary reports deleted root and active camera ids as null', () => {
   const bytes = buildSceneBytes(sampleScene())
   const withoutRoot = applyScenePatch(bytes, [{ op: 'deleteNode', nodeId: 'root' }])


### PR DESCRIPTION
## Summary\n- Add regression coverage that patched text animation tracks default omitted keyframes to an empty array.\n- Keep this as a CLI scene-builder test-only maintenance change.\n\n## Verification\n- pnpm --dir cli test\n\n## Notes\n- Repository-level pnpm typecheck/lint did not reach checks because pnpm 11 blocked Electron install scripts with ERR_PNPM_IGNORED_BUILDS.