### PR TITLE
Fix patch-created frame defaults

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -683,6 +683,40 @@ test('applyScenePatch fills size defaults for created shape nodes', () => {
   assert.deepEqual(nodes.badge.size, { width: 100, height: 100 })
 })
 
+test('applyScenePatch fills layout defaults for created frame nodes', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const patched = applyScenePatch(bytes, [
+    {
+      op: 'createNode',
+      node: {
+        id: 'panel',
+        kind: 'frame',
+        parent: 'root',
+        size: { width: 320 },
+        layout: { mode: 'flex', padding: { left: 12 } },
+      },
+    },
+  ])
+  const data = inspectScene(patched)
+  const nodes = data.nodes as Record<string, Record<string, unknown>>
+
+  assert.deepEqual(nodes.panel.size, { width: 320, height: 100 })
+  assert.deepEqual(nodes.panel.layout, {
+    mode: 'flex',
+    direction: 'column',
+    justify: 'start',
+    align: 'start',
+    gap: 0,
+    padding: { top: 0, right: 0, bottom: 0, left: 12 },
+    wrap: false,
+    columns: 1,
+    rowGap: 0,
+    columnGap: 0,
+  })
+  assert.equal(nodes.panel.clipsContent, true)
+  assert.deepEqual(nodes.panel.layoutGuides, [])
+})
+
 test('buildSceneBytes keys tracks by their declared ids', () => {
   const scene = sampleScene()
   const sceneTracks = scene.tracks ?? {}

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -1083,6 +1083,62 @@ function nodeToYMap(node: NodeJson): Y.Map<unknown> {
     handledKeys.add('size')
     y.set('size', mergeWithDefaults(DEFAULT_SIZE, node.size))
   }
+  if (node.kind === 'frame' || node.kind === 'component') {
+    for (const key of [
+      'size',
+      'layout',
+      'clipsContent',
+      'layoutGuides',
+      'variants',
+      'defaultSelection',
+      'variantOverrides',
+      'variantPositions',
+      'componentProperties',
+      'variantTransition',
+      'timelines',
+      'interactions',
+    ]) {
+      handledKeys.add(key)
+    }
+    y.set('size', mergeWithDefaults(DEFAULT_SIZE, node.size))
+    y.set('layout', mergeLayoutWithDefaults(DEFAULT_LAYOUT, node.layout))
+    if (node.kind === 'frame') {
+      y.set('clipsContent', node.clipsContent ?? true)
+      y.set('layoutGuides', node.layoutGuides ?? [])
+    } else {
+      y.set('variants', node.variants ?? [])
+      y.set('defaultSelection', node.defaultSelection ?? {})
+      y.set('variantOverrides', node.variantOverrides ?? [])
+      y.set('variantPositions', node.variantPositions ?? {})
+      y.set('componentProperties', node.componentProperties ?? [])
+      y.set('variantTransition', node.variantTransition ?? {
+        duration: 0.3,
+        easing: 'ease-in-out',
+        presetId: 'smooth',
+        strength: 50,
+      })
+      y.set('timelines', node.timelines ?? {})
+      y.set('interactions', node.interactions ?? [])
+    }
+  }
+  if (node.kind === 'instance') {
+    for (const key of [
+      'size',
+      'layout',
+      'componentId',
+      'selection',
+      'overrides',
+      'interactions',
+    ]) {
+      handledKeys.add(key)
+    }
+    y.set('size', mergeWithDefaults(DEFAULT_SIZE, node.size))
+    y.set('layout', mergeLayoutWithDefaults(DEFAULT_LAYOUT, node.layout))
+    y.set('componentId', node.componentId ?? '')
+    y.set('selection', node.selection ?? {})
+    y.set('overrides', node.overrides ?? {})
+    y.set('interactions', node.interactions ?? [])
+  }
   for (const [k, v] of Object.entries(node)) {
     if (handledKeys.has(k)) continue
     y.set(k, v)


### PR DESCRIPTION
## Summary\n- fill default size, layout, and frame/component/instance metadata when CLI patch operations create nodes\n- add regression coverage for patch-created frame layout defaults\n\n## Tests\n- pnpm test