### PR TITLE
Stabilize doctor missing app tests

### DIFF
--- a/cli/src/commands/doctor.test.ts
+++ b/cli/src/commands/doctor.test.ts
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import test from 'node:test'
 import { captureStderr } from '../testUtils/stdout.js'
 import { getDoctorReport } from './doctor.js'
 
 test('doctor report lists supported commands and MCP tools once', async () => {
   const previousAppPath = process.env.HYPERMOTION_APP_PATH
-  process.env.HYPERMOTION_APP_PATH = '/tmp/hypermotion-doctor-missing-app'
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-doctor-missing-'))
+  process.env.HYPERMOTION_APP_PATH = path.join(dir, 'hyper-motion')
 
   try {
     const state: { report?: Awaited<ReturnType<typeof getDoctorReport>> } = {}
@@ -33,5 +37,6 @@ test('doctor report lists supported commands and MCP tools once', async () => {
     } else {
       process.env.HYPERMOTION_APP_PATH = previousAppPath
     }
+    fs.rmSync(dir, { recursive: true, force: true })
   }
 })

--- a/cli/src/mcp/doctor.test.ts
+++ b/cli/src/mcp/doctor.test.ts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import test from 'node:test'
 import type { DoctorReport } from '../commands/doctor.js'
 import { captureStderr } from '../testUtils/stdout.js'
@@ -15,7 +18,8 @@ test('doctor input schema accepts no arguments', () => {
 
 test('doctor returns the report as MCP JSON content', async () => {
   const previousAppPath = process.env.HYPERMOTION_APP_PATH
-  process.env.HYPERMOTION_APP_PATH = '/tmp/hypermotion-mcp-doctor-missing-app'
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-doctor-missing-'))
+  process.env.HYPERMOTION_APP_PATH = path.join(dir, 'hyper-motion')
 
   try {
     const state: { result?: Awaited<ReturnType<typeof handleDoctor>> } = {}
@@ -41,5 +45,6 @@ test('doctor returns the report as MCP JSON content', async () => {
     } else {
       process.env.HYPERMOTION_APP_PATH = previousAppPath
     }
+    fs.rmSync(dir, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Summary
- use per-test temporary missing app paths in doctor CLI and MCP tests
- clean up temporary directories after each test

## Tests
- pnpm --dir cli test