### PR TITLE
Expose validation tools in MCP capabilities

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -35,6 +35,7 @@ test('capability tools list the full supported keyframe property set', async () 
     'list_tracks',
     'list_cameras',
   ])
+  assert.deepEqual(capabilities.validationTools, ['validate_scene'])
   assert.deepEqual(capabilities.renderFormats, ['mp4', 'webm', 'gif'])
   assert.deepEqual(capabilities.renderQualities, ['comp', '720p', '2k', '4k'])
   assert.deepEqual(capabilities.keyframeableProperties, PROPERTY_IDS)
@@ -50,6 +51,7 @@ function parseToolJson(result: CallToolResult): {
   nodeKinds?: string[]
   patchOperations?: string[]
   queryTools?: string[]
+  validationTools?: string[]
   renderFormats?: string[]
   renderQualities?: string[]
 } {
@@ -78,6 +80,7 @@ function parseToolJson(result: CallToolResult): {
     nodeKinds,
     patchOperations: optionalStringArray(parsedObject, 'patchOperations'),
     queryTools: optionalStringArray(parsedObject, 'queryTools'),
+    validationTools: optionalStringArray(parsedObject, 'validationTools'),
     renderFormats: optionalStringArray(parsedObject, 'renderFormats'),
     renderQualities: optionalStringArray(parsedObject, 'renderQualities'),
   }

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -10,6 +10,7 @@ type CapabilitiesPayload = {
   validation: {
     structuralSceneValidation: boolean
   }
+  validationTools: string[]
   queryTools: string[]
   renderFormats: string[]
   renderQualities: string[]
@@ -54,6 +55,7 @@ export async function handleGetCapabilities(): Promise<CallToolResult> {
     validation: {
       structuralSceneValidation: true,
     },
+    validationTools: ['validate_scene'],
     queryTools: ['list_layers', 'get_layer', 'list_tracks', 'list_cameras'],
     renderFormats: ['mp4', 'webm', 'gif'],
     renderQualities: ['comp', '720p', '2k', '4k'],


### PR DESCRIPTION
## Summary
- add validationTools to the MCP capabilities payload
- cover the new capability field in the existing MCP capabilities test

## Tests
- cd cli && pnpm install --frozen-lockfile && pnpm test