### PR TITLE
test(cli): cover validate json errors

### DIFF
--- a/cli/src/commands/validate.test.ts
+++ b/cli/src/commands/validate.test.ts
@@ -93,6 +93,49 @@ test('validate command prints human-readable validation errors', async () => {
   }
 })
 
+test('validate command prints JSON validation errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const previousExitCode = process.exitCode
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Validate JSON Errors',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: ['missing-child'],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await validateCommand()
+        .exitOverride()
+        .parseAsync([scenePath, '--json'], { from: 'user' })
+    })
+
+    assert.deepEqual(JSON.parse(stdout), {
+      ok: false,
+      errors: ['node root has missing child: missing-child'],
+      warnings: ['scene.activeCameraId is missing'],
+    })
+    assert.equal(process.exitCode, 1)
+  } finally {
+    process.exitCode = previousExitCode
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('validate command rejects a non-camera active camera id', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
   const scenePath = path.join(dir, 'scene.hype')


### PR DESCRIPTION
## Summary
- Add CLI validate coverage for invalid scenes with --json output
- Assert the JSON error payload and nonzero exitCode behavior

## Verification
- pnpm --dir cli test