### PR TITLE
chore: type CLI fatal handler

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -53,7 +53,7 @@ program.addCommand(serveCommand())
 // Surface unknown commands cleanly instead of a stack trace.
 program.showHelpAfterError('(use --help for available commands)')
 
-program.parseAsync().catch((err) => {
+program.parseAsync().catch((err: unknown) => {
   console.error('\n[hypermotion] fatal:', err instanceof Error ? err.message : err)
   process.exit(1)
 })


### PR DESCRIPTION
## Summary
- annotate the CLI fatal parse handler parameter as unknown
- keep the existing Error narrowing explicit before logging

## Verification
- CI=true npx pnpm@9 install --frozen-lockfile && npx pnpm@9 test (from cli/)