### PR TITLE
Handle non-finite canvas values in CLI info

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -182,3 +182,39 @@ test('info command omits camera line when no active camera exists', async () => 
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('info command replaces non-finite canvas numbers with placeholders', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Invalid Canvas',
+          canvas: { width: Number.NaN, height: Number.POSITIVE_INFINITY },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 400, height: 300 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await infoCommand().exitOverride().parseAsync([scenePath], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^ {2}Canvas: {4}\? × \?$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -81,11 +81,16 @@ function printableCanvas(canvas: unknown): PrintableCanvas {
     const height = 'height' in canvas ? canvas.height : '?'
 
     return {
-      width: typeof width === 'number' || typeof width === 'string' ? width : '?',
-      height:
-        typeof height === 'number' || typeof height === 'string' ? height : '?',
+      width: printableCanvasValue(width),
+      height: printableCanvasValue(height),
     }
   }
 
   return { width: '?', height: '?' }
+}
+
+function printableCanvasValue(value: unknown): number | string {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') return value
+  return '?'
 }


### PR DESCRIPTION
## Summary
- display non-finite canvas width/height values as placeholders in `hypermotion info`
- add a focused CLI test for malformed canvas metadata

## Tests
- `pnpm test` from `cli/`

Labels: attempted codex/codex-automation, but this repository does not currently define those labels.