### PR TITLE
Share MCP patch operation capabilities

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -7,7 +7,7 @@ import {
   handleGetCapabilities,
   handleListKeyframeableProperties,
 } from './tools/capabilities.js'
-import { NODE_KINDS, PROPERTY_IDS } from '../scene/build.js'
+import { NODE_KINDS, PATCH_OPERATION_TYPES, PROPERTY_IDS } from '../scene/build.js'
 
 test('capability tools list the full supported keyframe property set', async () => {
   const capabilities = parseToolJson(await handleGetCapabilities())
@@ -15,21 +15,7 @@ test('capability tools list the full supported keyframe property set', async () 
 
   assert.equal(capabilities.sceneExtension, '.hype')
   assert.deepEqual(capabilities.nodeKinds, NODE_KINDS)
-  assert.deepEqual(capabilities.patchOperations, [
-    'setMeta',
-    'setRoot',
-    'setActiveCameraId',
-    'createNode',
-    'deleteNode',
-    'setNode',
-    'setNodeProperty',
-    'appendChild',
-    'moveChild',
-    'setTrack',
-    'deleteTrack',
-    'setSection',
-    'deleteSection',
-  ])
+  assert.deepEqual(capabilities.patchOperations, PATCH_OPERATION_TYPES)
   assert.deepEqual(capabilities.queryTools, [
     'list_layers',
     'get_layer',

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
-import { NODE_KINDS, PROPERTY_IDS } from '../../scene/build.js'
+import { NODE_KINDS, PATCH_OPERATION_TYPES, PROPERTY_IDS } from '../../scene/build.js'
 
 type CapabilitiesPayload = {
   sceneExtension: '.hype'
   nodeKinds: typeof NODE_KINDS
-  patchOperations: string[]
+  patchOperations: typeof PATCH_OPERATION_TYPES
   validation: {
     structuralSceneValidation: boolean
   }
@@ -37,21 +37,7 @@ export async function handleGetCapabilities(): Promise<CallToolResult> {
   const payload: CapabilitiesPayload = {
     sceneExtension: '.hype',
     nodeKinds: NODE_KINDS,
-    patchOperations: [
-      'setMeta',
-      'setRoot',
-      'setActiveCameraId',
-      'createNode',
-      'deleteNode',
-      'setNode',
-      'setNodeProperty',
-      'appendChild',
-      'moveChild',
-      'setTrack',
-      'deleteTrack',
-      'setSection',
-      'deleteSection',
-    ],
+    patchOperations: PATCH_OPERATION_TYPES,
     validation: {
       structuralSceneValidation: true,
     },

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -473,6 +473,22 @@ export interface ScenePatch {
   ops: PatchOperation[]
 }
 
+export const PATCH_OPERATION_TYPES = [
+  'setMeta',
+  'setRoot',
+  'setActiveCameraId',
+  'createNode',
+  'deleteNode',
+  'setNode',
+  'setNodeProperty',
+  'appendChild',
+  'moveChild',
+  'setTrack',
+  'deleteTrack',
+  'setSection',
+  'deleteSection',
+] as const satisfies readonly PatchOperation['op'][]
+
 export type PatchOperation =
   | { op: 'setMeta'; patch: Record<string, unknown> }
   | { op: 'setRoot'; nodeId: string }


### PR DESCRIPTION
## Summary
- export the supported patch operation names from the scene builder
- reuse that typed list in MCP capabilities responses and tests

## Tests
- pnpm test (cli)