### PR TITLE
Validate scene section id consistency

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -907,6 +907,27 @@ test('validateScene rejects track ids that do not match their map key', () => {
   ])
 })
 
+test('validateScene rejects section ids that do not match their map key', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const sections = scene.get('sections') as Y.Map<Record<string, unknown>>
+  sections.set('alias', {
+    id: 'intro',
+    name: 'Intro',
+    color: '#2563eb',
+    start: 0,
+    end: 2.5,
+  })
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'section map key alias does not match section id: intro',
+  ])
+})
+
 test('buildSceneBytes preserves variant selection keyframe values', () => {
   const scene = sampleScene()
   scene.tracks = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -908,6 +908,12 @@ export function validateScene(bytes: Uint8Array): {
     }
   }
 
+  const sections = asRecord(data.sections)
+  for (const [id, raw] of Object.entries(sections)) {
+    const section = asRecord(raw)
+    if (section.id !== id) errors.push(`section map key ${id} does not match section id: ${String(section.id)}`)
+  }
+
   return { ok: errors.length === 0, errors, warnings }
 }
 


### PR DESCRIPTION
## Summary
- validate section map keys against section ids in CLI scene validation
- add regression coverage for mismatched section ids

## Tests
- pnpm --dir cli test