### PR TITLE
Improve CLI validate malformed file errors

### DIFF
--- a/cli/src/commands/validate.test.ts
+++ b/cli/src/commands/validate.test.ts
@@ -250,3 +250,29 @@ test('validate command reports missing scene files', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('validate command reports malformed scene files', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
+  const scenePath = path.join(dir, 'malformed.hype')
+  const previousExit = process.exit
+  try {
+    fs.writeFileSync(scenePath, 'not a yjs update')
+    process.exit = ((code?: number) => {
+      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
+    }) as typeof process.exit
+
+    const stderr = await captureStderr(async () => {
+      assert.throws(
+        () => {
+          validateCommand().parse([scenePath], { from: 'user' })
+        },
+        { exitCode: 2 },
+      )
+    })
+
+    assert.match(stderr, /^\[validate\] .*malformed\.hype doesn't look like a valid \.hype file:/)
+  } finally {
+    process.exit = previousExit
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/commands/validate.ts
+++ b/cli/src/commands/validate.ts
@@ -10,11 +10,18 @@ export function validateCommand(): Command {
     .argument('<scene>', 'Path to a .hype scene file')
     .option('--json', 'Output validation result as JSON')
     .action((scenePath: string, options: { json?: boolean }) => {
+      let bytes: Buffer
       let result: ReturnType<typeof validateScene>
       try {
-        result = validateScene(new Uint8Array(fs.readFileSync(scenePath)))
+        bytes = fs.readFileSync(scenePath)
       } catch (err) {
         console.error(`[validate] failed to read ${scenePath}: ${err instanceof Error ? err.message : err}`)
+        process.exit(2)
+      }
+      try {
+        result = validateScene(new Uint8Array(bytes))
+      } catch (err) {
+        console.error(`[validate] ${scenePath} doesn't look like a valid .hype file: ${err instanceof Error ? err.message : err}`)
         process.exit(2)
       }
       if (options.json) {


### PR DESCRIPTION
## Summary
- distinguish malformed .hype files from file read failures in the CLI validate command
- add a regression test for malformed scene bytes

## Tests
- pnpm --dir cli run build && node --test cli/dist/commands/validate.test.js
- pnpm --dir cli test