### PR TITLE
Update animation engine property comment

### DIFF
--- a/src/anim/engine.ts
+++ b/src/anim/engine.ts
@@ -401,8 +401,8 @@ function applyTextProgressTrack(
 /**
  * Write one resolved track value into the per-node AnimatedValue.
  *
- * Only the transform + appearance.opacity properties are live in MVP.
- * Layout-property tracks are accepted (see PropertyId in scene/types)
+ * Post-layout numeric and color properties are applied directly here.
+ * Layout and semantic tracks are accepted (see PropertyId in scene/types)
  * but the engine skips them until the FLIP pass arrives. Rather than
  * throw for those values, silently no-op — a stray layout track from
  * a saved doc shouldn't crash the renderer.


### PR DESCRIPTION
## Summary
- Update the animation engine comment to reflect the current set of directly applied post-layout properties.
- Clarify that layout and semantic tracks are accepted but skipped pending FLIP handling.

## Verification
- PASS: ./node_modules/.bin/eslint src/anim/engine.ts
- NOTE: pnpm lint / pnpm typecheck could not be used as clean full-repo gates in this worktree. pnpm first stopped on Electron build-script approval, and direct full-repo lint/typecheck are already red on unrelated existing React/TypeScript issues outside this comment-only change.