### PR TITLE
test(cli): cover invalid inspect scene files

### DIFF
--- a/cli/src/commands/inspect.test.ts
+++ b/cli/src/commands/inspect.test.ts
@@ -85,3 +85,29 @@ test('inspect command reports missing scene files', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('inspect command reports invalid scene files', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-'))
+  const scenePath = path.join(dir, 'invalid.hype')
+  const previousExit = process.exit
+  try {
+    fs.writeFileSync(scenePath, Buffer.from('not a hype scene'))
+    process.exit = ((code?: number) => {
+      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
+    }) as typeof process.exit
+
+    const stderr = await captureStderr(async () => {
+      assert.throws(
+        () => {
+          inspectCommand().parse([scenePath], { from: 'user' })
+        },
+        { exitCode: 2 },
+      )
+    })
+
+    assert.match(stderr, /^\[inspect\] failed to inspect .*invalid\.hype:/)
+  } finally {
+    process.exit = previousExit
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add CLI inspect coverage for invalid .hype file handling
- verify the command exits through the existing inspect error path

## Tests
- pnpm --dir cli test