### PR TITLE
test(cli): cover typed array stderr capture

### DIFF
--- a/cli/src/testUtils/stdout.test.ts
+++ b/cli/src/testUtils/stdout.test.ts
@@ -2,7 +2,7 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { captureStdout } from './stdout.js'
+import { captureStderr, captureStdout } from './stdout.js'
 
 test('captureStdout decodes Uint8Array chunks as text', async () => {
   const output = await captureStdout(() => {
@@ -10,4 +10,12 @@ test('captureStdout decodes Uint8Array chunks as text', async () => {
   })
 
   assert.equal(output, 'render complete')
+})
+
+test('captureStderr decodes Uint8Array chunks as text', async () => {
+  const output = await captureStderr(() => {
+    process.stderr.write(new TextEncoder().encode('render failed'))
+  })
+
+  assert.equal(output, 'render failed')
 })


### PR DESCRIPTION
## Summary\n- Extend the CLI stream capture tests to cover Uint8Array stderr writes.\n- Keeps stdout/stderr capture behavior covered consistently after the stdout fix on main.\n\n## Tests\n- pnpm test (in cli/)