### PR TITLE
Defend info canvas output against strings

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -218,3 +218,39 @@ test('info command replaces non-finite canvas numbers with placeholders', async 
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('info command replaces string canvas dimensions with placeholders', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'String Canvas',
+          canvas: { width: 'wide' as never, height: 'tall' as never },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 400, height: 300 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await infoCommand().exitOverride().parseAsync([scenePath], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^ {2}Canvas: {4}\? × \?$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -17,8 +17,8 @@ type InfoCommandOptions = {
 }
 
 type PrintableCanvas = {
-  width: number | string
-  height: number | string
+  width: number | '?'
+  height: number | '?'
 }
 
 export function infoCommand(): Command {
@@ -89,8 +89,7 @@ function printableCanvas(canvas: unknown): PrintableCanvas {
   return { width: '?', height: '?' }
 }
 
-function printableCanvasValue(value: unknown): number | string {
+function printableCanvasValue(value: unknown): number | '?' {
   if (typeof value === 'number' && Number.isFinite(value)) return value
-  if (typeof value === 'string') return value
   return '?'
 }


### PR DESCRIPTION
## Summary\n- Show placeholders for non-numeric canvas dimensions in human-readable `hypermotion info` output\n- Add regression coverage for corrupted string canvas metadata\n\n## Tests\n- `pnpm --dir cli test`\n\nAutomation: Hypermotion maintainer