### PR TITLE
test(cli): capture Uint8Array stdout chunks

### DIFF
--- a/cli/src/testUtils/stdout.test.ts
+++ b/cli/src/testUtils/stdout.test.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { captureStdout } from './stdout.js'
+
+test('captureStdout decodes Uint8Array chunks as text', async () => {
+  const output = await captureStdout(() => {
+    process.stdout.write(new TextEncoder().encode('render complete'))
+  })
+
+  assert.equal(output, 'render complete')
+})

--- a/cli/src/testUtils/stdout.ts
+++ b/cli/src/testUtils/stdout.ts
@@ -3,6 +3,11 @@
 type WritableStream = typeof process.stdout | typeof process.stderr
 type CaptureCallback = () => Promise<void> | void
 
+function stringifyChunk(chunk: Parameters<typeof process.stdout.write>[0]): string {
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString()
+  return chunk.toString()
+}
+
 async function captureStream(
   stream: WritableStream,
   run: CaptureCallback,
@@ -14,7 +19,7 @@ async function captureStream(
     encodingOrCallback?: Parameters<typeof stream.write>[1],
     callback?: Parameters<typeof stream.write>[2],
   ) => {
-    output += chunk.toString()
+    output += stringifyChunk(chunk)
     const done =
       typeof encodingOrCallback === 'function' ? encodingOrCallback : callback
     done?.()


### PR DESCRIPTION
## Summary\n- Decode Uint8Array chunks correctly in the CLI stdout/stderr capture test helper\n- Add a regression test for Uint8Array stdout writes\n\n## Tests\n- pnpm test (in cli/)