### PR TITLE
Handle malformed validate_scene inputs

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -54,12 +54,26 @@ export async function handleValidateScene(
     }
   }
 
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: JSON.stringify(validateScene(new Uint8Array(bytes)), null, 2),
-      },
-    ],
+  try {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(validateScene(new Uint8Array(bytes)), null, 2),
+        },
+      ],
+    }
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `validate_scene: ${parsed.data.scene} doesn't look like a valid .hype file: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+    }
   }
 }

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -41,6 +41,23 @@ test('validate_scene reports missing files as MCP errors', async () => {
   }
 })
 
+test('validate_scene reports malformed scene files as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-malformed-'))
+  const scenePath = path.join(dir, 'malformed.hype')
+
+  try {
+    fs.writeFileSync(scenePath, 'not a yjs update')
+
+    const result = await handleValidateScene({ scene: scenePath })
+
+    assert.equal(result.isError, true)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    assert.match(text, /^validate_scene: .*malformed\.hype doesn't look like a valid \.hype file:/)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('validate_scene returns validation JSON for readable scenes', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-mcp-'))
   const scenePath = path.join(dir, 'scene.hype')


### PR DESCRIPTION
## Summary\n- Return a structured MCP error when validate_scene receives malformed .hype bytes\n- Add coverage for malformed scene validation through the MCP handler\n\n## Tests\n- pnpm test (from cli/)