### PR TITLE
Handle blank scene names in CLI info

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -183,6 +183,42 @@ test('info command omits camera line when no active camera exists', async () => 
   }
 })
 
+test('info command falls back for blank scene names', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: '   ',
+          canvas: { width: 400, height: 300 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 400, height: 300 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await infoCommand().exitOverride().parseAsync([scenePath], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^Scene: \(unnamed\)$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('info command replaces non-finite canvas numbers with placeholders', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -58,7 +58,7 @@ export function infoCommand(): Command {
 
       const { meta } = summary
       const canvas = printableCanvas(meta.canvas)
-      const name = meta.name ?? '(unnamed)'
+      const name = printableSceneName(meta.name)
       const duration = meta.duration ?? 0
       const frameRate = meta.frameRate ?? 60
 
@@ -92,4 +92,9 @@ function printableCanvas(canvas: unknown): PrintableCanvas {
 function printableCanvasValue(value: unknown): number | '?' {
   if (typeof value === 'number' && Number.isFinite(value)) return value
   return '?'
+}
+
+function printableSceneName(value: unknown): string {
+  if (typeof value === 'string' && value.trim().length > 0) return value
+  return '(unnamed)'
 }


### PR DESCRIPTION
## Summary
- Treat blank scene names as unnamed in the human-readable `hypermotion info` output.
- Add a CLI regression test for whitespace-only scene names.

## Tests
- `pnpm --dir cli test`