### PR TITLE
Validate open scene paths are files

### DIFF
--- a/cli/src/commands/open.test.ts
+++ b/cli/src/commands/open.test.ts
@@ -30,3 +30,27 @@ test('open command reports missing scene files before launching the app', async 
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('open command reports directories before launching the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-dir-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  fs.mkdirSync(scenePath)
+  const previousExit = process.exit
+  try {
+    process.exit = ((code?: number) => {
+      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
+    }) as typeof process.exit
+
+    const stderr = await captureStderr(async () => {
+      await assert.rejects(
+        openCommand().parseAsync([scenePath], { from: 'user' }),
+        { exitCode: 2 },
+      )
+    })
+
+    assert.match(stderr, /^\[open\] scene path is not a file: .*scene\.hype$/m)
+  } finally {
+    process.exit = previousExit
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -16,6 +16,10 @@ export function openCommand(): Command {
         console.error(`[open] scene file not found: ${scenePath}`)
         process.exit(2)
       }
+      if (!fs.statSync(scenePath).isFile()) {
+        console.error(`[open] scene path is not a file: ${scenePath}`)
+        process.exit(2)
+      }
       const appPath = await locateDesktopApp()
       if (!appPath) {
         console.error('[open] hyper-motion desktop app not found.')


### PR DESCRIPTION
## Summary
- make the CLI open command reject directory paths before locating or launching the desktop app
- add a focused test for directory-valued .hype paths

## Tests
- pnpm --dir cli test