### PR TITLE
docs(cli): clarify render scene help

### DIFF
--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -50,7 +50,7 @@ export function renderCommand(): Command {
     .option('--fps <n>', 'Frame rate', '30')
     .option(
       '--scene <path>',
-      'Path to a .hype scene file; accepted for forward compatibility',
+      'Path to a .hype scene file to forward to the desktop app',
     )
     .action(async (opts: RenderOptions) => {
       const outputPath = path.resolve(opts.output)


### PR DESCRIPTION
## Summary\n- Clarify the CLI `--scene` render help text to say the path is forwarded to the desktop app.\n\n## Tests\n- `cd cli && pnpm run test`