### PR TITLE
test(cli): isolate doctor env overrides

### DIFF
--- a/cli/src/commands/doctor.test.ts
+++ b/cli/src/commands/doctor.test.ts
@@ -5,19 +5,19 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
+import { withEnvVar } from '../testUtils/env.js'
 import { captureStderr } from '../testUtils/stdout.js'
 import { getDoctorReport } from './doctor.js'
 
 test('doctor report lists supported commands and MCP tools once', async () => {
-  const previousAppPath = process.env.HYPERMOTION_APP_PATH
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-doctor-missing-'))
-  process.env.HYPERMOTION_APP_PATH = path.join(dir, 'hyper-motion')
-
   try {
     const state: { report?: Awaited<ReturnType<typeof getDoctorReport>> } = {}
-    const stderr = await captureStderr(async () => {
-      state.report = await getDoctorReport()
-    })
+    const stderr = await captureStderr(() =>
+      withEnvVar('HYPERMOTION_APP_PATH', path.join(dir, 'hyper-motion'), async () => {
+        state.report = await getDoctorReport()
+      }),
+    )
 
     assert.match(stderr, /HYPERMOTION_APP_PATH is set/)
     const { report } = state
@@ -32,11 +32,6 @@ test('doctor report lists supported commands and MCP tools once', async () => {
     assert.ok(report.mcpTools.includes('render_scene'))
     assert.equal(report.render.fileSceneInput, true)
   } finally {
-    if (previousAppPath === undefined) {
-      delete process.env.HYPERMOTION_APP_PATH
-    } else {
-      process.env.HYPERMOTION_APP_PATH = previousAppPath
-    }
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })

--- a/cli/src/mcp/doctor.test.ts
+++ b/cli/src/mcp/doctor.test.ts
@@ -6,6 +6,7 @@ import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import type { DoctorReport } from '../commands/doctor.js'
+import { withEnvVar } from '../testUtils/env.js'
 import { captureStderr } from '../testUtils/stdout.js'
 import { doctorTool, handleDoctor } from './tools/doctor.js'
 
@@ -17,15 +18,14 @@ test('doctor input schema accepts no arguments', () => {
 })
 
 test('doctor returns the report as MCP JSON content', async () => {
-  const previousAppPath = process.env.HYPERMOTION_APP_PATH
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-doctor-missing-'))
-  process.env.HYPERMOTION_APP_PATH = path.join(dir, 'hyper-motion')
-
   try {
     const state: { result?: Awaited<ReturnType<typeof handleDoctor>> } = {}
-    const stderr = await captureStderr(async () => {
-      state.result = await handleDoctor()
-    })
+    const stderr = await captureStderr(() =>
+      withEnvVar('HYPERMOTION_APP_PATH', path.join(dir, 'hyper-motion'), async () => {
+        state.result = await handleDoctor()
+      }),
+    )
 
     assert.match(stderr, /HYPERMOTION_APP_PATH is set/)
     const { result } = state
@@ -40,11 +40,6 @@ test('doctor returns the report as MCP JSON content', async () => {
     assert.ok(report.mcpTools.includes('doctor'))
     assert.ok(report.commands.includes('doctor'))
   } finally {
-    if (previousAppPath === undefined) {
-      delete process.env.HYPERMOTION_APP_PATH
-    } else {
-      process.env.HYPERMOTION_APP_PATH = previousAppPath
-    }
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })

--- a/cli/src/testUtils/env.ts
+++ b/cli/src/testUtils/env.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export async function withEnvVar(
+  name: string,
+  value: string,
+  run: () => Promise<void>,
+): Promise<void> {
+  const previous = process.env[name]
+  process.env[name] = value
+  try {
+    await run()
+  } finally {
+    if (previous === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = previous
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a small CLI test helper for scoped environment variable overrides
- use it in doctor command and MCP doctor tests to avoid duplicated restore logic

## Verification
- pnpm test (in cli)