### PR TITLE
Clean up removed custom font faces

### DIFF
--- a/src/ui/fonts/useCustomFonts.ts
+++ b/src/ui/fonts/useCustomFonts.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useSceneAPI, useSceneVersion } from '@/scene'
 import { registerFont, unregisterFont, isFontRegistered } from '@/fonts'
 import { notifyFontLoaded } from '@/ui/fonts/googleFonts'
@@ -14,10 +14,7 @@ import { notifyFontLoaded } from '@/ui/fonts/googleFonts'
  *   1. Snapshots the current `customFonts` set.
  *   2. Registers any fonts that are in the scene but not yet in the
  *      FontFaceSet.
- *   3. (TODO when needed) unregisters fonts that have been removed
- *      from the scene. Not done in MVP — leaving a stale FontFace
- *      registered is harmless (no node uses it) and avoids a churn
- *      cycle on every undo / redo.
+ *   3. Unregisters fonts that were removed from the scene.
  *   4. After each register, calls `notifyFontLoaded()` so useLayout
  *      re-solves with the new font's true metrics.
  *
@@ -30,10 +27,24 @@ import { notifyFontLoaded } from '@/ui/fonts/googleFonts'
 export function useCustomFonts(): void {
   const api = useSceneAPI()
   const version = useSceneVersion()
+  const previousFontsRef = useRef<Map<string, Parameters<typeof unregisterFont>[0]>>(
+    new Map(),
+  )
 
   useEffect(() => {
     let cancelled = false
     const fonts = api.getAllCustomFonts()
+    const nextFontIds = new Set(fonts.map((font) => font.id))
+    let removedAnyFont = false
+
+    for (const [id, font] of previousFontsRef.current) {
+      if (!nextFontIds.has(id)) {
+        void unregisterFont(font)
+        removedAnyFont = true
+      }
+    }
+    previousFontsRef.current = new Map(fonts.map((font) => [font.id, font]))
+    if (removedAnyFont) notifyFontLoaded()
 
     void (async () => {
       for (const font of fonts) {


### PR DESCRIPTION
## Summary\n- unregister custom FontFace entries when scene custom fonts are removed\n- refresh layout metrics after removed font cleanup\n- update the hook comment now that cleanup is implemented\n\n## Verification\n- ./node_modules/.bin/eslint src/ui/fonts/useCustomFonts.ts\n- git diff --check origin/main..HEAD\n\nNote: repository-wide pnpm run typecheck/lint currently cannot run in this environment because pnpm rejects the Electron ignored build script during dependency-status install; direct repository typecheck also reports pre-existing unrelated errors outside this change.