### PR TITLE
fix(cli): report patch scene argument errors

### DIFF
--- a/cli/src/mcp/patchScene.test.ts
+++ b/cli/src/mcp/patchScene.test.ts
@@ -6,7 +6,31 @@ import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { buildSceneBytes, readSceneSummary } from '../scene/build.js'
-import { handlePatchScene } from './tools/patchScene.js'
+import { handlePatchScene, patchSceneTool } from './tools/patchScene.js'
+
+test('patch_scene input schema exposes required scene and patch', () => {
+  assert.deepEqual(patchSceneTool.inputSchema, {
+    type: 'object',
+    properties: {
+      scene: { type: 'string', description: 'Path to the input .hype scene file.' },
+      output: { type: 'string', description: 'Path to write. Defaults to overwriting scene.' },
+      patch: { description: 'Patch as { ops: [...] }, an operation array, or a JSON string.' },
+      applyLive: {
+        type: 'boolean',
+        description: 'Push the patched scene into the running desktop app. Defaults to true.',
+      },
+    },
+    required: ['scene', 'patch'],
+  })
+})
+
+test('patch_scene reports invalid arguments as MCP errors', async () => {
+  const result = await handlePatchScene({ scene: 42, patch: [] })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.match(text, /^patch_scene: invalid arguments/)
+})
 
 test('patch_scene writes alternate output without applying live', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-patch-'))

--- a/cli/src/mcp/tools/patchScene.ts
+++ b/cli/src/mcp/tools/patchScene.ts
@@ -36,23 +36,35 @@ export const patchSceneTool: Tool = {
 export async function handlePatchScene(
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
-  const parsed = PatchInput.parse(args)
-  const output = path.resolve(parsed.output ?? parsed.scene)
+  const parsed = PatchInput.safeParse(args)
+  if (!parsed.success) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `patch_scene: invalid arguments — ${parsed.error.message}`,
+        },
+      ],
+    }
+  }
+
+  const output = path.resolve(parsed.data.output ?? parsed.data.scene)
   const patch =
-    typeof parsed.patch === 'string'
-      ? (JSON.parse(parsed.patch) as ScenePatch | PatchOperation[])
-      : (parsed.patch as ScenePatch | PatchOperation[])
-  const bytes = fs.readFileSync(parsed.scene)
+    typeof parsed.data.patch === 'string'
+      ? (JSON.parse(parsed.data.patch) as ScenePatch | PatchOperation[])
+      : (parsed.data.patch as ScenePatch | PatchOperation[])
+  const bytes = fs.readFileSync(parsed.data.scene)
   const next = applyScenePatch(new Uint8Array(bytes), patch)
   fs.mkdirSync(path.dirname(output), { recursive: true })
   fs.writeFileSync(output, Buffer.from(next))
-  const shouldApplyLive = parsed.applyLive ?? true
+  const shouldApplyLive = parsed.data.applyLive ?? true
   const liveApplied = shouldApplyLive ? await pushSceneToRunningApp(output) : false
   return {
     content: [
       {
         type: 'text' as const,
-        text: `Patched ${parsed.scene} → ${output}${liveApplied ? ' and applied it to the running desktop app' : ''}`,
+        text: `Patched ${parsed.data.scene} → ${output}${liveApplied ? ' and applied it to the running desktop app' : ''}`,
       },
     ],
   }


### PR DESCRIPTION
## Summary\n- return a structured MCP error when patch_scene receives invalid arguments\n- add direct MCP tests for the patch_scene schema and invalid argument path\n\n## Tests\n- pnpm test (in cli/)