### PR TITLE
Reject array scene JSON in create command

### DIFF
--- a/cli/src/commands/create.test.ts
+++ b/cli/src/commands/create.test.ts
@@ -7,7 +7,7 @@ import path from 'node:path'
 import test from 'node:test'
 import { createCommand } from './create.js'
 import { readSceneSummary } from '../scene/build.js'
-import { captureStdout } from '../testUtils/stdout.js'
+import { captureStderr, captureStdout } from '../testUtils/stdout.js'
 
 test('create command makes nested output directories', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-create-'))
@@ -109,6 +109,39 @@ test('create command reports authored layer and track counts', async () => {
     assert.equal(summary.layerCount, 1)
     assert.equal(summary.trackCount, 1)
   } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('create command rejects top-level JSON arrays', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-create-'))
+  const sourcePath = path.join(dir, 'scene.json')
+  const scenePath = path.join(dir, 'scene.hype')
+  const previousExit = process.exit
+  try {
+    process.exit = ((code?: number) => {
+      throw Object.assign(new Error(`process.exit ${code ?? 0}`), {
+        exitCode: code,
+      })
+    }) as typeof process.exit
+
+    fs.writeFileSync(sourcePath, '[]')
+
+    const stderr = await captureStderr(async () => {
+      await assert.rejects(
+        createCommand()
+          .parseAsync([scenePath, '--from', sourcePath], { from: 'user' }),
+        { exitCode: 2 },
+      )
+    })
+
+    assert.match(
+      stderr,
+      /^\[create\] scene JSON must be an object at the top level\.$/m,
+    )
+    assert.equal(fs.existsSync(scenePath), false)
+  } finally {
+    process.exit = previousExit
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -82,7 +82,7 @@ export function createCommand(): Command {
         process.exit(2)
       }
 
-      if (typeof json !== 'object' || json == null) {
+      if (typeof json !== 'object' || json == null || Array.isArray(json)) {
         console.error('[create] scene JSON must be an object at the top level.')
         process.exit(2)
       }


### PR DESCRIPTION
## Summary
- reject top-level JSON arrays in the `hypermotion create` command
- add a command test that asserts the error and avoids writing an output file

## Tests
- `pnpm test` from `cli/`