### PR TITLE
Update CLI roadmap scope

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -96,7 +96,6 @@ What works today:
 
 What's longer-term:
 
-- In-place editing for existing `.hype` files.
 - Chapter / range rendering and batch workflows.
 
 ## How rendering works


### PR DESCRIPTION
## Summary
- remove stale CLI README roadmap bullet for in-place .hype editing, which is now covered by patch_scene behavior

## Verification
- pnpm test (from cli/)