### PR TITLE
Reject array scene JSON in MCP create

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -144,6 +144,17 @@ test('create_scene reports invalid arguments as MCP errors', async () => {
   assert.match(text, /^create_scene: invalid arguments/)
 })
 
+test('create_scene rejects array scene JSON', async () => {
+  const result = await handleCreateScene({
+    output: path.join(os.tmpdir(), 'array-scene.hype'),
+    scene: '[]',
+  })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.equal(text, 'create_scene: scene must be an object (or a JSON-encoded object).')
+})
+
 test('create_scene reports persisted layer and track counts', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-create-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -147,7 +147,7 @@ export async function handleCreateScene(
     }
   }
 
-  if (typeof scene !== 'object' || scene == null) {
+  if (typeof scene !== 'object' || scene == null || Array.isArray(scene)) {
     return {
       isError: true,
       content: [


### PR DESCRIPTION
## Summary
- reject top-level array scene JSON in the MCP create_scene handler
- add coverage for JSON-string arrays so MCP validation matches the CLI create command

## Verification
- pnpm --dir cli test

Note: root `pnpm typecheck` currently fails on unrelated app TypeScript errors outside this change.