### PR TITLE
Mark invalid validate_scene results as MCP errors

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -55,11 +55,13 @@ export async function handleValidateScene(
   }
 
   try {
+    const result = validateScene(new Uint8Array(bytes))
     return {
+      isError: result.ok ? undefined : true,
       content: [
         {
           type: 'text' as const,
-          text: JSON.stringify(validateScene(new Uint8Array(bytes)), null, 2),
+          text: JSON.stringify(result, null, 2),
         },
       ],
     }

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -95,3 +95,41 @@ test('validate_scene returns validation JSON for readable scenes', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('validate_scene marks structurally invalid scenes as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-invalid-'))
+  const scenePath = path.join(dir, 'invalid.hype')
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Validate Invalid MCP',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: ['missing-child'],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const result = await handleValidateScene({ scene: scenePath })
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+
+    assert.equal(result.isError, true)
+    assert.deepEqual(JSON.parse(text), {
+      ok: false,
+      errors: ['node root has missing child: missing-child'],
+      warnings: ['scene.activeCameraId is missing'],
+    })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- mark structurally invalid validate_scene results with MCP isError
- add a regression test for invalid-but-readable .hype scenes

## Verification
- pnpm --dir cli test

## Notes
- pnpm typecheck and pnpm lint still fail on existing root app issues unrelated to this CLI change.