### PR TITLE
test: reuse env helper in locator tests

### DIFF
--- a/cli/src/electron/locator.test.ts
+++ b/cli/src/electron/locator.test.ts
@@ -6,72 +6,53 @@ import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { locateDesktopApp } from './locator.js'
+import { withEnvVar } from '../testUtils/env.js'
 import { captureStderr } from '../testUtils/stdout.js'
 
 test('locator returns an existing HYPERMOTION_APP_PATH override', async () => {
-  const previousOverride = process.env.HYPERMOTION_APP_PATH
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-'))
   const appPath = path.join(dir, 'hyper-motion')
 
   try {
     fs.writeFileSync(appPath, '')
-    process.env.HYPERMOTION_APP_PATH = appPath
 
-    assert.equal(await locateDesktopApp(), appPath)
+    await withEnvVar('HYPERMOTION_APP_PATH', appPath, async () => {
+      assert.equal(await locateDesktopApp(), appPath)
+    })
   } finally {
-    if (previousOverride === undefined) {
-      delete process.env.HYPERMOTION_APP_PATH
-    } else {
-      process.env.HYPERMOTION_APP_PATH = previousOverride
-    }
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
 
 test('locator rejects a missing HYPERMOTION_APP_PATH override', async () => {
-  const previousOverride = process.env.HYPERMOTION_APP_PATH
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-missing-'))
   const missingPath = path.join(dir, 'hyper-motion')
 
   try {
-    process.env.HYPERMOTION_APP_PATH = missingPath
-
-    const stderr = await captureStderr(async () => {
-      assert.equal(await locateDesktopApp(), null)
-    })
+    const stderr = await captureStderr(() =>
+      withEnvVar('HYPERMOTION_APP_PATH', missingPath, async () => {
+        assert.equal(await locateDesktopApp(), null)
+      }),
+    )
 
     assert.match(stderr, /HYPERMOTION_APP_PATH is set/)
     assert.equal(stderr.includes(missingPath), true)
   } finally {
-    if (previousOverride === undefined) {
-      delete process.env.HYPERMOTION_APP_PATH
-    } else {
-      process.env.HYPERMOTION_APP_PATH = previousOverride
-    }
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
 
 test('locator treats an empty HYPERMOTION_APP_PATH as unset', async () => {
-  const previousOverride = process.env.HYPERMOTION_APP_PATH
+  let locatedPath: string | null = null
 
-  try {
-    process.env.HYPERMOTION_APP_PATH = ''
-    let locatedPath: string | null = null
-
-    const stderr = await captureStderr(async () => {
+  const stderr = await captureStderr(() =>
+    withEnvVar('HYPERMOTION_APP_PATH', '', async () => {
       locatedPath = await locateDesktopApp()
-    })
+    }),
+  )
 
-    assert.equal(stderr, '')
-    if (locatedPath !== null) {
-      assert.equal(fs.existsSync(locatedPath), true)
-    }
-  } finally {
-    if (previousOverride === undefined) {
-      delete process.env.HYPERMOTION_APP_PATH
-    } else {
-      process.env.HYPERMOTION_APP_PATH = previousOverride
-    }
+  assert.equal(stderr, '')
+  if (locatedPath !== null) {
+    assert.equal(fs.existsSync(locatedPath), true)
   }
 })


### PR DESCRIPTION
## Summary
- Reuse the existing withEnvVar helper in desktop locator tests
- Remove repeated manual HYPERMOTION_APP_PATH restoration logic

## Tests
- pnpm test