### PR TITLE
[codex] Validate create_scene output paths

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -155,6 +155,17 @@ test('create_scene rejects array scene JSON', async () => {
   assert.equal(text, 'create_scene: scene must be an object (or a JSON-encoded object).')
 })
 
+test('create_scene rejects relative output paths', async () => {
+  const result = await handleCreateScene({
+    output: 'relative-scene.hype',
+    scene: { nodes: {} },
+  })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.equal(text, 'create_scene: output must be an absolute path.')
+})
+
 test('create_scene reports persisted layer and track counts', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-create-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -181,8 +181,20 @@ export async function handleCreateScene(
   // specify deep paths and we don't want a simple ENOENT to obscure
   // the actual failure.
   const outputPath = parsed.data.output
+  if (!path.isAbsolute(outputPath)) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: 'create_scene: output must be an absolute path.',
+        },
+      ],
+    }
+  }
+
   try {
-    fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true })
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true })
   } catch (err) {
     return {
       isError: true,


### PR DESCRIPTION
## Summary
- Reject relative `create_scene` output paths so runtime behavior matches the MCP schema.
- Add coverage for the relative-path error response.

## Validation
- `pnpm --dir cli test`
