### PR TITLE
test: allow sync env helper callbacks

### DIFF
--- a/cli/src/testUtils/env.test.ts
+++ b/cli/src/testUtils/env.test.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { withEnvVar } from './env.js'
+
+test('withEnvVar restores values after sync callbacks', async () => {
+  const name = 'HYPERMOTION_TEST_ENV_SYNC'
+  process.env[name] = 'before'
+
+  try {
+    await withEnvVar(name, 'during', () => {
+      assert.equal(process.env[name], 'during')
+    })
+
+    assert.equal(process.env[name], 'before')
+  } finally {
+    delete process.env[name]
+  }
+})

--- a/cli/src/testUtils/env.ts
+++ b/cli/src/testUtils/env.ts
@@ -3,7 +3,7 @@
 export async function withEnvVar(
   name: string,
   value: string,
-  run: () => Promise<void>,
+  run: () => Promise<void> | void,
 ): Promise<void> {
   const previous = process.env[name]
   process.env[name] = value


### PR DESCRIPTION
## Summary
- widen the CLI withEnvVar helper callback type to allow synchronous callbacks
- add a unit test that verifies sync callbacks still restore the previous env value

## Verification
- pnpm --dir cli test

Note: full root typecheck was checked before this patch and is currently failing on unrelated existing app-level TypeScript errors on origin/main.