### PR TITLE
Validate render scene paths before app lookup

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { captureStderr } from '../testUtils/stdout.js'
+import { renderCommand } from './render.js'
+
+test('render command reports missing scene files before launching the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-'))
+  const scenePath = path.join(dir, 'missing.hype')
+  const outPath = path.join(dir, 'out.mp4')
+  const previousExit = process.exit
+  try {
+    process.exit = ((code?: number) => {
+      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
+    }) as typeof process.exit
+
+    const stderr = await captureStderr(async () => {
+      await assert.rejects(
+        renderCommand().parseAsync(['--scene', scenePath, '-o', outPath], {
+          from: 'user',
+        }),
+        { exitCode: 2 },
+      )
+    })
+
+    assert.match(stderr, /^\[render\] scene file not found: .*missing\.hype$/m)
+  } finally {
+    process.exit = previousExit
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('render command reports directories before launching the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-dir-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const outPath = path.join(dir, 'out.mp4')
+  fs.mkdirSync(scenePath)
+  const previousExit = process.exit
+  try {
+    process.exit = ((code?: number) => {
+      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
+    }) as typeof process.exit
+
+    const stderr = await captureStderr(async () => {
+      await assert.rejects(
+        renderCommand().parseAsync(['--scene', scenePath, '-o', outPath], {
+          from: 'user',
+        }),
+        { exitCode: 2 },
+      )
+    })
+
+    assert.match(stderr, /^\[render\] scene path is not a file: .*scene\.hype$/m)
+  } finally {
+    process.exit = previousExit
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -73,15 +73,6 @@ export function renderCommand(): Command {
         process.exit(1)
       }
 
-      const appPath = await locateDesktopApp()
-      if (!appPath) {
-        console.error(
-          '[render] hyper-motion desktop app not found.\n' +
-            '         Install from https://hypermotion.app, then retry.',
-        )
-        process.exit(1)
-      }
-
       // Make sure the output directory exists so the desktop app's
       // post-render write doesn't fail on a missing parent.
       const outDir = path.dirname(outputPath)
@@ -93,6 +84,19 @@ export function renderCommand(): Command {
       if (scenePath && !fs.existsSync(scenePath)) {
         console.error(`[render] scene file not found: ${scenePath}`)
         process.exit(2)
+      }
+      if (scenePath && !fs.statSync(scenePath).isFile()) {
+        console.error(`[render] scene path is not a file: ${scenePath}`)
+        process.exit(2)
+      }
+
+      const appPath = await locateDesktopApp()
+      if (!appPath) {
+        console.error(
+          '[render] hyper-motion desktop app not found.\n' +
+            '         Install from https://hypermotion.app, then retry.',
+        )
+        process.exit(1)
       }
 
       console.log(`[render] output:  ${outputPath}`)


### PR DESCRIPTION
## Summary
- validate render --scene paths before locating the desktop app
- reject directory paths with a clear render-specific error
- add focused render command coverage for missing scene files and directories

## Tests
- pnpm test