### PR TITLE
fix(cli): reject directory open scene paths

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -39,3 +39,19 @@ test('open_scene reports missing files as MCP errors', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('open_scene reports directories as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-dir-'))
+  const sceneDir = path.join(dir, 'scene.hype')
+  fs.mkdirSync(sceneDir)
+
+  try {
+    const result = await handleOpenScene({ scene: sceneDir })
+
+    assert.equal(result.isError, true)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    assert.equal(text, `Scene path is not a file: ${sceneDir}`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -45,6 +45,12 @@ export async function handleOpenScene(
       content: [{ type: 'text' as const, text: `Scene file not found: ${scenePath}` }],
     }
   }
+  if (!fs.statSync(scenePath).isFile()) {
+    return {
+      isError: true,
+      content: [{ type: 'text' as const, text: `Scene path is not a file: ${scenePath}` }],
+    }
+  }
   const opened = await pushSceneToRunningApp(scenePath)
   if (!opened) {
     return {


### PR DESCRIPTION
## Summary\n- reject directory paths in the open_scene MCP handler before launching the desktop app\n- add MCP coverage for directory scene paths\n\n## Tests\n- pnpm test