### PR TITLE
Expose MCP tool names in capabilities

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -19,6 +19,7 @@ import {
 type CapabilitiesToolPayload = {
   keyframeableProperties: readonly PropertyIdJson[]
   sceneExtension?: string
+  mcpTools?: readonly string[]
   validation?: {
     structuralSceneValidation: boolean
   }
@@ -36,6 +37,22 @@ test('capability tools list the full supported keyframe property set', async () 
   const listed = parseToolJson(await handleListKeyframeableProperties())
 
   assert.equal(capabilities.sceneExtension, '.hype')
+  assert.deepEqual(capabilities.mcpTools, [
+    'doctor',
+    'get_capabilities',
+    'create_scene',
+    'info_scene',
+    'inspect_scene',
+    'patch_scene',
+    'validate_scene',
+    'list_layers',
+    'get_layer',
+    'list_tracks',
+    'list_cameras',
+    'open_scene',
+    'render_scene',
+    'list_keyframeable_properties',
+  ])
   assert.deepEqual(capabilities.nodeKinds, NODE_KINDS)
   assert.deepEqual(capabilities.patchOperations, PATCH_OPERATION_TYPES)
   assert.deepEqual(capabilities.queryTools, [
@@ -106,6 +123,7 @@ function parseToolJson(result: CallToolResult): CapabilitiesToolPayload {
   return {
     keyframeableProperties,
     sceneExtension,
+    mcpTools: optionalStringArray(parsedObject, 'mcpTools'),
     validation,
     nodeKinds,
     patchOperations: optionalStringArray(parsedObject, 'patchOperations') as

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -5,11 +5,28 @@ import { NODE_KINDS, PATCH_OPERATION_TYPES, PROPERTY_IDS } from '../../scene/bui
 
 const VALIDATION_TOOLS = ['validate_scene'] as const
 const QUERY_TOOLS = ['list_layers', 'get_layer', 'list_tracks', 'list_cameras'] as const
+const MCP_TOOLS = [
+  'doctor',
+  'get_capabilities',
+  'create_scene',
+  'info_scene',
+  'inspect_scene',
+  'patch_scene',
+  'validate_scene',
+  'list_layers',
+  'get_layer',
+  'list_tracks',
+  'list_cameras',
+  'open_scene',
+  'render_scene',
+  'list_keyframeable_properties',
+] as const
 const RENDER_FORMATS = ['mp4', 'webm', 'gif'] as const
 const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
 
 type CapabilitiesPayload = {
   sceneExtension: '.hype'
+  mcpTools: typeof MCP_TOOLS
   nodeKinds: typeof NODE_KINDS
   patchOperations: typeof PATCH_OPERATION_TYPES
   validation: {
@@ -42,6 +59,7 @@ export const listKeyframeablePropertiesTool: Tool = {
 export async function handleGetCapabilities(): Promise<CallToolResult> {
   const payload: CapabilitiesPayload = {
     sceneExtension: '.hype',
+    mcpTools: MCP_TOOLS,
     nodeKinds: NODE_KINDS,
     patchOperations: PATCH_OPERATION_TYPES,
     validation: {


### PR DESCRIPTION
## Summary
- add the MCP tool name list to get_capabilities output
- pin the capability payload shape with a focused unit assertion

## Tests
- pnpm --dir cli test