### PR TITLE
test(cli): cover unset env restoration

### DIFF
--- a/cli/src/testUtils/env.test.ts
+++ b/cli/src/testUtils/env.test.ts
@@ -18,3 +18,14 @@ test('withEnvVar restores values after sync callbacks', async () => {
     delete process.env[name]
   }
 })
+
+test('withEnvVar removes variables that were originally unset', async () => {
+  const name = 'HYPERMOTION_TEST_ENV_UNSET'
+  delete process.env[name]
+
+  await withEnvVar(name, 'during', () => {
+    assert.equal(process.env[name], 'during')
+  })
+
+  assert.equal(process.env[name], undefined)
+})


### PR DESCRIPTION
## Summary\n- add CLI test coverage for withEnvVar when the target variable starts unset\n\n## Tests\n- pnpm --dir cli test -- --test-name-pattern=withEnvVar