### PR TITLE
test(cli): share process exit test helper

### DIFF
--- a/cli/src/commands/open.test.ts
+++ b/cli/src/commands/open.test.ts
@@ -5,28 +5,25 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
+import { withProcessExitThrow } from '../testUtils/processExit.js'
 import { captureStderr } from '../testUtils/stdout.js'
 import { openCommand } from './open.js'
 
 test('open command reports missing scene files before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-'))
   const scenePath = path.join(dir, 'missing.hype')
-  const previousExit = process.exit
   try {
-    process.exit = ((code?: number) => {
-      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
-    }) as typeof process.exit
-
-    const stderr = await captureStderr(async () => {
-      await assert.rejects(
-        openCommand().parseAsync([scenePath], { from: 'user' }),
-        { exitCode: 2 },
-      )
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          openCommand().parseAsync([scenePath], { from: 'user' }),
+          { exitCode: 2 },
+        )
+      })
     })
 
     assert.match(stderr, /^\[open\] scene file not found: .*missing\.hype$/m)
   } finally {
-    process.exit = previousExit
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
@@ -35,22 +32,18 @@ test('open command reports directories before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-dir-'))
   const scenePath = path.join(dir, 'scene.hype')
   fs.mkdirSync(scenePath)
-  const previousExit = process.exit
   try {
-    process.exit = ((code?: number) => {
-      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
-    }) as typeof process.exit
-
-    const stderr = await captureStderr(async () => {
-      await assert.rejects(
-        openCommand().parseAsync([scenePath], { from: 'user' }),
-        { exitCode: 2 },
-      )
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          openCommand().parseAsync([scenePath], { from: 'user' }),
+          { exitCode: 2 },
+        )
+      })
     })
 
     assert.match(stderr, /^\[open\] scene path is not a file: .*scene\.hype$/m)
   } finally {
-    process.exit = previousExit
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })

--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
+import { withProcessExitThrow } from '../testUtils/processExit.js'
 import { captureStderr } from '../testUtils/stdout.js'
 import { renderCommand } from './render.js'
 
@@ -12,24 +13,20 @@ test('render command reports missing scene files before launching the app', asyn
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-'))
   const scenePath = path.join(dir, 'missing.hype')
   const outPath = path.join(dir, 'out.mp4')
-  const previousExit = process.exit
   try {
-    process.exit = ((code?: number) => {
-      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
-    }) as typeof process.exit
-
-    const stderr = await captureStderr(async () => {
-      await assert.rejects(
-        renderCommand().parseAsync(['--scene', scenePath, '-o', outPath], {
-          from: 'user',
-        }),
-        { exitCode: 2 },
-      )
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          renderCommand().parseAsync(['--scene', scenePath, '-o', outPath], {
+            from: 'user',
+          }),
+          { exitCode: 2 },
+        )
+      })
     })
 
     assert.match(stderr, /^\[render\] scene file not found: .*missing\.hype$/m)
   } finally {
-    process.exit = previousExit
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
@@ -39,24 +36,20 @@ test('render command reports directories before launching the app', async () => 
   const scenePath = path.join(dir, 'scene.hype')
   const outPath = path.join(dir, 'out.mp4')
   fs.mkdirSync(scenePath)
-  const previousExit = process.exit
   try {
-    process.exit = ((code?: number) => {
-      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
-    }) as typeof process.exit
-
-    const stderr = await captureStderr(async () => {
-      await assert.rejects(
-        renderCommand().parseAsync(['--scene', scenePath, '-o', outPath], {
-          from: 'user',
-        }),
-        { exitCode: 2 },
-      )
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          renderCommand().parseAsync(['--scene', scenePath, '-o', outPath], {
+            from: 'user',
+          }),
+          { exitCode: 2 },
+        )
+      })
     })
 
     assert.match(stderr, /^\[render\] scene path is not a file: .*scene\.hype$/m)
   } finally {
-    process.exit = previousExit
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })

--- a/cli/src/testUtils/processExit.ts
+++ b/cli/src/testUtils/processExit.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+type ProcessExitCallback = () => Promise<void> | void
+
+export async function withProcessExitThrow(
+  run: ProcessExitCallback,
+): Promise<void> {
+  const previousExit = process.exit
+  try {
+    process.exit = ((code?: number) => {
+      throw Object.assign(new Error(`process.exit ${code ?? 0}`), {
+        exitCode: code,
+      })
+    }) as typeof process.exit
+
+    await run()
+  } finally {
+    process.exit = previousExit
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared CLI test helper for intercepting process.exit
- use it in open/render command tests so global restoration stays centralized

## Verification
- pnpm --dir cli test