### PR TITLE
test(cli): cover env restore after async failure

### DIFF
--- a/cli/src/testUtils/env.test.ts
+++ b/cli/src/testUtils/env.test.ts
@@ -29,3 +29,22 @@ test('withEnvVar removes variables that were originally unset', async () => {
 
   assert.equal(process.env[name], undefined)
 })
+
+test('withEnvVar restores values after async callback failures', async () => {
+  const name = 'HYPERMOTION_TEST_ENV_ASYNC_THROW'
+  process.env[name] = 'before'
+
+  try {
+    await assert.rejects(
+      withEnvVar(name, 'during', async () => {
+        assert.equal(process.env[name], 'during')
+        throw new Error('callback failed')
+      }),
+      /callback failed/,
+    )
+
+    assert.equal(process.env[name], 'before')
+  } finally {
+    delete process.env[name]
+  }
+})


### PR DESCRIPTION
## Summary\n- add a regression test that verifies withEnvVar restores the original value after an async callback rejects\n\n## Verification\n- pnpm --dir cli test -- --test-name-pattern='withEnvVar'