### PR TITLE
test(cli): cover malformed info scene files

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -315,3 +315,29 @@ test('info command reports missing scene files', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('info command reports malformed scene files', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
+  const scenePath = path.join(dir, 'malformed.hype')
+  const previousExit = process.exit
+  try {
+    fs.writeFileSync(scenePath, 'not a yjs update')
+    process.exit = ((code?: number) => {
+      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
+    }) as typeof process.exit
+
+    const stderr = await captureStderr(async () => {
+      assert.throws(
+        () => {
+          infoCommand().parse([scenePath], { from: 'user' })
+        },
+        { exitCode: 2 },
+      )
+    })
+
+    assert.match(stderr, /^\[info\] .*malformed\.hype doesn't look like a valid \.hype file:/)
+  } finally {
+    process.exit = previousExit
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- Add CLI info command coverage for malformed .hype scene files.
- Keep behavior unchanged; this verifies the existing error path.

## Tests
- pnpm --dir cli test