### PR TITLE
Use SceneSummary type in CLI info paths

### DIFF
--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -10,7 +10,7 @@
 
 import { Command } from 'commander'
 import fs from 'node:fs'
-import { readSceneSummary } from '../scene/build.js'
+import { readSceneSummary, type SceneSummary } from '../scene/build.js'
 
 type InfoCommandOptions = {
   json?: boolean
@@ -39,7 +39,7 @@ export function infoCommand(): Command {
         process.exit(2)
       }
 
-      let summary: ReturnType<typeof readSceneSummary>
+      let summary: SceneSummary
       try {
         summary = readSceneSummary(new Uint8Array(bytes))
       } catch (err) {

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -10,7 +10,7 @@
 import { z } from 'zod'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
-import { readSceneSummary } from '../../scene/build.js'
+import { readSceneSummary, type SceneSummary } from '../../scene/build.js'
 
 const InfoInput = z.object({
   scene: z.string().describe('Path to a .hype scene file'),
@@ -65,7 +65,7 @@ export async function handleInfoScene(
     }
   }
 
-  let summary: ReturnType<typeof readSceneSummary>
+  let summary: SceneSummary
   try {
     summary = readSceneSummary(new Uint8Array(bytes))
   } catch (err) {


### PR DESCRIPTION
## Summary
- use the exported SceneSummary type in CLI and MCP info handlers
- avoid duplicating the readSceneSummary return type expression at call sites

## Tests
- pnpm --dir cli exec tsc --noEmit
- pnpm --dir cli test