### PR TITLE
Honor encodings in CLI stdout capture helper

### DIFF
--- a/cli/src/testUtils/stdout.test.ts
+++ b/cli/src/testUtils/stdout.test.ts
@@ -20,6 +20,14 @@ test('captureStderr decodes Uint8Array chunks as text', async () => {
   assert.equal(output, 'render failed')
 })
 
+test('captureStdout honors string chunk encodings', async () => {
+  const output = await captureStdout(() => {
+    process.stdout.write('cmVuZGVyIGNvbXBsZXRl', 'base64')
+  })
+
+  assert.equal(output, 'render complete')
+})
+
 test('captureStdout restores the writer when the callback throws', async () => {
   const originalWrite = process.stdout.write
 

--- a/cli/src/testUtils/stdout.ts
+++ b/cli/src/testUtils/stdout.ts
@@ -3,8 +3,12 @@
 type WritableStream = typeof process.stdout | typeof process.stderr
 type CaptureCallback = () => Promise<void> | void
 
-function stringifyChunk(chunk: Parameters<typeof process.stdout.write>[0]): string {
+function stringifyChunk(
+  chunk: Parameters<typeof process.stdout.write>[0],
+  encoding?: BufferEncoding,
+): string {
   if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString()
+  if (encoding) return Buffer.from(chunk, encoding).toString()
   return chunk.toString()
 }
 
@@ -19,7 +23,9 @@ async function captureStream(
     encodingOrCallback?: Parameters<typeof stream.write>[1],
     callback?: Parameters<typeof stream.write>[2],
   ) => {
-    output += stringifyChunk(chunk)
+    const encoding =
+      typeof encodingOrCallback === 'string' ? encodingOrCallback : undefined
+    output += stringifyChunk(chunk, encoding)
     const done =
       typeof encodingOrCallback === 'function' ? encodingOrCallback : callback
     done?.()


### PR DESCRIPTION
## Summary
- decode captured CLI test output with the provided string chunk encoding
- add a regression test for base64-encoded stdout writes

## Tests
- pnpm test