### PR TITLE
Clarify create_scene schema comment

### DIFF
--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -9,7 +9,7 @@
  *
  * The agent doesn't need to know about Y.Doc, CRDTs, or the desktop
  * app's internals. It only knows the JSON shape, which mirrors the
- * desktop's `Scene` type one-to-one.
+ * desktop's `Scene` type closely enough for file authoring.
  *
  * Common pattern:
  *


### PR DESCRIPTION
## Summary\n- Clarify that the MCP create_scene JSON shape follows the desktop scene type closely enough for file authoring, rather than claiming a one-to-one mirror.\n\n## Tests\n- pnpm --dir cli test