### PR TITLE
test(cli): cover invalid render fps

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -9,6 +9,21 @@ import { withProcessExitThrow } from '../testUtils/processExit.js'
 import { captureStderr } from '../testUtils/stdout.js'
 import { renderCommand } from './render.js'
 
+test('render command reports invalid fps before launching the app', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        renderCommand().parseAsync(['-o', 'out.mp4', '--fps', '0'], {
+          from: 'user',
+        }),
+        { exitCode: 1 },
+      )
+    })
+  })
+
+  assert.match(stderr, /^\[render\] invalid fps: 0$/m)
+})
+
 test('render command reports missing scene files before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-'))
   const scenePath = path.join(dir, 'missing.hype')


### PR DESCRIPTION
## Summary
- add CLI render coverage for invalid fps validation before app launch

## Tests
- pnpm test (from cli/)