### PR TITLE
test: avoid opening app in create scene count test

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -172,6 +172,7 @@ test('create_scene reports persisted layer and track counts', async () => {
   try {
     const result = await handleCreateScene({
       output: scenePath,
+      open: false,
       scene: {
         nodes: {
           aliasA: {


### PR DESCRIPTION
## Summary
- opt the create_scene layer/track count unit test out of live-opening the desktop app
- keeps the test focused on persisted scene counts and avoids environment-dependent side effects

## Verification
- pnpm --dir cli test

Ready for review. Mergify should handle merging if checks pass.