### PR TITLE
test(cli): reuse process exit helper in info tests

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -7,6 +7,7 @@ import path from 'node:path'
 import test from 'node:test'
 import { infoCommand } from './info.js'
 import { buildSceneBytes, type SceneSummary } from '../scene/build.js'
+import { withProcessExitThrow } from '../testUtils/processExit.js'
 import { captureStderr, captureStdout } from '../testUtils/stdout.js'
 
 test('info command prints JSON scene summaries', async () => {
@@ -294,24 +295,20 @@ test('info command replaces string canvas dimensions with placeholders', async (
 test('info command reports missing scene files', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
   const scenePath = path.join(dir, 'missing.hype')
-  const previousExit = process.exit
   try {
-    process.exit = ((code?: number) => {
-      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
-    }) as typeof process.exit
-
     const stderr = await captureStderr(async () => {
-      assert.throws(
-        () => {
-          infoCommand().parse([scenePath], { from: 'user' })
-        },
-        { exitCode: 2 },
-      )
+      await withProcessExitThrow(() => {
+        assert.throws(
+          () => {
+            infoCommand().parse([scenePath], { from: 'user' })
+          },
+          { exitCode: 2 },
+        )
+      })
     })
 
     assert.match(stderr, /^\[info\] failed to read .*missing\.hype:/)
   } finally {
-    process.exit = previousExit
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
@@ -319,25 +316,22 @@ test('info command reports missing scene files', async () => {
 test('info command reports malformed scene files', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
   const scenePath = path.join(dir, 'malformed.hype')
-  const previousExit = process.exit
   try {
     fs.writeFileSync(scenePath, 'not a yjs update')
-    process.exit = ((code?: number) => {
-      throw Object.assign(new Error(`process.exit ${code ?? 0}`), { exitCode: code })
-    }) as typeof process.exit
 
     const stderr = await captureStderr(async () => {
-      assert.throws(
-        () => {
-          infoCommand().parse([scenePath], { from: 'user' })
-        },
-        { exitCode: 2 },
-      )
+      await withProcessExitThrow(() => {
+        assert.throws(
+          () => {
+            infoCommand().parse([scenePath], { from: 'user' })
+          },
+          { exitCode: 2 },
+        )
+      })
     })
 
     assert.match(stderr, /^\[info\] .*malformed\.hype doesn't look like a valid \.hype file:/)
   } finally {
-    process.exit = previousExit
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Summary
- Reuse the shared withProcessExitThrow helper in info command error-path tests
- Remove duplicated process.exit monkeypatching from the info tests

## Verification
- pnpm test (from cli/)