### PR TITLE
chore(cli): name scene validation result type

### DIFF
--- a/cli/src/commands/validate.ts
+++ b/cli/src/commands/validate.ts
@@ -2,7 +2,7 @@
 
 import { Command } from 'commander'
 import fs from 'node:fs'
-import { validateScene } from '../scene/build.js'
+import { validateScene, type SceneValidationResult } from '../scene/build.js'
 
 export function validateCommand(): Command {
   return new Command('validate')
@@ -11,7 +11,7 @@ export function validateCommand(): Command {
     .option('--json', 'Output validation result as JSON')
     .action((scenePath: string, options: { json?: boolean }) => {
       let bytes: Buffer
-      let result: ReturnType<typeof validateScene>
+      let result: SceneValidationResult
       try {
         bytes = fs.readFileSync(scenePath)
       } catch (err) {

--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -3,7 +3,7 @@
 import { z } from 'zod'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
-import { validateScene } from '../../scene/build.js'
+import { validateScene, type SceneValidationResult } from '../../scene/build.js'
 
 const ValidateInput = z.object({
   scene: z.string().describe('Path to a .hype scene file.'),
@@ -55,7 +55,7 @@ export async function handleValidateScene(
   }
 
   try {
-    const result = validateScene(new Uint8Array(bytes))
+    const result: SceneValidationResult = validateScene(new Uint8Array(bytes))
     return {
       isError: result.ok ? undefined : true,
       content: [

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -853,11 +853,13 @@ export function inspectScene(bytes: Uint8Array): Record<string, unknown> {
   return yToPlain(scene) as Record<string, unknown>
 }
 
-export function validateScene(bytes: Uint8Array): {
+export interface SceneValidationResult {
   ok: boolean
   errors: string[]
   warnings: string[]
-} {
+}
+
+export function validateScene(bytes: Uint8Array): SceneValidationResult {
   const data = inspectScene(bytes)
   const errors: string[] = []
   const warnings: string[] = []


### PR DESCRIPTION
## Summary
- add an exported SceneValidationResult type for CLI scene validation
- use the named type in the validate command and MCP validate_scene handler

## Tests
- pnpm test (from cli/)