### PR TITLE
test(cli): reuse process exit helper in create tests

### DIFF
--- a/cli/src/commands/create.test.ts
+++ b/cli/src/commands/create.test.ts
@@ -7,6 +7,7 @@ import path from 'node:path'
 import test from 'node:test'
 import { createCommand } from './create.js'
 import { readSceneSummary } from '../scene/build.js'
+import { withProcessExitThrow } from '../testUtils/processExit.js'
 import { captureStderr, captureStdout } from '../testUtils/stdout.js'
 
 test('create command makes nested output directories', async () => {
@@ -117,22 +118,17 @@ test('create command rejects top-level JSON arrays', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-create-'))
   const sourcePath = path.join(dir, 'scene.json')
   const scenePath = path.join(dir, 'scene.hype')
-  const previousExit = process.exit
   try {
-    process.exit = ((code?: number) => {
-      throw Object.assign(new Error(`process.exit ${code ?? 0}`), {
-        exitCode: code,
-      })
-    }) as typeof process.exit
-
     fs.writeFileSync(sourcePath, '[]')
 
-    const stderr = await captureStderr(async () => {
-      await assert.rejects(
-        createCommand()
-          .parseAsync([scenePath, '--from', sourcePath], { from: 'user' }),
-        { exitCode: 2 },
-      )
+    const stderr = await withProcessExitThrow(async () => {
+      return captureStderr(async () => {
+        await assert.rejects(
+          createCommand()
+            .parseAsync([scenePath, '--from', sourcePath], { from: 'user' }),
+          { exitCode: 2 },
+        )
+      })
     })
 
     assert.match(
@@ -141,7 +137,6 @@ test('create command rejects top-level JSON arrays', async () => {
     )
     assert.equal(fs.existsSync(scenePath), false)
   } finally {
-    process.exit = previousExit
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })

--- a/cli/src/testUtils/processExit.ts
+++ b/cli/src/testUtils/processExit.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-type ProcessExitCallback = () => Promise<void> | void
+type ProcessExitCallback<T> = () => Promise<T> | T
 
-export async function withProcessExitThrow(
-  run: ProcessExitCallback,
-): Promise<void> {
+export async function withProcessExitThrow<T>(
+  run: ProcessExitCallback<T>,
+): Promise<T> {
   const previousExit = process.exit
   try {
     process.exit = ((code?: number) => {
@@ -13,7 +13,7 @@ export async function withProcessExitThrow(
       })
     }) as typeof process.exit
 
-    await run()
+    return await run()
   } finally {
     process.exit = previousExit
   }


### PR DESCRIPTION
## Summary
- Reuse the shared process exit helper in the create command test
- Make the helper generic so callers can return captured output

## Tests
- pnpm test