### PR TITLE
test(cli): cover env restoration on sync failure

### DIFF
--- a/cli/src/testUtils/env.test.ts
+++ b/cli/src/testUtils/env.test.ts
@@ -46,6 +46,25 @@ test('withEnvVar restores values after async callbacks', async () => {
   }
 })
 
+test('withEnvVar restores values after sync callback failures', async () => {
+  const name = 'HYPERMOTION_TEST_ENV_SYNC_THROW'
+  process.env[name] = 'before'
+
+  try {
+    await assert.rejects(
+      withEnvVar(name, 'during', () => {
+        assert.equal(process.env[name], 'during')
+        throw new Error('callback failed')
+      }),
+      /callback failed/,
+    )
+
+    assert.equal(process.env[name], 'before')
+  } finally {
+    delete process.env[name]
+  }
+})
+
 test('withEnvVar restores values after async callback failures', async () => {
   const name = 'HYPERMOTION_TEST_ENV_ASYNC_THROW'
   process.env[name] = 'before'


### PR DESCRIPTION
## Summary\n- add coverage for withEnvVar restoring the previous value after a synchronous callback throws\n\n## Verification\n- pnpm test