### PR TITLE
chore(cli): type stdin chunks in create command

### DIFF
--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -140,7 +140,7 @@ function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
     let data = ''
     process.stdin.setEncoding('utf-8')
-    process.stdin.on('data', (chunk) => {
+    process.stdin.on('data', (chunk: string) => {
       data += chunk
     })
     process.stdin.on('end', () => resolve(data))


### PR DESCRIPTION
## Summary
- Type the create command stdin data callback as a string after setting stdin encoding.

## Verification
- pnpm test