### PR TITLE
Align render CLI fps limit

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -24,6 +24,21 @@ test('render command reports invalid fps before launching the app', async () => 
   assert.match(stderr, /^\[render\] invalid fps: 0$/m)
 })
 
+test('render command rejects fps values above the MCP limit before launching the app', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        renderCommand().parseAsync(['-o', 'out.mp4', '--fps', '121'], {
+          from: 'user',
+        }),
+        { exitCode: 1 },
+      )
+    })
+  })
+
+  assert.match(stderr, /^\[render\] invalid fps: 121$/m)
+})
+
 test('render command reports missing scene files before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-'))
   const scenePath = path.join(dir, 'missing.hype')

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -68,7 +68,7 @@ export function renderCommand(): Command {
       }
 
       const fps = Number(opts.fps ?? '30')
-      if (!Number.isFinite(fps) || fps <= 0) {
+      if (!Number.isFinite(fps) || fps <= 0 || fps > 120) {
         console.error(`[render] invalid fps: ${opts.fps}`)
         process.exit(1)
       }


### PR DESCRIPTION
## Summary
- cap the human CLI render fps validation at 120 to match the MCP render tool schema
- add a regression test that rejects 121 fps before locating or launching the desktop app

## Tests
- pnpm --dir cli test