### PR TITLE
test(cli): allow env helper to unset variables

### DIFF
--- a/cli/src/testUtils/env.test.ts
+++ b/cli/src/testUtils/env.test.ts
@@ -30,6 +30,21 @@ test('withEnvVar removes variables that were originally unset', async () => {
   assert.equal(process.env[name], undefined)
 })
 
+test('withEnvVar can temporarily unset an existing variable', async () => {
+  const name = 'HYPERMOTION_TEST_ENV_TEMP_UNSET'
+  process.env[name] = 'before'
+
+  try {
+    await withEnvVar(name, undefined, () => {
+      assert.equal(process.env[name], undefined)
+    })
+
+    assert.equal(process.env[name], 'before')
+  } finally {
+    delete process.env[name]
+  }
+})
+
 test('withEnvVar restores values after async callbacks', async () => {
   const name = 'HYPERMOTION_TEST_ENV_ASYNC'
   process.env[name] = 'before'

--- a/cli/src/testUtils/env.ts
+++ b/cli/src/testUtils/env.ts
@@ -2,11 +2,15 @@
 
 export async function withEnvVar(
   name: string,
-  value: string,
+  value: string | undefined,
   run: () => Promise<void> | void,
 ): Promise<void> {
   const previous = process.env[name]
-  process.env[name] = value
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
   try {
     await run()
   } finally {


### PR DESCRIPTION
## Summary
- Let the CLI test env helper temporarily unset an existing environment variable
- Add coverage that the previous value is restored afterward

## Tests
- pnpm test