### PR TITLE
test(cli): cover unsupported render formats

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -39,6 +39,21 @@ test('render command rejects fps values above the MCP limit before launching the
   assert.match(stderr, /^\[render\] invalid fps: 121$/m)
 })
 
+test('render command reports unsupported formats before launching the app', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        renderCommand().parseAsync(['-o', 'out.mp4', '--format', 'mov'], {
+          from: 'user',
+        }),
+        { exitCode: 1 },
+      )
+    })
+  })
+
+  assert.match(stderr, /^\[render\] unsupported format: mov \(use mp4 \/ webm \/ gif\)$/m)
+})
+
 test('render command reports missing scene files before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-'))
   const scenePath = path.join(dir, 'missing.hype')


### PR DESCRIPTION
## Summary
- add CLI render command coverage for unsupported explicit formats
- verify the guard exits before desktop app launch

## Verification
- pnpm -C cli test

Note: repo-level `pnpm typecheck` and `pnpm lint` currently fail on pre-existing app issues outside this change; the CLI package test suite passes.