### PR TITLE
test(cli): cover invalid render quality

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -54,6 +54,21 @@ test('render command reports unsupported formats before launching the app', asyn
   assert.match(stderr, /^\[render\] unsupported format: mov \(use mp4 \/ webm \/ gif\)$/m)
 })
 
+test('render command reports unsupported quality before launching the app', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        renderCommand().parseAsync(['-o', 'out.mp4', '--quality', 'draft'], {
+          from: 'user',
+        }),
+        { exitCode: 1 },
+      )
+    })
+  })
+
+  assert.match(stderr, /^\[render\] unsupported quality: draft \(use comp \/ 720p \/ 2k \/ 4k\)$/m)
+})
+
 test('render command reports missing scene files before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-'))
   const scenePath = path.join(dir, 'missing.hype')


### PR DESCRIPTION
## Summary\n- add CLI render command coverage for unsupported quality presets\n- verify invalid quality exits before the desktop app is launched\n\n## Tests\n- pnpm --dir cli test