### PR TITLE
test(cli): isolate missing query scene path

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -60,22 +60,28 @@ test('query scene MCP handlers report invalid arguments as MCP errors', async ()
 })
 
 test('query scene MCP handlers report missing scene files as MCP errors', async () => {
-  const missingScene = path.join(os.tmpdir(), `hypermotion-missing-query-${Date.now()}.hype`)
-  const cases: Array<{
-    name: string
-    run: () => Promise<Awaited<ReturnType<typeof handleListLayers>>>
-  }> = [
-    { name: 'list_layers', run: () => handleListLayers({ scene: missingScene }) },
-    { name: 'get_layer', run: () => handleGetLayer({ scene: missingScene, nodeId: 'title' }) },
-    { name: 'list_tracks', run: () => handleListTracks({ scene: missingScene }) },
-    { name: 'list_cameras', run: () => handleListCameras({ scene: missingScene }) },
-  ]
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-missing-query-'))
+  const missingScene = path.join(dir, 'missing.hype')
 
-  for (const entry of cases) {
-    const result = await entry.run()
-    assert.equal(result.isError, true)
-    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-    assert.match(text, new RegExp(`^${entry.name}: failed to read ${missingScene}:`))
+  try {
+    const cases: Array<{
+      name: string
+      run: () => Promise<Awaited<ReturnType<typeof handleListLayers>>>
+    }> = [
+      { name: 'list_layers', run: () => handleListLayers({ scene: missingScene }) },
+      { name: 'get_layer', run: () => handleGetLayer({ scene: missingScene, nodeId: 'title' }) },
+      { name: 'list_tracks', run: () => handleListTracks({ scene: missingScene }) },
+      { name: 'list_cameras', run: () => handleListCameras({ scene: missingScene }) },
+    ]
+
+    for (const entry of cases) {
+      const result = await entry.run()
+      assert.equal(result.isError, true)
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+      assert.match(text, new RegExp(`^${entry.name}: failed to read ${missingScene}:`))
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
   }
 })
 


### PR DESCRIPTION
## Summary
- use an isolated temp directory for the missing-scene MCP query test
- clean up the temp directory after assertions

## Tests
- pnpm --dir cli run build && node --test cli/dist/mcp/queryScene.test.js
- pnpm --dir cli test