### PR TITLE
test(cli): keep MCP capabilities aligned

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -7,6 +7,7 @@ import {
   handleGetCapabilities,
   handleListKeyframeableProperties,
 } from './tools/capabilities.js'
+import { TOOLS } from './server.js'
 import {
   NODE_KINDS,
   PATCH_OPERATION_TYPES,
@@ -70,6 +71,10 @@ test('capability tools list the full supported keyframe property set', async () 
   assert.equal(capabilities.renderFileSceneInput, true)
   assert.deepEqual(capabilities.keyframeableProperties, PROPERTY_IDS)
   assert.deepEqual(listed.keyframeableProperties, PROPERTY_IDS)
+  assert.deepEqual(
+    capabilities.mcpTools,
+    TOOLS.map((tool) => tool.name),
+  )
   assert.equal(
     new Set(capabilities.keyframeableProperties).size,
     PROPERTY_IDS.length,

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -57,7 +57,7 @@ import { CLI_VERSION } from '../version.js'
 
 const SERVER_NAME = 'hypermotion'
 
-const TOOLS: Tool[] = [
+export const TOOLS: Tool[] = [
   doctorTool,
   getCapabilitiesTool,
   createSceneTool,


### PR DESCRIPTION
## Summary
- export the MCP tool registry for test visibility
- assert get_capabilities advertises the same MCP tool names the server registers

## Verification
- pnpm test -- capabilities.test.ts

Labels requested by automation were not present in this repository (codex, codex-automation).