### PR TITLE
Fix default process exit test helper code

### DIFF
--- a/cli/src/testUtils/processExit.test.ts
+++ b/cli/src/testUtils/processExit.test.ts
@@ -36,3 +36,12 @@ test('withProcessExitThrow converts process.exit into a thrown error', async () 
     { exitCode: 2 },
   )
 })
+
+test('withProcessExitThrow treats process.exit without a code as success', async () => {
+  await assert.rejects(
+    withProcessExitThrow(() => {
+      process.exit()
+    }),
+    { exitCode: 0 },
+  )
+})

--- a/cli/src/testUtils/processExit.ts
+++ b/cli/src/testUtils/processExit.ts
@@ -8,8 +8,9 @@ export async function withProcessExitThrow<T>(
   const previousExit = process.exit
   try {
     process.exit = ((code?: number) => {
-      throw Object.assign(new Error(`process.exit ${code ?? 0}`), {
-        exitCode: code,
+      const exitCode = code ?? 0
+      throw Object.assign(new Error(`process.exit ${exitCode}`), {
+        exitCode,
       })
     }) as typeof process.exit
 


### PR DESCRIPTION
## Summary\n- make withProcessExitThrow report exitCode 0 when process.exit() is called without an explicit code\n- add a regression test for the default process.exit() case\n\n## Tests\n- pnpm --dir cli test