### PR TITLE
Clarify optional camera guidance

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -61,6 +61,16 @@ test('create_scene description lists supported camera property ids', () => {
   }
 })
 
+test('create_scene description keeps camera nodes optional', () => {
+  const description = createSceneTool.description
+  if (typeof description !== 'string') {
+    throw new Error('create_scene description is missing')
+  }
+
+  assert.match(description, /'camera' kind node .* is optional/)
+  assert.doesNotMatch(description, /Include exactly one 'camera' kind node/)
+})
+
 test('create_scene description lists supported transform property ids', () => {
   const description = createSceneTool.description
   if (typeof description !== 'string') {

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -84,8 +84,8 @@ export const createSceneTool: Tool = {
     "keep it scene-level with parent: null, set activeCameraId to that camera id, do not list it in any frame/artboard children, " +
     "and default focalLength to 1000 unless the user explicitly requests a different camera/lens feel.\n" +
     `Property IDs you can keyframe: ${KEYFRAMEABLE_PROPERTY_DESCRIPTION}.\n\n` +
-    "Include exactly one 'camera' kind node (parent: null) plus a 'frame' kind root (parent: null) for the " +
-    "scene to render. The artboard size lives in meta.canvas.width / height.",
+    "Include a 'frame' kind root (parent: null) for the scene to render. A scene-level 'camera' kind node " +
+    "(parent: null) is optional unless the design needs camera properties. The artboard size lives in meta.canvas.width / height.",
   inputSchema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary
- Clarify that create_scene only requires a root frame for renderable scenes
- Keep camera nodes optional unless the design needs camera properties
- Add a regression assertion for the MCP tool description

## Tests
- pnpm --dir cli test -- createScene