### PR TITLE
Add typed process exit test error

### DIFF
--- a/cli/src/testUtils/processExit.test.ts
+++ b/cli/src/testUtils/processExit.test.ts
@@ -2,7 +2,7 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { withProcessExitThrow } from './processExit.js'
+import { type ProcessExitError, withProcessExitThrow } from './processExit.js'
 
 test('withProcessExitThrow restores process.exit after sync callbacks', async () => {
   const previousExit = process.exit
@@ -44,7 +44,11 @@ test('withProcessExitThrow converts process.exit into a thrown error', async () 
     withProcessExitThrow(() => {
       process.exit(2)
     }),
-    { exitCode: 2 },
+    (err: unknown) => {
+      assert.ok(err instanceof Error)
+      assert.equal((err as ProcessExitError).exitCode, 2)
+      return true
+    },
   )
 })
 

--- a/cli/src/testUtils/processExit.ts
+++ b/cli/src/testUtils/processExit.ts
@@ -2,6 +2,10 @@
 
 type ProcessExitCallback<T> = () => Promise<T> | T
 
+export interface ProcessExitError extends Error {
+  exitCode: number
+}
+
 export async function withProcessExitThrow<T>(
   run: ProcessExitCallback<T>,
 ): Promise<T> {
@@ -9,9 +13,13 @@ export async function withProcessExitThrow<T>(
   try {
     process.exit = ((code?: number) => {
       const exitCode = code ?? 0
-      throw Object.assign(new Error(`process.exit ${exitCode}`), {
-        exitCode,
-      })
+      const err: ProcessExitError = Object.assign(
+        new Error(`process.exit ${exitCode}`),
+        {
+          exitCode,
+        },
+      )
+      throw err
     }) as typeof process.exit
 
     return await run()


### PR DESCRIPTION
## Summary
- add an explicit ProcessExitError type for the CLI process-exit test helper
- assert the helper throws a real Error while preserving exitCode

## Tests
- pnpm --dir cli test