### PR TITLE
test(cli): cover open command launch path

### DIFF
--- a/cli/src/commands/open.test.ts
+++ b/cli/src/commands/open.test.ts
@@ -4,11 +4,48 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import type { ChildProcess } from 'node:child_process'
 import test from 'node:test'
 import { withEnvVar } from '../testUtils/env.js'
 import { withProcessExitThrow } from '../testUtils/processExit.js'
-import { captureStderr } from '../testUtils/stdout.js'
+import { captureStderr, captureStdout } from '../testUtils/stdout.js'
 import { openCommand } from './open.js'
+
+test('open command launches the desktop app with the resolved scene path', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-ok-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const appPath = path.join(dir, 'hyper-motion')
+  const spawnCalls: Array<{
+    command: string
+    args: readonly string[]
+    options: { detached?: boolean; stdio?: string }
+  }> = []
+  let unrefCalled = false
+  fs.writeFileSync(scenePath, '')
+  try {
+    const stdout = await captureStdout(async () => {
+      await openCommand({
+        locateApp: async () => appPath,
+        spawnApp: (command, args, options) => {
+          spawnCalls.push({ command, args, options })
+          return { unref: () => { unrefCalled = true } } as ChildProcess
+        },
+      }).parseAsync([scenePath], { from: 'user' })
+    })
+
+    assert.deepEqual(spawnCalls, [
+      {
+        command: appPath,
+        args: [scenePath],
+        options: { detached: true, stdio: 'ignore' },
+      },
+    ])
+    assert.equal(unrefCalled, true)
+    assert.match(stdout, new RegExp(`^Opened ${scenePath}$`, 'm'))
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
 
 test('open command reports missing scene files before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-'))

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -2,11 +2,26 @@
 
 import { Command } from 'commander'
 import { spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { locateDesktopApp } from '../electron/locator.js'
 
-export function openCommand(): Command {
+interface OpenCommandDeps {
+  locateApp: typeof locateDesktopApp
+  spawnApp: (
+    command: string,
+    args: string[],
+    options: { detached: true; stdio: 'ignore' },
+  ) => Pick<ChildProcess, 'unref'>
+}
+
+const defaultDeps: OpenCommandDeps = {
+  locateApp: locateDesktopApp,
+  spawnApp: spawn,
+}
+
+export function openCommand(deps: OpenCommandDeps = defaultDeps): Command {
   return new Command('open')
     .description('Open a .hype scene file in the hyper-motion desktop app.')
     .argument('<scene>', 'Path to a .hype scene file')
@@ -20,12 +35,12 @@ export function openCommand(): Command {
         console.error(`[open] scene path is not a file: ${scenePath}`)
         process.exit(2)
       }
-      const appPath = await locateDesktopApp()
+      const appPath = await deps.locateApp()
       if (!appPath) {
         console.error('[open] hyper-motion desktop app not found.')
         process.exit(1)
       }
-      const child = spawn(appPath, [scenePath], {
+      const child = deps.spawnApp(appPath, [scenePath], {
         detached: true,
         stdio: 'ignore',
       })


### PR DESCRIPTION
## Summary\n- add a focused success-path test for the CLI open command\n- inject the desktop app locator/spawn call so the test can verify launch args without starting Electron\n\n## Tests\n- pnpm --dir cli test