### PR TITLE
Tighten CLI process exit test helper typing

### DIFF
--- a/cli/src/testUtils/processExit.test.ts
+++ b/cli/src/testUtils/processExit.test.ts
@@ -52,6 +52,15 @@ test('withProcessExitThrow converts process.exit into a thrown error', async () 
   )
 })
 
+test('withProcessExitThrow preserves string exit codes', async () => {
+  await assert.rejects(
+    withProcessExitThrow(() => {
+      process.exit('1')
+    }),
+    { exitCode: '1' },
+  )
+})
+
 test('withProcessExitThrow treats process.exit without a code as success', async () => {
   await assert.rejects(
     withProcessExitThrow(() => {

--- a/cli/src/testUtils/processExit.ts
+++ b/cli/src/testUtils/processExit.ts
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 type ProcessExitCallback<T> = () => Promise<T> | T
+type ProcessExitCode = Parameters<typeof process.exit>[0]
 
 export interface ProcessExitError extends Error {
-  exitCode: number
+  exitCode: ProcessExitCode
 }
 
 export async function withProcessExitThrow<T>(
@@ -11,7 +12,7 @@ export async function withProcessExitThrow<T>(
 ): Promise<T> {
   const previousExit = process.exit
   try {
-    process.exit = ((code?: number) => {
+    process.exit = ((code?: ProcessExitCode) => {
       const exitCode = code ?? 0
       const err: ProcessExitError = Object.assign(
         new Error(`process.exit ${exitCode}`),


### PR DESCRIPTION
## Summary
- use Node's actual process.exit code parameter type in the CLI test helper
- add coverage for preserving string exit codes when process.exit is stubbed

## Tests
- pnpm --dir cli test