### PR TITLE
test(cli): avoid cast in missing-node validation fixture

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -799,17 +799,15 @@ test('validateScene rejects unsupported track property ids', () => {
 })
 
 test('validateScene rejects tracks targeting missing nodes', () => {
-  const scene = {
-    ...sampleScene(),
-    tracks: {
-      orphan: {
-        id: 'orphan',
-        nodeId: 'missing-node',
-        propertyId: 'appearance.opacity',
-        keyframes: [],
-      },
+  const scene = sampleScene()
+  scene.tracks = {
+    orphan: {
+      id: 'orphan',
+      nodeId: 'missing-node',
+      propertyId: 'appearance.opacity',
+      keyframes: [],
     },
-  } as unknown as SceneJson
+  }
 
   const result = validateScene(buildSceneBytes(scene))
 


### PR DESCRIPTION
## Summary
- Rework the missing-node validation fixture to mutate the typed sample scene instead of casting through unknown.

## Tests
- pnpm --dir cli test