### PR TITLE
docs(cli): avoid stale scope version heading

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -83,7 +83,7 @@ command = "hypermotion-mcp"
 Spawn `hypermotion-mcp` as a subprocess. The server speaks MCP over
 stdio per the [Model Context Protocol spec](https://modelcontextprotocol.io).
 
-## v0.1.2 scope
+## Current scope
 
 What works today:
 


### PR DESCRIPTION
## Summary
- Rename the CLI README scope heading from a fixed version to a current-scope heading so the quick-reference does not go stale on future releases.

## Tests
- pnpm --dir cli test