### PR TITLE
Clarify info_scene frame rate wording

### DIFF
--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -2,7 +2,7 @@
 
 /**
  * `info_scene` MCP tool — read a `.hype` file and return a structured
- * summary (canvas, duration, framerate, layer/track/section/keyframe
+ * summary (canvas, duration, frame rate, layer/track/section/keyframe
  * counts). Used by AI agents to inspect a scene before deciding what
  * to render or modify.
  */


### PR DESCRIPTION
## Summary
- Align the info_scene tool header comment with the existing "frame rate" wording used in the tool description.

## Verification
- pnpm --dir cli test

## Notes
- pnpm typecheck currently fails on pre-existing app-wide TypeScript errors outside this comment-only change.