### PR TITLE
Improve CLI env test helper return typing

### DIFF
--- a/cli/src/testUtils/env.test.ts
+++ b/cli/src/testUtils/env.test.ts
@@ -61,6 +61,29 @@ test('withEnvVar restores values after async callbacks', async () => {
   }
 })
 
+test('withEnvVar returns sync callback values', async () => {
+  const name = 'HYPERMOTION_TEST_ENV_SYNC_RETURN'
+  delete process.env[name]
+
+  const value = await withEnvVar(name, 'during', () => process.env[name])
+
+  assert.equal(value, 'during')
+  assert.equal(process.env[name], undefined)
+})
+
+test('withEnvVar returns async callback values', async () => {
+  const name = 'HYPERMOTION_TEST_ENV_ASYNC_RETURN'
+  delete process.env[name]
+
+  const value = await withEnvVar(name, 'during', async () => {
+    await Promise.resolve()
+    return process.env[name]
+  })
+
+  assert.equal(value, 'during')
+  assert.equal(process.env[name], undefined)
+})
+
 test('withEnvVar restores values after sync callback failures', async () => {
   const name = 'HYPERMOTION_TEST_ENV_SYNC_THROW'
   process.env[name] = 'before'

--- a/cli/src/testUtils/env.ts
+++ b/cli/src/testUtils/env.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-export async function withEnvVar(
+export async function withEnvVar<T>(
   name: string,
   value: string | undefined,
-  run: () => Promise<void> | void,
-): Promise<void> {
+  run: () => Promise<T> | T,
+): Promise<T> {
   const previous = process.env[name]
   if (value === undefined) {
     delete process.env[name]
@@ -12,7 +12,7 @@ export async function withEnvVar(
     process.env[name] = value
   }
   try {
-    await run()
+    return await run()
   } finally {
     if (previous === undefined) {
       delete process.env[name]


### PR DESCRIPTION
## Summary
- Preserve and type the callback return value from the CLI withEnvVar test helper.
- Add sync and async return-value coverage for the helper.

## Tests
- pnpm test (in cli/)