### PR TITLE
docs: avoid pinning CLI verify version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Requires Node 20+.
 
 ```sh
 hypermotion --version
-# 0.1.2
+# prints the installed CLI version
 
 hypermotion render --help
 ```


### PR DESCRIPTION
## Summary
- make the AGENTS.md CLI verification snippet version-agnostic so it does not go stale after CLI releases

## Tests
- pnpm --filter @psiddharthdesign/hypermotion test