### PR TITLE
test(cli): cover sync process exit cleanup

### DIFF
--- a/cli/src/testUtils/processExit.test.ts
+++ b/cli/src/testUtils/processExit.test.ts
@@ -39,6 +39,20 @@ test('withProcessExitThrow restores process.exit after async callback failures',
   assert.equal(process.exit, previousExit)
 })
 
+test('withProcessExitThrow restores process.exit after sync callback failures', async () => {
+  const previousExit = process.exit
+
+  await assert.rejects(
+    withProcessExitThrow(() => {
+      assert.notEqual(process.exit, previousExit)
+      throw new Error('callback failed')
+    }),
+    /callback failed/,
+  )
+
+  assert.equal(process.exit, previousExit)
+})
+
 test('withProcessExitThrow converts process.exit into a thrown error', async () => {
   await assert.rejects(
     withProcessExitThrow(() => {


### PR DESCRIPTION
## Summary
- add coverage that withProcessExitThrow restores process.exit after synchronous callback failures

## Tests
- pnpm --dir cli run build && node --test cli/dist/testUtils/processExit.test.js
- pnpm --dir cli test