### PR TITLE
test(cli): assert capability schemas take no args

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -81,6 +81,24 @@ test('capability tools list the full supported keyframe property set', async () 
   )
 })
 
+test('capability tool schemas accept no arguments', () => {
+  const getCapabilities = TOOLS.find((tool) => tool.name === 'get_capabilities')
+  const listKeyframeableProperties = TOOLS.find(
+    (tool) => tool.name === 'list_keyframeable_properties',
+  )
+
+  assert.deepEqual(getCapabilities?.inputSchema, {
+    type: 'object',
+    properties: {},
+    required: [],
+  })
+  assert.deepEqual(listKeyframeableProperties?.inputSchema, {
+    type: 'object',
+    properties: {},
+    required: [],
+  })
+})
+
 function parseToolJson(result: CallToolResult): CapabilitiesToolPayload {
   const item = result.content[0]
   assert.equal(item?.type, 'text')

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -47,13 +47,13 @@ type KeyframeablePropertiesPayload = {
 export const getCapabilitiesTool: Tool = {
   name: 'get_capabilities',
   description: 'Return supported scene node kinds, patch operations, render formats, and keyframeable properties.',
-  inputSchema: { type: 'object', properties: {} },
+  inputSchema: { type: 'object', properties: {}, required: [] },
 }
 
 export const listKeyframeablePropertiesTool: Tool = {
   name: 'list_keyframeable_properties',
   description: 'Return property ids that can be animated with tracks/keyframes.',
-  inputSchema: { type: 'object', properties: {} },
+  inputSchema: { type: 'object', properties: {}, required: [] },
 }
 
 export async function handleGetCapabilities(): Promise<CallToolResult> {


### PR DESCRIPTION
## Summary
- make the no-argument capability MCP schemas explicitly declare an empty required list
- add a focused test that keeps both capability schemas aligned with that contract

## Tests
- pnpm test (in cli/)