### PR TITLE
docs: update capture frame export comment

### DIFF
--- a/src/export/captureFrame.ts
+++ b/src/export/captureFrame.ts
@@ -2,9 +2,9 @@
 
 /**
  * Deprecated. The export pipeline now renders frames via
- * `src/render/PixiExportRenderer.ts` instead of html-to-image. This
- * file is kept as an empty stub to avoid breaking any stale imports
- * during the transition; safe to delete once the worktree is
+ * Electron's `webContents.capturePage` path instead of html-to-image.
+ * This file is kept as an empty stub to avoid breaking any stale
+ * imports during the transition; safe to delete once the worktree is
  * confirmed clean of references.
  */
 export {}


### PR DESCRIPTION
## Summary
- Update the deprecated captureFrame stub comment to point at the current Electron capturePage export path.

## Verification
- pnpm exec eslint src/export/captureFrame.ts
- rg -n "from ['\"]@?/?.*captureFrame|import\(.*captureFrame|captureFrame" src cli figma-plugin --glob '!figma-plugin/src/code.ts' (no matches)

Note: root pnpm run typecheck currently fails on existing unrelated TypeScript errors before this change.