### PR TITLE
test(cli): cover process exit helper returns

### DIFF
--- a/cli/src/testUtils/processExit.test.ts
+++ b/cli/src/testUtils/processExit.test.ts
@@ -53,6 +53,21 @@ test('withProcessExitThrow restores process.exit after sync callback failures', 
   assert.equal(process.exit, previousExit)
 })
 
+test('withProcessExitThrow returns sync callback values', async () => {
+  const value = await withProcessExitThrow(() => 'render complete')
+
+  assert.equal(value, 'render complete')
+})
+
+test('withProcessExitThrow returns async callback values', async () => {
+  const value = await withProcessExitThrow(async () => {
+    await Promise.resolve()
+    return 'render complete'
+  })
+
+  assert.equal(value, 'render complete')
+})
+
 test('withProcessExitThrow converts process.exit into a thrown error', async () => {
   await assert.rejects(
     withProcessExitThrow(() => {


### PR DESCRIPTION
## Summary\n- add sync and async return-value coverage for the CLI process exit test helper\n\n## Tests\n- pnpm --dir cli test -- --test-name-pattern withProcessExitThrow