### PR TITLE
fix(cli): handle malformed inspect MCP scenes

### DIFF
--- a/cli/src/mcp/inspectScene.test.ts
+++ b/cli/src/mcp/inspectScene.test.ts
@@ -34,6 +34,23 @@ test('inspect_scene reports missing files as MCP errors', async () => {
   assert.match(text, /^inspect_scene: failed to read /)
 })
 
+test('inspect_scene reports malformed scene files as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-mcp-'))
+  const scenePath = path.join(dir, 'broken.hype')
+
+  try {
+    fs.writeFileSync(scenePath, 'not a yjs update')
+
+    const result = await handleInspectScene({ scene: scenePath })
+
+    assert.equal(result.isError, true)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    assert.match(text, new RegExp(`^inspect_scene: failed to inspect ${scenePath}:`))
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('inspect_scene returns editable scene JSON for readable scenes', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-mcp-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/inspectScene.ts
+++ b/cli/src/mcp/tools/inspectScene.ts
@@ -54,12 +54,26 @@ export async function handleInspectScene(
     }
   }
 
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: JSON.stringify(inspectScene(new Uint8Array(bytes)), null, 2),
-      },
-    ],
+  try {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(inspectScene(new Uint8Array(bytes)), null, 2),
+        },
+      ],
+    }
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `inspect_scene: failed to inspect ${parsed.data.scene}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+    }
   }
 }


### PR DESCRIPTION
## Summary
- return a structured MCP error when inspect_scene reads malformed .hype data
- add regression coverage for malformed inspect_scene inputs

## Tests
- pnpm --dir cli test