### PR TITLE
test(cli): cover sync env helper failures

### DIFF
--- a/cli/src/testUtils/env.test.ts
+++ b/cli/src/testUtils/env.test.ts
@@ -64,3 +64,22 @@ test('withEnvVar restores values after async callback failures', async () => {
     delete process.env[name]
   }
 })
+
+test('withEnvVar restores values after sync callback failures', async () => {
+  const name = 'HYPERMOTION_TEST_ENV_SYNC_THROW'
+  process.env[name] = 'before'
+
+  try {
+    await assert.rejects(
+      withEnvVar(name, 'during', () => {
+        assert.equal(process.env[name], 'during')
+        throw new Error('callback failed')
+      }),
+      /callback failed/,
+    )
+
+    assert.equal(process.env[name], 'before')
+  } finally {
+    delete process.env[name]
+  }
+})


### PR DESCRIPTION
## Summary
- Add coverage that withEnvVar restores the previous value after a synchronous callback throws.

## Verification
- pnpm test