### PR TITLE
chore(cli): share doctor capability constants

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander'
 import os from 'node:os'
 import { locateDesktopApp } from '../electron/locator.js'
+import { MCP_TOOLS, RENDER_FORMATS, RENDER_QUALITIES } from '../mcp/tools/capabilities.js'
 import { CLI_VERSION } from '../version.js'
 
 export interface DoctorReport {
@@ -51,25 +52,10 @@ export async function getDoctorReport(): Promise<DoctorReport> {
       'doctor',
       'serve --mcp',
     ],
-    mcpTools: [
-      'doctor',
-      'get_capabilities',
-      'create_scene',
-      'info_scene',
-      'inspect_scene',
-      'patch_scene',
-      'validate_scene',
-      'list_layers',
-      'get_layer',
-      'list_tracks',
-      'list_cameras',
-      'open_scene',
-      'render_scene',
-      'list_keyframeable_properties',
-    ],
+    mcpTools: [...MCP_TOOLS],
     render: {
-      formats: ['mp4', 'webm', 'gif'],
-      qualities: ['comp', '720p', '2k', '4k'],
+      formats: [...RENDER_FORMATS],
+      qualities: [...RENDER_QUALITIES],
       fileSceneInput: true,
     },
   }

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -5,7 +5,7 @@ import { NODE_KINDS, PATCH_OPERATION_TYPES, PROPERTY_IDS } from '../../scene/bui
 
 const VALIDATION_TOOLS = ['validate_scene'] as const
 const QUERY_TOOLS = ['list_layers', 'get_layer', 'list_tracks', 'list_cameras'] as const
-const MCP_TOOLS = [
+export const MCP_TOOLS = [
   'doctor',
   'get_capabilities',
   'create_scene',
@@ -21,8 +21,8 @@ const MCP_TOOLS = [
   'render_scene',
   'list_keyframeable_properties',
 ] as const
-const RENDER_FORMATS = ['mp4', 'webm', 'gif'] as const
-const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
+export const RENDER_FORMATS = ['mp4', 'webm', 'gif'] as const
+export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
 
 type CapabilitiesPayload = {
   sceneExtension: '.hype'


### PR DESCRIPTION
## Summary
- export the CLI capability tool and render preset constants
- reuse those constants in the doctor report to avoid a duplicate MCP tool/render list

## Tests
- pnpm test