### PR TITLE
test(cli): make doctor MCP schema explicit

### DIFF
--- a/cli/src/mcp/doctor.test.ts
+++ b/cli/src/mcp/doctor.test.ts
@@ -14,6 +14,7 @@ test('doctor input schema accepts no arguments', () => {
   assert.deepEqual(doctorTool.inputSchema, {
     type: 'object',
     properties: {},
+    required: [],
   })
 })
 

--- a/cli/src/mcp/tools/doctor.ts
+++ b/cli/src/mcp/tools/doctor.ts
@@ -6,7 +6,7 @@ import { getDoctorReport } from '../../commands/doctor.js'
 export const doctorTool: Tool = {
   name: 'doctor',
   description: 'Check hyper-motion CLI, desktop app, scene format, render, and MCP capabilities.',
-  inputSchema: { type: 'object', properties: {} },
+  inputSchema: { type: 'object', properties: {}, required: [] },
 }
 
 export async function handleDoctor(): Promise<CallToolResult> {


### PR DESCRIPTION
## Summary
- make the doctor MCP tool's no-argument input schema explicit with an empty required list
- update the existing doctor MCP schema test expectation

## Tests
- pnpm test (from cli/)