### PR TITLE
test(cli): cover empty track filter results

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -206,6 +206,12 @@ test('query scene MCP handlers return layers, tracks, and cameras', async () => 
       ['fade-title', 'move-root'],
     )
 
+    const unrelatedTracksResult = await handleListTracks({ scene: scenePath, nodeId: 'missing' })
+    const unrelatedTracksText =
+      unrelatedTracksResult.content[0]?.type === 'text' ? unrelatedTracksResult.content[0].text : ''
+    const unrelatedTracksPayload = JSON.parse(unrelatedTracksText) as { tracks: unknown[] }
+    assert.deepEqual(unrelatedTracksPayload.tracks, [])
+
     const camerasResult = await handleListCameras({ scene: scenePath })
     const camerasText = camerasResult.content[0]?.type === 'text' ? camerasResult.content[0].text : ''
     const camerasPayload = JSON.parse(camerasText) as {


### PR DESCRIPTION
## Summary
- add MCP query coverage for empty list_tracks filter results

## Tests
- pnpm --dir cli test