### PR TITLE
fix(cli): surface plain-text render errors

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { driveHeadlessRender } from './driver.js'
+
+test('driveHeadlessRender surfaces plain-text error sentinels', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "await import('node:fs').then((fs) => fs.writeFileSync(`${out}.error`, 'encoder failed before JSON'))",
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await assert.rejects(
+      driveHeadlessRender({
+        appPath,
+        outputPath,
+        format: 'mp4',
+        quality: 'comp',
+        fps: 30,
+      }),
+      /encoder failed before JSON/,
+    )
+    assert.equal(fs.existsSync(`${outputPath}.error`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -127,8 +127,13 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
       let message = 'Render failed (no details available)'
       try {
         const raw = fs.readFileSync(errorPath, 'utf-8')
-        const data = JSON.parse(raw) as { message?: string }
-        if (data.message) message = data.message
+        try {
+          const data = JSON.parse(raw) as { message?: string }
+          if (data.message) message = data.message
+        } catch {
+          const text = raw.trim()
+          if (text) message = text
+        }
       } catch {
         /* best effort — fall through with the generic message */
       }


### PR DESCRIPTION
## Summary
- preserve plain-text render error sentinels when they are not valid JSON
- add a focused CLI driver test with a fake app writing a text error sentinel

## Tests
- pnpm test