### PR TITLE
Tidy validate command option typing

### DIFF
--- a/cli/src/commands/validate.ts
+++ b/cli/src/commands/validate.ts
@@ -4,24 +4,36 @@ import { Command } from 'commander'
 import fs from 'node:fs'
 import { validateScene, type SceneValidationResult } from '../scene/build.js'
 
+type ValidateCommandOptions = {
+  json?: boolean
+}
+
 export function validateCommand(): Command {
   return new Command('validate')
     .description('Validate a .hype scene file for agent-editable structural consistency.')
     .argument('<scene>', 'Path to a .hype scene file')
     .option('--json', 'Output validation result as JSON')
-    .action((scenePath: string, options: { json?: boolean }) => {
+    .action((scenePath: string, options: ValidateCommandOptions) => {
       let bytes: Buffer
       let result: SceneValidationResult
       try {
         bytes = fs.readFileSync(scenePath)
       } catch (err) {
-        console.error(`[validate] failed to read ${scenePath}: ${err instanceof Error ? err.message : err}`)
+        console.error(
+          `[validate] failed to read ${scenePath}: ${
+            err instanceof Error ? err.message : err
+          }`,
+        )
         process.exit(2)
       }
       try {
         result = validateScene(new Uint8Array(bytes))
       } catch (err) {
-        console.error(`[validate] ${scenePath} doesn't look like a valid .hype file: ${err instanceof Error ? err.message : err}`)
+        console.error(
+          `[validate] ${scenePath} doesn't look like a valid .hype file: ${
+            err instanceof Error ? err.message : err
+          }`,
+        )
         process.exit(2)
       }
       if (options.json) {


### PR DESCRIPTION
## Summary
- add a named options type for the validate CLI command
- reflow validate command read/parse diagnostics for consistency with neighboring commands

## Tests
- pnpm test