### PR TITLE
fix(cli): handle missing patch scene files

### DIFF
--- a/cli/src/mcp/patchScene.test.ts
+++ b/cli/src/mcp/patchScene.test.ts
@@ -32,6 +32,24 @@ test('patch_scene reports invalid arguments as MCP errors', async () => {
   assert.match(text, /^patch_scene: invalid arguments/)
 })
 
+test('patch_scene reports missing files as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-patch-missing-'))
+  const missingScene = path.join(dir, 'scene.hype')
+
+  try {
+    const result = await handlePatchScene({
+      scene: missingScene,
+      patch: { ops: [{ op: 'setMeta', patch: { name: 'Patched' } }] },
+    })
+
+    assert.equal(result.isError, true)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    assert.match(text, new RegExp(`^patch_scene: failed to read ${escapeRegExp(missingScene)}:`))
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('patch_scene writes alternate output without applying live', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-patch-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/patchScene.ts
+++ b/cli/src/mcp/tools/patchScene.ts
@@ -54,7 +54,22 @@ export async function handlePatchScene(
     typeof parsed.data.patch === 'string'
       ? (JSON.parse(parsed.data.patch) as ScenePatch | PatchOperation[])
       : (parsed.data.patch as ScenePatch | PatchOperation[])
-  const bytes = fs.readFileSync(parsed.data.scene)
+  let bytes: Buffer
+  try {
+    bytes = fs.readFileSync(parsed.data.scene)
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `patch_scene: failed to read ${parsed.data.scene}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+    }
+  }
   const next = applyScenePatch(new Uint8Array(bytes), patch)
   fs.mkdirSync(path.dirname(output), { recursive: true })
   fs.writeFileSync(output, Buffer.from(next))


### PR DESCRIPTION
## Summary\n- return structured MCP errors when patch_scene cannot read the input scene\n- add regression coverage for missing patch scene files\n\n## Tests\n- pnpm --dir cli test -- --test-name-pattern patch_scene