### PR TITLE
docs(cli): mention render error sentinel cleanup

### DIFF
--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -5,8 +5,8 @@
  *
  * Wire diagram:
  *
- *   1. CLI deletes any stale `<output>` and `<output>.done` from a
- *      previous run.
+ *   1. CLI deletes any stale `<output>`, `<output>.done`, and
+ *      `<output>.error` from a previous run.
  *   2. CLI spawns the .app binary with `--render --out=<path> ...`.
  *   3. Inside the binary, `app.requestSingleInstanceLock()` either
  *      succeeds (we're the first instance) or fails (another hyper-motion


### PR DESCRIPTION
## Summary
- update the CLI headless render driver wire diagram to include stale `<output>.error` cleanup
- keep the comment aligned with the existing cleanup code

## Verification
- `pnpm --dir cli test`

## Notes
- `pnpm lint` and `pnpm typecheck` are currently red on pre-existing app-level issues outside this comment-only change.