### PR TITLE
Tighten CLI node kind list typing

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -65,7 +65,7 @@ export const NODE_KINDS = [
   'component',
   'instance',
   'camera',
-] as const
+] as const satisfies readonly NodeKindJson[]
 
 export interface SizeJson extends Record<string, unknown> {
   width?: number | 'hug' | 'fill'


### PR DESCRIPTION
## Summary
- tie the CLI runtime node kind list back to the NodeKindJson union with a satisfies check

## Verification
- pnpm --dir cli test

Labels: codex/codex-automation are not present in this repo.