### PR TITLE
docs(cli): clarify saved scene rendering

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -45,7 +45,7 @@ Quality presets: `comp` (matches the scene canvas — fastest), `720p`,
 Render targets whichever scene is currently loaded in your desktop app.
 To script a scene from JSON, build a `.hype` file with
 `hypermotion create`, inspect it with `hypermotion info`, and pass it to
-compatible desktop builds with `hypermotion render --scene <path>`.
+the installed desktop app with `hypermotion render --scene <path>`.
 
 ## MCP server — AI agent integration
 

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -9,9 +9,8 @@
  * off-screen window, loads the scene, runs the export pipeline, and
  * writes the rendered file to `<out>`.
  *
- * `--scene <path>` forwards a saved .hype file to desktop builds that
- * support file-based rendering; otherwise the current desktop scene is
- * rendered.
+ * `--scene <path>` renders a saved .hype file; without it, the current
+ * desktop scene is rendered.
  */
 
 import { Command } from 'commander'

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -33,7 +33,7 @@ export interface HeadlessRenderRequest {
   format: 'mp4' | 'webm' | 'gif'
   quality: 'comp' | '720p' | '2k' | '4k'
   fps: number
-  /** Optional .hype scene path to forward to compatible desktop builds. */
+  /** Optional .hype scene path to render instead of the current desktop scene. */
   scenePath?: string
 }
 

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -4,8 +4,8 @@
  * `render_scene` MCP tool.
  *
  * Renders the user's current desktop scene to MP4 / WebM / GIF by
- * driving the installed desktop app. A .hype scene path is accepted and
- * forwarded to desktop builds that support file-based rendering.
+ * driving the installed desktop app. A .hype scene path renders that saved
+ * scene instead of the current desktop scene.
  *
  * Returns the absolute output path on success, or a descriptive error
  * if the app isn't installed or the render fails.
@@ -33,7 +33,7 @@ const RenderInput = z.object({
     .string()
     .optional()
     .describe(
-      'Path to a .hype scene file. Forwarded to compatible desktop builds for file-based rendering.',
+      'Path to a .hype scene file to render instead of the current desktop scene.',
     ),
 })
 
@@ -41,8 +41,8 @@ export const renderSceneTool: Tool = {
   name: 'render_scene',
   description:
     'Render the current scene loaded in the desktop app to MP4, WebM, or GIF. ' +
-    'A `scene` path is forwarded to compatible desktop builds for file-based ' +
-    'rendering. Drives the installed desktop app under the hood.',
+    'A `scene` path renders a saved .hype file instead. Drives the installed ' +
+    'desktop app under the hood.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -66,7 +66,7 @@ export const renderSceneTool: Tool = {
       scene: {
         type: 'string',
         description:
-          'Path to a .hype scene file. Forwarded to compatible desktop builds for file-based rendering.',
+          'Path to a .hype scene file to render instead of the current desktop scene.',
       },
     },
     required: ['output'],


### PR DESCRIPTION
## Summary
- clarify that `--scene` renders saved .hype files through the installed desktop app
- update matching MCP render_scene schema/help text and driver comment

## Tests
- `pnpm --dir cli test`