### PR TITLE
test(cli): cover sync stream capture restoration

### DIFF
--- a/cli/src/testUtils/stdout.test.ts
+++ b/cli/src/testUtils/stdout.test.ts
@@ -62,6 +62,26 @@ test('captureStderr invokes write callbacks', async () => {
   assert.equal(callbackCalled, true)
 })
 
+test('captureStdout restores the writer after sync callbacks', async () => {
+  const originalWrite = process.stdout.write
+
+  await captureStdout(() => {
+    process.stdout.write('render complete')
+  })
+
+  assert.equal(process.stdout.write, originalWrite)
+})
+
+test('captureStderr restores the writer after sync callbacks', async () => {
+  const originalWrite = process.stderr.write
+
+  await captureStderr(() => {
+    process.stderr.write('render failed')
+  })
+
+  assert.equal(process.stderr.write, originalWrite)
+})
+
 test('captureStdout restores the writer after async callbacks', async () => {
   const originalWrite = process.stdout.write
 


### PR DESCRIPTION
## Summary
- add stdout/stderr capture utility coverage for restoring patched writers after synchronous callbacks

## Tests
- pnpm --dir cli run build && node --test cli/dist/testUtils/stdout.test.js
- pnpm --dir cli test