### PR TITLE
chore(cli): share render option constants

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -3,7 +3,8 @@
 import { Command } from 'commander'
 import os from 'node:os'
 import { locateDesktopApp } from '../electron/locator.js'
-import { MCP_TOOLS, RENDER_FORMATS, RENDER_QUALITIES } from '../mcp/tools/capabilities.js'
+import { MCP_TOOLS } from '../mcp/tools/capabilities.js'
+import { RENDER_FORMATS, RENDER_QUALITIES } from '../renderOptions.js'
 import { CLI_VERSION } from '../version.js'
 
 export interface DoctorReport {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -18,12 +18,15 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { locateDesktopApp } from '../electron/locator.js'
 import { driveHeadlessRender } from '../electron/driver.js'
+import {
+  RENDER_FORMATS,
+  RENDER_QUALITIES,
+  type RenderFormat,
+  type RenderQuality,
+} from '../renderOptions.js'
 
-type Format = 'mp4' | 'webm' | 'gif'
-type Quality = 'comp' | '720p' | '2k' | '4k'
-
-const FORMATS = ['mp4', 'webm', 'gif'] as const
-const QUALITIES = ['comp', '720p', '2k', '4k'] as const
+const FORMAT_HELP = RENDER_FORMATS.join(' / ')
+const QUALITY_HELP = RENDER_QUALITIES.join(' / ')
 
 interface RenderOptions {
   output: string
@@ -59,14 +62,14 @@ export function renderCommand(): Command {
 
       const requestedFormat = opts.format ?? inferFormat(outputPath)
       if (!isFormat(requestedFormat)) {
-        console.error(`[render] unsupported format: ${requestedFormat} (use mp4 / webm / gif)`)
+        console.error(`[render] unsupported format: ${requestedFormat} (use ${FORMAT_HELP})`)
         process.exit(1)
       }
       const format = requestedFormat
 
       const requestedQuality = opts.quality ?? 'comp'
       if (!isQuality(requestedQuality)) {
-        console.error(`[render] unsupported quality: ${requestedQuality} (use comp / 720p / 2k / 4k)`)
+        console.error(`[render] unsupported quality: ${requestedQuality} (use ${QUALITY_HELP})`)
         process.exit(1)
       }
       const quality = requestedQuality
@@ -126,16 +129,16 @@ export function renderCommand(): Command {
     })
 }
 
-function inferFormat(outPath: string): Format {
+function inferFormat(outPath: string): RenderFormat {
   const ext = path.extname(outPath).toLowerCase().slice(1)
   if (isFormat(ext)) return ext
   return 'mp4'
 }
 
-function isFormat(value: string): value is Format {
-  return FORMATS.includes(value as Format)
+function isFormat(value: string): value is RenderFormat {
+  return RENDER_FORMATS.includes(value as RenderFormat)
 }
 
-function isQuality(value: string): value is Quality {
-  return QUALITIES.includes(value as Quality)
+function isQuality(value: string): value is RenderQuality {
+  return RENDER_QUALITIES.includes(value as RenderQuality)
 }

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -2,6 +2,7 @@
 
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import { NODE_KINDS, PATCH_OPERATION_TYPES, PROPERTY_IDS } from '../../scene/build.js'
+import { RENDER_FORMATS, RENDER_QUALITIES } from '../../renderOptions.js'
 
 const VALIDATION_TOOLS = ['validate_scene'] as const
 const QUERY_TOOLS = ['list_layers', 'get_layer', 'list_tracks', 'list_cameras'] as const
@@ -21,9 +22,6 @@ export const MCP_TOOLS = [
   'render_scene',
   'list_keyframeable_properties',
 ] as const
-export const RENDER_FORMATS = ['mp4', 'webm', 'gif'] as const
-export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
-
 type CapabilitiesPayload = {
   sceneExtension: '.hype'
   mcpTools: typeof MCP_TOOLS

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -17,15 +17,20 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { locateDesktopApp } from '../../electron/locator.js'
 import { driveHeadlessRender } from '../../electron/driver.js'
+import {
+  RENDER_FORMATS,
+  RENDER_QUALITIES,
+  type RenderFormat,
+} from '../../renderOptions.js'
 
 const RenderInput = z.object({
   output: z.string().describe('Absolute or relative path where the rendered file should be written'),
   format: z
-    .enum(['mp4', 'webm', 'gif'])
+    .enum(RENDER_FORMATS)
     .optional()
     .describe('Output format. Defaults to inferred from the output file extension.'),
   quality: z
-    .enum(['comp', '720p', '2k', '4k'])
+    .enum(RENDER_QUALITIES)
     .optional()
     .describe('Output resolution preset. `comp` matches the scene canvas size (fastest). Default: comp.'),
   fps: z.number().int().positive().max(120).optional().describe('Frame rate. Default: 30.'),
@@ -49,12 +54,12 @@ export const renderSceneTool: Tool = {
       output: { type: 'string', description: 'Output file path' },
       format: {
         type: 'string',
-        enum: ['mp4', 'webm', 'gif'],
+        enum: [...RENDER_FORMATS],
         description: 'Output format. Defaults to inferred from the output extension.',
       },
       quality: {
         type: 'string',
-        enum: ['comp', '720p', '2k', '4k'],
+        enum: [...RENDER_QUALITIES],
         description: 'Resolution preset. `comp` matches scene canvas size. Default: comp.',
       },
       fps: {
@@ -157,8 +162,8 @@ export async function handleRenderScene(
   }
 }
 
-function inferFormat(outPath: string): 'mp4' | 'webm' | 'gif' {
+function inferFormat(outPath: string): RenderFormat {
   const ext = path.extname(outPath).toLowerCase().slice(1)
-  if (ext === 'mp4' || ext === 'webm' || ext === 'gif') return ext
+  if (RENDER_FORMATS.includes(ext as RenderFormat)) return ext as RenderFormat
   return 'mp4'
 }

--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const RENDER_FORMATS = ['mp4', 'webm', 'gif'] as const
+export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
+
+export type RenderFormat = (typeof RENDER_FORMATS)[number]
+export type RenderQuality = (typeof RENDER_QUALITIES)[number]


### PR DESCRIPTION
## Summary
- Add shared CLI render format and quality constants
- Reuse them in render command, doctor report, MCP capabilities, and render_scene schema

## Tests
- pnpm test (in cli/)