### PR TITLE
docs: align scene doc storage types

### DIFF
--- a/src/scene/doc.ts
+++ b/src/scene/doc.ts
@@ -54,10 +54,10 @@ const DEFAULT_UI_STATE: UiStateSlab = {
  * Y.Doc shape:
  *
  *   doc.getMap('scene')
- *     ├── meta    Y.Map<keyof SceneMeta, any>
+ *     ├── meta    Y.Map<unknown>          // flat SceneMeta fields
  *     ├── root    string (NodeId of the scene root)
- *     ├── nodes   Y.Map<NodeId, Y.Map>     // each value is a node's flat Y.Map
- *     └── tracks  Y.Map<TrackId, Y.Map>    // each value is a track's flat Y.Map
+ *     ├── nodes   Y.Map<Y.Map<unknown>>   // each value is a node's flat Y.Map
+ *     └── tracks  Y.Map<Y.Map<unknown>>   // each value is a track's flat Y.Map
  *
  * Nodes are stored as Y.Maps with FLAT keys. Whole property groups
  * (transform, layout, appearance, size) are stored as plain JS objects


### PR DESCRIPTION
## Summary
- Update the Y.Doc shape comment in src/scene/doc.ts to match the current Y.Map<unknown>-based storage boundary.
- Remove the stale comment-only any/keyed-map wording from the scene storage diagram.

## Verification
- PASS: pnpm exec eslint src/scene/doc.ts
- PASS: git diff --check
- NOTE: pnpm lint currently fails on unrelated existing React Hooks / refresh lint errors outside this change.
- NOTE: pnpm typecheck currently fails on unrelated existing TypeScript errors outside this change.