### PR TITLE
test(cli): cover JSON render error sentinels

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -84,3 +84,38 @@ test('driveHeadlessRender surfaces plain-text error sentinels', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('driveHeadlessRender surfaces JSON error sentinel messages', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(`${out}.error`, JSON.stringify({ message: 'encoder reported JSON failure' }));",
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await assert.rejects(
+      driveHeadlessRender({
+        appPath,
+        outputPath,
+        format: 'mp4',
+        quality: 'comp',
+        fps: 30,
+      }),
+      /encoder reported JSON failure/,
+    )
+    assert.equal(fs.existsSync(`${outputPath}.error`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add CLI driver coverage for JSON-formatted render error sentinels
- verify the sentinel is cleaned up after surfacing the renderer message

## Tests
- pnpm --dir cli run build && node --test cli/dist/electron/driver.test.js
- pnpm --dir cli test