### PR TITLE
Use forced file removal for render cleanup

### DIFF
--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -171,7 +171,7 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
 
 function cleanFile(p: string): void {
   try {
-    if (fs.existsSync(p)) fs.unlinkSync(p)
+    fs.rmSync(p, { force: true })
   } catch {
     /* best-effort */
   }


### PR DESCRIPTION
## Summary
- replace the render cleanup helper's exists-then-unlink sequence with forced removal
- keep cleanup best-effort while avoiding a small existence-check race window

## Tests
- pnpm --dir cli test
