### PR TITLE
Type inspect command options

### DIFF
--- a/cli/src/commands/inspect.ts
+++ b/cli/src/commands/inspect.ts
@@ -4,12 +4,16 @@ import { Command } from 'commander'
 import fs from 'node:fs'
 import { inspectScene } from '../scene/build.js'
 
+type InspectCommandOptions = {
+  json: boolean
+}
+
 export function inspectCommand(): Command {
   return new Command('inspect')
     .description('Print the full editable scene graph for a .hype file.')
     .argument('<scene>', 'Path to a .hype scene file')
     .option('--json', 'Output JSON (default)', true)
-    .action((scenePath: string) => {
+    .action((scenePath: string, _options: InspectCommandOptions) => {
       let bytes: Buffer
       try {
         bytes = fs.readFileSync(scenePath)


### PR DESCRIPTION
## Summary
- Add an explicit options type for the CLI inspect command action.
- Preserve current JSON-only inspect output behavior.

## Tests
- pnpm test