### PR TITLE
test(cli): cover async capture cleanup

### DIFF
--- a/cli/src/testUtils/stdout.test.ts
+++ b/cli/src/testUtils/stdout.test.ts
@@ -117,11 +117,41 @@ test('captureStdout restores the writer when the callback throws', async () => {
   assert.equal(process.stdout.write, originalWrite)
 })
 
+test('captureStdout restores the writer when an async callback rejects', async () => {
+  const originalWrite = process.stdout.write
+
+  await assert.rejects(
+    captureStdout(async () => {
+      process.stdout.write('render complete')
+      await Promise.resolve()
+      throw new Error('boom')
+    }),
+    /boom/,
+  )
+
+  assert.equal(process.stdout.write, originalWrite)
+})
+
 test('captureStderr restores the writer when the callback throws', async () => {
   const originalWrite = process.stderr.write
 
   await assert.rejects(
     captureStderr(() => {
+      throw new Error('boom')
+    }),
+    /boom/,
+  )
+
+  assert.equal(process.stderr.write, originalWrite)
+})
+
+test('captureStderr restores the writer when an async callback rejects', async () => {
+  const originalWrite = process.stderr.write
+
+  await assert.rejects(
+    captureStderr(async () => {
+      process.stderr.write('render failed')
+      await Promise.resolve()
       throw new Error('boom')
     }),
     /boom/,


### PR DESCRIPTION
## Summary\n- Add CLI stdout/stderr capture tests for async callback rejection cleanup.\n- Keep the change scoped to test infrastructure only.\n\n## Verification\n- pnpm exec tsc && node --test dist/testUtils/stdout.test.js\n- pnpm test