### PR TITLE
test(cli): narrow invalid track test type

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -10,10 +10,15 @@ import {
   validateScene,
   type SceneJson,
   type TextAnimationJson,
+  type TrackJson,
 } from './build.js'
 
 type PlainRecord = Record<string, unknown>
 type PlainSceneMap = Record<string, PlainRecord>
+type InvalidTrackJson = Omit<TrackJson, 'propertyId'> & { propertyId: string }
+type InvalidSceneJson = Omit<SceneJson, 'tracks'> & {
+  tracks: Record<string, InvalidTrackJson>
+}
 
 function sampleScene(): SceneJson {
   return {
@@ -786,11 +791,11 @@ test('validateScene rejects unsupported track property ids', () => {
         nodeId: 'title',
         propertyId: 'appearance.missing',
         keyframes: [],
-      },
+      } satisfies InvalidTrackJson,
     },
-  } as unknown as SceneJson
+  } satisfies InvalidSceneJson
 
-  const result = validateScene(buildSceneBytes(scene))
+  const result = validateScene(buildSceneBytes(scene as SceneJson))
 
   assert.equal(result.ok, false)
   assert.deepEqual(result.errors, [


### PR DESCRIPTION
## Summary
- replace a broad double assertion in the invalid track property test with a local invalid scene type
- keep the negative validation fixture explicit while preserving the intended invalid property id coverage

## Tests
- pnpm --dir cli test