### PR TITLE
Handle validate directories explicitly

### DIFF
--- a/cli/src/commands/validate.test.ts
+++ b/cli/src/commands/validate.test.ts
@@ -293,6 +293,26 @@ test('validate command reports missing scene files', async () => {
   }
 })
 
+test('validate command reports directories before reading scene bytes', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-dir-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  fs.mkdirSync(scenePath)
+  try {
+    const stderr = await withProcessExitThrow(() => captureStderr(() => {
+      assert.throws(
+        () => {
+          validateCommand().parse([scenePath], { from: 'user' })
+        },
+        { exitCode: 2 },
+      )
+    }))
+
+    assert.match(stderr, /^\[validate\] scene path is not a file: .*scene\.hype$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('validate command reports malformed scene files', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
   const scenePath = path.join(dir, 'malformed.hype')

--- a/cli/src/commands/validate.ts
+++ b/cli/src/commands/validate.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander'
 import fs from 'node:fs'
+import path from 'node:path'
 import { validateScene, type SceneValidationResult } from '../scene/build.js'
 
 type ValidateCommandOptions = {
@@ -14,13 +15,18 @@ export function validateCommand(): Command {
     .argument('<scene>', 'Path to a .hype scene file')
     .option('--json', 'Output validation result as JSON')
     .action((scenePath: string, options: ValidateCommandOptions) => {
+      const resolvedScenePath = path.resolve(scenePath)
       let bytes: Buffer
       let result: SceneValidationResult
+      if (fs.existsSync(resolvedScenePath) && !fs.statSync(resolvedScenePath).isFile()) {
+        console.error(`[validate] scene path is not a file: ${resolvedScenePath}`)
+        process.exit(2)
+      }
       try {
-        bytes = fs.readFileSync(scenePath)
+        bytes = fs.readFileSync(resolvedScenePath)
       } catch (err) {
         console.error(
-          `[validate] failed to read ${scenePath}: ${
+          `[validate] failed to read ${resolvedScenePath}: ${
             err instanceof Error ? err.message : err
           }`,
         )
@@ -30,7 +36,7 @@ export function validateCommand(): Command {
         result = validateScene(new Uint8Array(bytes))
       } catch (err) {
         console.error(
-          `[validate] ${scenePath} doesn't look like a valid .hype file: ${
+          `[validate] ${resolvedScenePath} doesn't look like a valid .hype file: ${
             err instanceof Error ? err.message : err
           }`,
         )


### PR DESCRIPTION
## Summary
- Resolve validate command scene paths before reading them
- Report directory inputs with a clear `scene path is not a file` error
- Add a focused regression test for directory inputs

## Tests
- `pnpm --dir cli test -- --test-name-pattern "validate command"` ✅

## Notes
- `pnpm lint` and `pnpm typecheck` are currently blocked by pre-existing app-side errors unrelated to this CLI change.