### PR TITLE
chore(scene): export scene node alias

### DIFF
--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -739,6 +739,7 @@ export type Node =
   | InstanceNode
   | CameraNode
 
+export type SceneNode = Node
 export type NodeKind = Node['kind']
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- export a SceneNode alias for the scene node union from the public scene types
- keeps imports explicit where Node would collide with the DOM Node type

## Verification
- pnpm -C cli test
- pnpm typecheck (fails on unrelated existing root TS errors; SceneNode export errors are gone)