### PR TITLE
test(cli): cover render error fallback

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -122,3 +122,38 @@ test('driveHeadlessRender surfaces JSON error sentinel messages', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('driveHeadlessRender falls back when JSON error sentinels omit messages', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(`${out}.error`, JSON.stringify({ code: 'ENCODER_FAILED' }));",
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await assert.rejects(
+      driveHeadlessRender({
+        appPath,
+        outputPath,
+        format: 'mp4',
+        quality: 'comp',
+        fps: 30,
+      }),
+      /Render failed \(no details available\)/,
+    )
+    assert.equal(fs.existsSync(`${outputPath}.error`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add a focused CLI driver test for JSON error sentinels that omit a message
- assert the generic fallback error is surfaced and the sentinel is cleaned up

## Verification
- pnpm test