### PR TITLE
Harden CLI render error sentinel parsing

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -157,3 +157,38 @@ test('driveHeadlessRender falls back when JSON error sentinels omit messages', a
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('driveHeadlessRender falls back when JSON error sentinel messages are not strings', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(`${out}.error`, JSON.stringify({ message: 42 }));",
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await assert.rejects(
+      driveHeadlessRender({
+        appPath,
+        outputPath,
+        format: 'mp4',
+        quality: 'comp',
+        fps: 30,
+      }),
+      /Render failed \(no details available\)/,
+    )
+    assert.equal(fs.existsSync(`${outputPath}.error`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -128,8 +128,8 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
       try {
         const raw = fs.readFileSync(errorPath, 'utf-8')
         try {
-          const data = JSON.parse(raw) as { message?: string }
-          if (data.message) message = data.message
+          const data = JSON.parse(raw) as { message?: unknown }
+          if (typeof data.message === 'string' && data.message) message = data.message
         } catch {
           const text = raw.trim()
           if (text) message = text


### PR DESCRIPTION
## Summary
- Treat JSON render error sentinel messages as usable only when they are strings
- Add a regression test for non-string JSON sentinel messages falling back cleanly

## Tests
- pnpm test