### PR TITLE
test(cli): cover stale render error sentinel cleanup

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -88,6 +88,43 @@ test('driveHeadlessRender surfaces plain-text error sentinels', async () => {
   }
 })
 
+test('driveHeadlessRender clears stale error sentinels after successful renders', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(`${outputPath}.error`, 'stale failure')
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(out, 'fresh output');",
+      "fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: 12 }));",
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await driveHeadlessRender({
+      appPath,
+      outputPath,
+      format: 'mp4',
+      quality: 'comp',
+      fps: 30,
+    })
+
+    assert.equal(fs.readFileSync(outputPath, 'utf-8'), 'fresh output')
+    assert.equal(fs.existsSync(`${outputPath}.done`), false)
+    assert.equal(fs.existsSync(`${outputPath}.error`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('driveHeadlessRender surfaces JSON error sentinel messages', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
   const appPath = path.join(dir, 'fake-app.mjs')


### PR DESCRIPTION
## Summary
- Add a CLI render-driver test covering stale `.error` sentinel cleanup after a successful render
- Keep the change limited to existing fake-app test coverage

## Tests
- pnpm --dir cli test