### PR TITLE
Validate single-camera scene invariant

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -889,6 +889,27 @@ test('validateScene rejects cameras nested under scene nodes', () => {
   ])
 })
 
+test('validateScene rejects multiple camera nodes', () => {
+  const scene = sampleScene()
+  const camera = scene.nodes?.camera
+  if (!camera) throw new Error('missing sample camera')
+  scene.nodes = {
+    ...scene.nodes,
+    cameraB: {
+      ...camera,
+      id: 'cameraB',
+      name: 'Second Camera',
+    },
+  }
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'scene has multiple camera nodes: camera, cameraB',
+  ])
+})
+
 test('validateScene rejects duplicate child references', () => {
   const scene = sampleScene()
   const root = scene.nodes?.root

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -911,6 +911,13 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
     }
   }
 
+  const cameraIds = Object.entries(nodes)
+    .filter(([, raw]) => asRecord(raw).kind === 'camera')
+    .map(([id]) => id)
+  if (cameraIds.length > 1) {
+    errors.push(`scene has multiple camera nodes: ${cameraIds.join(', ')}`)
+  }
+
   for (const [id, raw] of Object.entries(tracks)) {
     const track = asRecord(raw)
     if (track.id !== id) errors.push(`track map key ${id} does not match track id: ${String(track.id)}`)


### PR DESCRIPTION
## Summary
- Reject authored .hype scenes that contain multiple camera nodes during CLI validation
- Add a focused regression test for the documented single-camera scene constraint

## Tests
- pnpm test