### PR TITLE
test(cli): cover non-numeric render fps

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -24,6 +24,21 @@ test('render command reports invalid fps before launching the app', async () => 
   assert.match(stderr, /^\[render\] invalid fps: 0$/m)
 })
 
+test('render command reports non-numeric fps before launching the app', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        renderCommand().parseAsync(['-o', 'out.mp4', '--fps', 'fast'], {
+          from: 'user',
+        }),
+        { exitCode: 1 },
+      )
+    })
+  })
+
+  assert.match(stderr, /^\[render\] invalid fps: fast$/m)
+})
+
 test('render command rejects fps values above the MCP limit before launching the app', async () => {
   const stderr = await captureStderr(() => {
     return withProcessExitThrow(async () => {


### PR DESCRIPTION
## Summary\n- add a focused CLI render command test for non-numeric FPS input\n- verifies the command exits before launching the desktop app\n\n## Tests\n- pnpm test (in cli/)