### PR TITLE
Validate malformed scene children fields

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -934,6 +934,22 @@ test('validateScene rejects child references to missing nodes', () => {
   assert.deepEqual(result.errors, ['node root has missing child: missing-child'])
 })
 
+test('validateScene rejects node children that are not arrays', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const nodes = scene.get('nodes') as Y.Map<Y.Map<unknown>>
+  nodes.get('root')?.set('children', 'title')
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'node root children must be an array',
+    'node title parent root does not list it as a child',
+  ])
+})
+
 test('validateScene rejects node ids that do not match their map key', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -899,6 +899,9 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
         errors.push(`node ${id} parent ${parent} does not list it as a child`)
       }
     }
+    if (node.children !== undefined && !Array.isArray(node.children)) {
+      errors.push(`node ${id} children must be an array`)
+    }
     const children = Array.isArray(node.children) ? node.children : []
     const seenChildren = new Set<string>()
     for (const child of children) {


### PR DESCRIPTION
## Summary
- reject malformed scene nodes whose children field is present but not an array
- add CLI validation coverage for the malformed children shape

## Tests
- pnpm --dir cli test