### PR TITLE
fix(cli): handle malformed MCP patch JSON

### DIFF
--- a/cli/src/mcp/patchScene.test.ts
+++ b/cli/src/mcp/patchScene.test.ts
@@ -32,6 +32,14 @@ test('patch_scene reports invalid arguments as MCP errors', async () => {
   assert.match(text, /^patch_scene: invalid arguments/)
 })
 
+test('patch_scene reports malformed JSON patches as MCP errors', async () => {
+  const result = await handlePatchScene({ scene: 'scene.hype', patch: '{bad json' })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.match(text, /^patch_scene: failed to parse patch JSON:/)
+})
+
 test('patch_scene reports missing files as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-patch-missing-'))
   const missingScene = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/patchScene.ts
+++ b/cli/src/mcp/tools/patchScene.ts
@@ -52,10 +52,25 @@ export async function handlePatchScene(
 
   const input: PatchInputData = parsed.data
   const output = path.resolve(input.output ?? input.scene)
-  const patch =
-    typeof input.patch === 'string'
-      ? (JSON.parse(input.patch) as ScenePatch | PatchOperation[])
-      : (input.patch as ScenePatch | PatchOperation[])
+  let patch: ScenePatch | PatchOperation[]
+  try {
+    patch =
+      typeof input.patch === 'string'
+        ? (JSON.parse(input.patch) as ScenePatch | PatchOperation[])
+        : (input.patch as ScenePatch | PatchOperation[])
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `patch_scene: failed to parse patch JSON: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+    }
+  }
   let bytes: Buffer
   try {
     bytes = fs.readFileSync(input.scene)


### PR DESCRIPTION
## Summary
- return a structured MCP error when patch_scene receives malformed JSON patch strings
- add a regression test for malformed patch JSON

## Tests
- pnpm test