### PR TITLE
fix(cli): report MCP patch apply errors

### DIFF
--- a/cli/src/mcp/patchScene.test.ts
+++ b/cli/src/mcp/patchScene.test.ts
@@ -58,6 +58,45 @@ test('patch_scene reports missing files as MCP errors', async () => {
   }
 })
 
+test('patch_scene reports invalid patch operations as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-patch-invalid-'))
+  const scenePath = path.join(dir, 'scene.hype')
+
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Original',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const result = await handlePatchScene({
+      scene: scenePath,
+      applyLive: false,
+      patch: { ops: [{ op: 'setNode', nodeId: 'missing', patch: { kind: 'text' } }] },
+    })
+
+    assert.equal(result.isError, true)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    assert.match(text, /^patch_scene: failed to apply patch: node does not exist: missing$/)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('patch_scene writes alternate output without applying live', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-patch-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/patchScene.ts
+++ b/cli/src/mcp/tools/patchScene.ts
@@ -87,7 +87,22 @@ export async function handlePatchScene(
       ],
     }
   }
-  const next = applyScenePatch(new Uint8Array(bytes), patch)
+  let next: Uint8Array
+  try {
+    next = applyScenePatch(new Uint8Array(bytes), patch)
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `patch_scene: failed to apply patch: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+    }
+  }
   fs.mkdirSync(path.dirname(output), { recursive: true })
   fs.writeFileSync(output, Buffer.from(next))
   const shouldApplyLive = input.applyLive ?? true


### PR DESCRIPTION
## Summary
- convert patch application failures in patch_scene into MCP error responses
- add coverage for invalid patch operations against a real .hype scene

## Tests
- pnpm --dir cli test