### PR TITLE
chore(cli): name env helper callback type

### DIFF
--- a/cli/src/testUtils/env.ts
+++ b/cli/src/testUtils/env.ts
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+type EnvVarCallback<T> = () => Promise<T> | T
+
 export async function withEnvVar<T>(
   name: string,
   value: string | undefined,
-  run: () => Promise<T> | T,
+  run: EnvVarCallback<T>,
 ): Promise<T> {
   const previous = process.env[name]
   if (value === undefined) {


### PR DESCRIPTION
## Summary\n- name the callback type used by the CLI env test helper\n- keep the helper behavior unchanged while matching adjacent test utility style\n\n## Verification\n- pnpm --dir cli test