### PR TITLE
test(cli): cover saved scene render forwarding

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -5,9 +5,47 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
+import type { HeadlessRenderRequest } from '../electron/driver.js'
 import { withProcessExitThrow } from '../testUtils/processExit.js'
-import { captureStderr } from '../testUtils/stdout.js'
+import { captureStderr, captureStdout } from '../testUtils/stdout.js'
 import { renderCommand } from './render.js'
+
+test('render command forwards saved scene paths to the driver', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-ok-'))
+  const scenePath = path.join(dir, 'scene with spaces.hype')
+  const outputPath = path.join(dir, 'exports', 'out.webm')
+  const appPath = path.join(dir, 'hyper-motion')
+  const calls: HeadlessRenderRequest[] = []
+  fs.writeFileSync(scenePath, 'fake scene')
+  try {
+    const stdout = await captureStdout(async () => {
+      await renderCommand({
+        locateApp: async () => appPath,
+        driveRender: async (req) => {
+          calls.push(req)
+        },
+      }).parseAsync(
+        ['--scene', scenePath, '-o', outputPath, '--quality', '720p', '--fps', '60'],
+        { from: 'user' },
+      )
+    })
+
+    assert.deepEqual(calls, [
+      {
+        appPath,
+        outputPath,
+        format: 'webm',
+        quality: '720p',
+        fps: 60,
+        scenePath,
+      },
+    ])
+    assert.match(stdout, new RegExp(`^\\[render\\] scene:   ${scenePath}$`, 'm'))
+    assert.equal(fs.existsSync(path.dirname(outputPath)), true)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
 
 test('render command reports invalid fps before launching the app', async () => {
   const stderr = await captureStderr(() => {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -17,7 +17,7 @@ import { Command } from 'commander'
 import path from 'node:path'
 import fs from 'node:fs'
 import { locateDesktopApp } from '../electron/locator.js'
-import { driveHeadlessRender } from '../electron/driver.js'
+import { driveHeadlessRender, type HeadlessRenderRequest } from '../electron/driver.js'
 import {
   RENDER_FORMATS,
   RENDER_QUALITIES,
@@ -36,7 +36,15 @@ interface RenderOptions {
   scene?: string
 }
 
-export function renderCommand(): Command {
+interface RenderCommandDeps {
+  locateApp?: () => Promise<string | null>
+  driveRender?: (req: HeadlessRenderRequest) => Promise<void>
+}
+
+export function renderCommand(deps: RenderCommandDeps = {}): Command {
+  const locateApp = deps.locateApp ?? locateDesktopApp
+  const driveRender = deps.driveRender ?? driveHeadlessRender
+
   return new Command('render')
     .description(
       "Render the current scene (whatever's loaded in the desktop app) " +
@@ -97,7 +105,7 @@ export function renderCommand(): Command {
         process.exit(2)
       }
 
-      const appPath = await locateDesktopApp()
+      const appPath = await locateApp()
       if (!appPath) {
         console.error(
           '[render] hyper-motion desktop app not found.\n' +
@@ -113,7 +121,7 @@ export function renderCommand(): Command {
       console.log(`[render] running… (the desktop app launches off-screen)`)
 
       try {
-        await driveHeadlessRender({
+        await driveRender({
           appPath,
           outputPath,
           format,


### PR DESCRIPTION
## Summary
- Add a focused render command test covering valid saved scene path forwarding to the driver
- Add lightweight dependency injection to renderCommand so the test avoids launching the desktop app

## Verification
- pnpm test (from cli/): passed, 221 tests
- pnpm typecheck (repo root): fails on unrelated existing app-level TypeScript errors in origin/main