### PR TITLE
test(cli): cover patch overwrite default

### DIFF
--- a/cli/src/commands/patch.test.ts
+++ b/cli/src/commands/patch.test.ts
@@ -55,3 +55,46 @@ test('patch command writes alternate output files', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('patch command overwrites the input scene by default', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-patch-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const patchPath = path.join(dir, 'patch.json')
+
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Before',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+    fs.writeFileSync(
+      patchPath,
+      JSON.stringify({ ops: [{ op: 'setMeta', patch: { name: 'After' } }] }),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await patchCommand().exitOverride().parseAsync([scenePath, '--from', patchPath], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^Patched .*scene\.hype → .*scene\.hype$/m)
+    assert.equal(readSceneSummary(fs.readFileSync(scenePath)).meta.name, 'After')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- Add CLI coverage for the default `hypermotion patch` behavior that overwrites the input scene when `--output` is omitted.

## Tests
- `pnpm --dir cli test`