### PR TITLE
fix(cli): reject query scene directories

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -91,6 +91,33 @@ test('query scene MCP handlers report missing scene files as MCP errors', async 
   }
 })
 
+test('query scene MCP handlers report directories as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-directory-query-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  fs.mkdirSync(scenePath)
+
+  try {
+    const cases: Array<{
+      name: string
+      run: () => Promise<CallToolResult>
+    }> = [
+      { name: 'list_layers', run: () => handleListLayers({ scene: scenePath }) },
+      { name: 'get_layer', run: () => handleGetLayer({ scene: scenePath, nodeId: 'title' }) },
+      { name: 'list_tracks', run: () => handleListTracks({ scene: scenePath }) },
+      { name: 'list_cameras', run: () => handleListCameras({ scene: scenePath }) },
+    ]
+
+    for (const entry of cases) {
+      const result = await entry.run()
+      assert.equal(result.isError, true)
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+      assert.equal(text, `${entry.name}: scene path is not a file: ${scenePath}`)
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('query scene MCP handlers report malformed scene files as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-malformed-query-'))
   const scenePath = path.join(dir, 'malformed.hype')

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -147,6 +147,22 @@ export async function handleListCameras(
 
 function read(toolName: QuerySceneToolName, scenePath: string): ReadSceneResult {
   try {
+    const stats = fs.statSync(scenePath)
+    if (!stats.isFile()) {
+      return {
+        ok: false,
+        result: {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `${toolName}: scene path is not a file: ${scenePath}`,
+            },
+          ],
+        },
+      }
+    }
+
     return { ok: true, scene: inspectScene(new Uint8Array(fs.readFileSync(scenePath))) }
   } catch (err) {
     return {


### PR DESCRIPTION
## Summary
- report directory scene paths as MCP errors before reading query-scene files
- add coverage for directory inputs across list_layers, get_layer, list_tracks, and list_cameras

## Tests
- pnpm test