### PR TITLE
test(cli): honor binary capture encodings

### DIFF
--- a/cli/src/testUtils/stdout.test.ts
+++ b/cli/src/testUtils/stdout.test.ts
@@ -36,6 +36,22 @@ test('captureStderr honors string chunk encodings', async () => {
   assert.equal(output, 'render failed')
 })
 
+test('captureStdout honors binary chunk encodings', async () => {
+  const output = await captureStdout(() => {
+    process.stdout.write(Buffer.from('render complete'), 'hex')
+  })
+
+  assert.equal(output, '72656e64657220636f6d706c657465')
+})
+
+test('captureStderr honors binary chunk encodings', async () => {
+  const output = await captureStderr(() => {
+    process.stderr.write(Buffer.from('render failed'), 'hex')
+  })
+
+  assert.equal(output, '72656e646572206661696c6564')
+})
+
 test('captureStdout invokes write callbacks', async () => {
   let callbackCalled = false
 

--- a/cli/src/testUtils/stdout.ts
+++ b/cli/src/testUtils/stdout.ts
@@ -7,7 +7,7 @@ function stringifyChunk(
   chunk: Parameters<typeof process.stdout.write>[0],
   encoding?: BufferEncoding,
 ): string {
-  if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString()
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString(encoding)
   if (encoding) return Buffer.from(chunk, encoding).toString()
   return chunk.toString()
 }


### PR DESCRIPTION
## Summary\n- Preserve explicit encodings when CLI stdout/stderr capture helpers receive binary chunks.\n- Add regression coverage for Buffer writes with hex encoding.\n\n## Tests\n- pnpm run build && node --test dist/testUtils/stdout.test.js\n- pnpm test