### PR TITLE
Handle blank render error messages

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -229,6 +229,41 @@ test('driveHeadlessRender falls back when JSON error sentinels omit messages', a
   }
 })
 
+test('driveHeadlessRender falls back when JSON error sentinel messages are blank', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(`${out}.error`, JSON.stringify({ message: '  \\n\\t  ' }));",
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await assert.rejects(
+      driveHeadlessRender({
+        appPath,
+        outputPath,
+        format: 'mp4',
+        quality: 'comp',
+        fps: 30,
+      }),
+      /Render failed \(no details available\)/,
+    )
+    assert.equal(fs.existsSync(`${outputPath}.error`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('driveHeadlessRender falls back when JSON error sentinel messages are not strings', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
   const appPath = path.join(dir, 'fake-app.mjs')

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -184,7 +184,7 @@ function hasErrorMessage(value: unknown): value is { message: string } {
     value !== null &&
     'message' in value &&
     typeof value.message === 'string' &&
-    value.message.length > 0
+    value.message.trim().length > 0
   )
 }
 


### PR DESCRIPTION
## Summary
- Treat whitespace-only JSON render error sentinel messages as missing details
- Add a CLI driver regression test for blank JSON error messages

## Tests
- pnpm test