### PR TITLE
Reject info_scene directory inputs

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -107,6 +107,22 @@ test('info_scene reports missing files as MCP errors', async () => {
   }
 })
 
+test('info_scene reports directories as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-directory-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  fs.mkdirSync(scenePath)
+
+  try {
+    const result = await handleInfoScene({ scene: scenePath })
+
+    assert.equal(result.isError, true)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    assert.equal(text, `info_scene: scene path is not a file: ${scenePath}`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('info_scene reports malformed scene files as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-malformed-'))
   const scenePath = path.join(dir, 'malformed.hype')

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -52,6 +52,19 @@ export async function handleInfoScene(
   const scenePath = input.scene
   let bytes: Buffer
   try {
+    const stats = fs.statSync(scenePath)
+    if (!stats.isFile()) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: `info_scene: scene path is not a file: ${scenePath}`,
+          },
+        ],
+      }
+    }
+
     bytes = fs.readFileSync(scenePath)
   } catch (err) {
     return {


### PR DESCRIPTION
## Summary
- preflight info_scene paths so directories return a clear MCP error
- add coverage for directory inputs in the info_scene MCP handler

## Tests
- pnpm --dir cli test