### PR TITLE
fix(cli): handle open scene stat failures

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -55,3 +55,28 @@ test('open_scene reports directories as MCP errors', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('open_scene reports stat failures as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-stat-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  fs.writeFileSync(scenePath, '')
+
+  try {
+    const result = await handleOpenScene(
+      { scene: scenePath },
+      {
+        existsSync: fs.existsSync,
+        statSync: () => {
+          throw new Error('stat failed')
+        },
+        openScene: async () => true,
+      },
+    )
+
+    assert.equal(result.isError, true)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    assert.equal(text, `open_scene: failed to read ${scenePath}: stat failed`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -10,6 +10,17 @@ const OpenInput = z.object({
   scene: z.string().describe('Path to a .hype scene file.'),
 })
 type OpenInputData = z.infer<typeof OpenInput>
+type OpenSceneDeps = {
+  existsSync: typeof fs.existsSync
+  statSync: typeof fs.statSync
+  openScene: typeof pushSceneToRunningApp
+}
+
+const defaultDeps: OpenSceneDeps = {
+  existsSync: fs.existsSync,
+  statSync: fs.statSync,
+  openScene: pushSceneToRunningApp,
+}
 
 export const openSceneTool: Tool = {
   name: 'open_scene',
@@ -25,6 +36,7 @@ export const openSceneTool: Tool = {
 
 export async function handleOpenScene(
   args: Record<string, unknown>,
+  deps: OpenSceneDeps = defaultDeps,
 ): Promise<CallToolResult> {
   const parsed = OpenInput.safeParse(args)
   if (!parsed.success) {
@@ -41,19 +53,35 @@ export async function handleOpenScene(
 
   const input: OpenInputData = parsed.data
   const scenePath = path.resolve(input.scene)
-  if (!fs.existsSync(scenePath)) {
+  if (!deps.existsSync(scenePath)) {
     return {
       isError: true,
       content: [{ type: 'text' as const, text: `Scene file not found: ${scenePath}` }],
     }
   }
-  if (!fs.statSync(scenePath).isFile()) {
+  let stats: fs.Stats
+  try {
+    stats = deps.statSync(scenePath)
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `open_scene: failed to read ${scenePath}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+    }
+  }
+  if (!stats.isFile()) {
     return {
       isError: true,
       content: [{ type: 'text' as const, text: `Scene path is not a file: ${scenePath}` }],
     }
   }
-  const opened = await pushSceneToRunningApp(scenePath)
+  const opened = await deps.openScene(scenePath)
   if (!opened) {
     return {
       isError: true,


### PR DESCRIPTION
## Summary
- Return a structured MCP error when open_scene cannot stat a scene path after existence checks
- Add focused coverage for the stat-failure path

## Tests
- pnpm --dir cli test -- openScene.test.js