### PR TITLE
fix(cli): handle open command stat failures

### DIFF
--- a/cli/src/commands/open.test.ts
+++ b/cli/src/commands/open.test.ts
@@ -89,6 +89,35 @@ test('open command reports directories before launching the app', async () => {
   }
 })
 
+test('open command reports stat failures before launching the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-stat-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  fs.writeFileSync(scenePath, '')
+  try {
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          openCommand({
+            locateApp: async () => path.join(dir, 'hyper-motion'),
+            existsSync: fs.existsSync,
+            statSync: () => {
+              throw new Error('stat failed')
+            },
+            spawnApp: () => {
+              throw new Error('should not launch')
+            },
+          }).parseAsync([scenePath], { from: 'user' }),
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.equal(stderr, `[open] failed to read ${scenePath}: stat failed\n`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('open command reports when the desktop app cannot be found', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-app-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -9,6 +9,8 @@ import { locateDesktopApp } from '../electron/locator.js'
 
 interface OpenCommandDeps {
   locateApp: typeof locateDesktopApp
+  existsSync: typeof fs.existsSync
+  statSync: typeof fs.statSync
   spawnApp: (
     command: string,
     args: string[],
@@ -18,29 +20,43 @@ interface OpenCommandDeps {
 
 const defaultDeps: OpenCommandDeps = {
   locateApp: locateDesktopApp,
+  existsSync: fs.existsSync,
+  statSync: fs.statSync,
   spawnApp: spawn,
 }
 
-export function openCommand(deps: OpenCommandDeps = defaultDeps): Command {
+export function openCommand(deps: Partial<OpenCommandDeps> = {}): Command {
+  const commandDeps = { ...defaultDeps, ...deps }
   return new Command('open')
     .description('Open a .hype scene file in the hyper-motion desktop app.')
     .argument('<scene>', 'Path to a .hype scene file')
     .action(async (scene: string) => {
       const scenePath = path.resolve(scene)
-      if (!fs.existsSync(scenePath)) {
+      if (!commandDeps.existsSync(scenePath)) {
         console.error(`[open] scene file not found: ${scenePath}`)
         process.exit(2)
       }
-      if (!fs.statSync(scenePath).isFile()) {
+      let stats: fs.Stats
+      try {
+        stats = commandDeps.statSync(scenePath)
+      } catch (err) {
+        console.error(
+          `[open] failed to read ${scenePath}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        )
+        process.exit(2)
+      }
+      if (!stats.isFile()) {
         console.error(`[open] scene path is not a file: ${scenePath}`)
         process.exit(2)
       }
-      const appPath = await deps.locateApp()
+      const appPath = await commandDeps.locateApp()
       if (!appPath) {
         console.error('[open] hyper-motion desktop app not found.')
         process.exit(1)
       }
-      const child = deps.spawnApp(appPath, [scenePath], {
+      const child = commandDeps.spawnApp(appPath, [scenePath], {
         detached: true,
         stdio: 'ignore',
       })


### PR DESCRIPTION
## Summary
- catch stat failures in the CLI open command and report a clean user-facing error
- keep the app launch path untouched unless the scene path validates as a file
- add regression coverage for the stat-failure path

## Tests
- pnpm --dir cli test