### PR TITLE
Validate desktop app locator paths

### DIFF
--- a/cli/src/electron/locator.test.ts
+++ b/cli/src/electron/locator.test.ts
@@ -42,6 +42,23 @@ test('locator rejects a missing HYPERMOTION_APP_PATH override', async () => {
   }
 })
 
+test('locator rejects a directory HYPERMOTION_APP_PATH override', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-dir-'))
+
+  try {
+    const stderr = await captureStderr(() =>
+      withEnvVar('HYPERMOTION_APP_PATH', dir, async () => {
+        assert.equal(await locateDesktopApp(), null)
+      }),
+    )
+
+    assert.match(stderr, /HYPERMOTION_APP_PATH is set/)
+    assert.equal(stderr.includes(dir), true)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('locator treats an empty HYPERMOTION_APP_PATH as unset', async () => {
   let locatedPath: string | null = null
 

--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -26,7 +26,7 @@ import fs from 'node:fs'
 export async function locateDesktopApp(): Promise<string | null> {
   const override = process.env.HYPERMOTION_APP_PATH
   if (override) {
-    if (fs.existsSync(override)) {
+    if (isFile(override)) {
       return override
     }
     // Loud failure — silently falling through when the user set an
@@ -58,7 +58,7 @@ function locateMac(): string | null {
     path.join(os.homedir(), 'Applications/hyper-motion.app/Contents/MacOS/hyper-motion'),
   ]
   for (const c of candidates) {
-    if (fs.existsSync(c)) return c
+    if (isFile(c)) return c
   }
   return null
 }
@@ -71,7 +71,7 @@ function locateWindows(): string | null {
     path.join(localAppData, 'Programs', 'hyper-motion', 'hyper-motion.exe'),
   ]
   for (const c of candidates) {
-    if (fs.existsSync(c)) return c
+    if (isFile(c)) return c
   }
   return null
 }
@@ -84,7 +84,15 @@ function locateLinux(): string | null {
     path.join(os.homedir(), '.local/bin/hyper-motion'),
   ]
   for (const c of candidates) {
-    if (fs.existsSync(c)) return c
+    if (isFile(c)) return c
   }
   return null
+}
+
+function isFile(p: string): boolean {
+  try {
+    return fs.statSync(p).isFile()
+  } catch {
+    return false
+  }
 }


### PR DESCRIPTION
## Summary
- require located desktop app paths to be files rather than any existing filesystem entry
- add coverage for directory-valued HYPERMOTION_APP_PATH overrides

## Tests
- pnpm run test