### PR TITLE
test(cli): reuse MCP text helper in capabilities tests

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -16,6 +16,7 @@ import {
   type PatchOperation,
   type PropertyIdJson,
 } from '../scene/build.js'
+import { assertToolText } from '../testUtils/mcp.js'
 
 type CapabilitiesToolPayload = {
   keyframeableProperties: readonly PropertyIdJson[]
@@ -100,10 +101,7 @@ test('capability tool schemas accept no arguments', () => {
 })
 
 function parseToolJson(result: CallToolResult): CapabilitiesToolPayload {
-  const item = result.content[0]
-  assert.equal(item?.type, 'text')
-
-  const parsed: unknown = JSON.parse(item.text)
+  const parsed: unknown = JSON.parse(assertToolText(result))
   assert.equal(typeof parsed, 'object')
   assert.notEqual(parsed, null)
   const parsedObject = parsed as Record<string, unknown>


### PR DESCRIPTION
## Summary
- reuse the shared MCP text assertion helper in capabilities tests
- remove duplicated text-content assertion logic

## Tests
- pnpm --dir cli test