### PR TITLE
test(cli): reuse MCP text helper in open scene tests

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
+import { assertToolText } from '../testUtils/mcp.js'
 import { handleOpenScene, openSceneTool } from './tools/openScene.js'
 
 test('open_scene input schema exposes required scene path', () => {
@@ -21,8 +22,7 @@ test('open_scene reports invalid arguments as MCP errors', async () => {
   const result = await handleOpenScene({ scene: 42 })
 
   assert.equal(result.isError, true)
-  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-  assert.match(text, /^open_scene: invalid arguments/)
+  assert.match(assertToolText(result), /^open_scene: invalid arguments/)
 })
 
 test('open_scene reports missing files as MCP errors', async () => {
@@ -33,8 +33,7 @@ test('open_scene reports missing files as MCP errors', async () => {
     const result = await handleOpenScene({ scene: missingScene })
 
     assert.equal(result.isError, true)
-    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-    assert.equal(text, `Scene file not found: ${missingScene}`)
+    assert.equal(assertToolText(result), `Scene file not found: ${missingScene}`)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }
@@ -49,8 +48,7 @@ test('open_scene reports directories as MCP errors', async () => {
     const result = await handleOpenScene({ scene: sceneDir })
 
     assert.equal(result.isError, true)
-    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-    assert.equal(text, `Scene path is not a file: ${sceneDir}`)
+    assert.equal(assertToolText(result), `Scene path is not a file: ${sceneDir}`)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }
@@ -74,8 +72,7 @@ test('open_scene reports stat failures as MCP errors', async () => {
     )
 
     assert.equal(result.isError, true)
-    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-    assert.equal(text, `open_scene: failed to read ${scenePath}: stat failed`)
+    assert.equal(assertToolText(result), `open_scene: failed to read ${scenePath}: stat failed`)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary
- Reuse the shared MCP text assertion helper in open_scene tests
- Remove duplicated inline content extraction in those assertions

## Verification
- pnpm --dir cli test