### PR TITLE
test(cli): cover default render logging env

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -224,6 +224,42 @@ test('driveHeadlessRender enables Electron logging when verbose mode is set', as
   }
 })
 
+test('driveHeadlessRender disables Electron logging by default', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(out, process.env.ELECTRON_ENABLE_LOGGING ?? 'missing');",
+      "fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: 0 }));",
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await withEnvVar('HYPERMOTION_VERBOSE', undefined, async () => {
+      await driveHeadlessRender({
+        appPath,
+        outputPath,
+        format: 'mp4',
+        quality: 'comp',
+        fps: 30,
+      })
+    })
+
+    assert.equal(fs.readFileSync(outputPath, 'utf-8'), '')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('driveHeadlessRender surfaces JSON error sentinel messages', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
   const appPath = path.join(dir, 'fake-app.mjs')


### PR DESCRIPTION
## Summary
- add driver coverage for the default Electron logging environment when verbose mode is unset

## Tests
- pnpm --dir cli run build && node --test cli/dist/electron/driver.test.js
- pnpm --dir cli test