### PR TITLE
fix(cli): reject inspect directory inputs

### DIFF
--- a/cli/src/commands/inspect.test.ts
+++ b/cli/src/commands/inspect.test.ts
@@ -121,6 +121,26 @@ test('inspect command reports missing scene files', async () => {
   }
 })
 
+test('inspect command reports directory inputs', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-dir-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  fs.mkdirSync(scenePath)
+  try {
+    const stderr = await captureStderr(async () => {
+      await assert.rejects(
+        withProcessExitThrow(async () => {
+          inspectCommand().parse([scenePath], { from: 'user' })
+        }),
+        { exitCode: 2 },
+      )
+    })
+
+    assert.match(stderr, /^\[inspect\] scene path is not a file: .*scene\.hype$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('inspect command reports malformed scene files', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-'))
   const scenePath = path.join(dir, 'broken.hype')

--- a/cli/src/commands/inspect.ts
+++ b/cli/src/commands/inspect.ts
@@ -15,6 +15,17 @@ export function inspectCommand(): Command {
     .option('--json', 'Output JSON (default)', true)
     .action((scenePath: string, _options: InspectCommandOptions) => {
       let bytes: Buffer
+      let stat: fs.Stats
+      try {
+        stat = fs.statSync(scenePath)
+      } catch (err) {
+        console.error(`[inspect] failed to read ${scenePath}: ${err instanceof Error ? err.message : err}`)
+        process.exit(2)
+      }
+      if (!stat.isFile()) {
+        console.error(`[inspect] scene path is not a file: ${scenePath}`)
+        process.exit(2)
+      }
       try {
         bytes = fs.readFileSync(scenePath)
       } catch (err) {


### PR DESCRIPTION
## Summary
- reject directory paths before inspect reads scene bytes
- add a command-level regression test for directory inputs

## Tests
- pnpm --dir cli test