### PR TITLE
fix(cli): report open scene launch failures

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -77,3 +77,27 @@ test('open_scene reports stat failures as MCP errors', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('open_scene reports desktop launch failures as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-launch-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  fs.writeFileSync(scenePath, '')
+
+  try {
+    const result = await handleOpenScene(
+      { scene: scenePath },
+      {
+        existsSync: fs.existsSync,
+        statSync: fs.statSync,
+        openScene: async () => {
+          throw new Error('launch failed')
+        },
+      },
+    )
+
+    assert.equal(result.isError, true)
+    assert.equal(assertToolText(result), `open_scene: failed to open ${scenePath}: launch failed`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -81,7 +81,22 @@ export async function handleOpenScene(
       content: [{ type: 'text' as const, text: `Scene path is not a file: ${scenePath}` }],
     }
   }
-  const opened = await deps.openScene(scenePath)
+  let opened: boolean
+  try {
+    opened = await deps.openScene(scenePath)
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `open_scene: failed to open ${scenePath}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+    }
+  }
   if (!opened) {
     return {
       isError: true,


### PR DESCRIPTION
## Summary
- convert thrown MCP open_scene launch failures into structured MCP errors
- add regression coverage for desktop launch exceptions

## Tests
- pnpm --dir cli test