### PR TITLE
fix(cli): reject validate_scene directory inputs

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -40,6 +40,33 @@ export async function handleValidateScene(
 
   const input: ValidateInputData = parsed.data
   let bytes: Buffer
+  let stat: fs.Stats
+  try {
+    stat = fs.statSync(input.scene)
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `validate_scene: failed to read ${input.scene}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+    }
+  }
+  if (!stat.isFile()) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `validate_scene: scene path is not a file: ${input.scene}`,
+        },
+      ],
+    }
+  }
   try {
     bytes = fs.readFileSync(input.scene)
   } catch (err) {

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -41,6 +41,20 @@ test('validate_scene reports missing files as MCP errors', async () => {
   }
 })
 
+test('validate_scene rejects directory inputs as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-dir-'))
+
+  try {
+    const result = await handleValidateScene({ scene: dir })
+
+    assert.equal(result.isError, true)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    assert.equal(text, `validate_scene: scene path is not a file: ${dir}`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('validate_scene reports malformed scene files as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-malformed-'))
   const scenePath = path.join(dir, 'malformed.hype')


### PR DESCRIPTION
## Summary
- reject directory paths before MCP validate_scene reads scene bytes
- add coverage for directory inputs matching the CLI validate behavior

## Verification
- pnpm test (in cli/)
- pnpm exec eslint cli/src/mcp/tools/validateScene.ts cli/src/mcp/validateScene.test.ts

Note: repo-level pnpm run typecheck and pnpm run lint still fail on existing unrelated main-branch issues outside this change.