### PR TITLE
Handle MCP render driver failures

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -123,6 +123,33 @@ test('render_scene reports scene stat failures as MCP errors', async () => {
   }
 })
 
+test('render_scene reports desktop driver failures as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-fail-'))
+  const appPath = path.join(dir, 'hyper-motion')
+  const previousAppPath = process.env.HYPERMOTION_APP_PATH
+
+  try {
+    fs.writeFileSync(appPath, '#!/bin/sh\nprintf "render failed\\n" >&2\nexit 2\n')
+    fs.chmodSync(appPath, 0o755)
+    process.env.HYPERMOTION_APP_PATH = appPath
+
+    const result = await handleRenderScene({
+      output: path.join(dir, 'out.mp4'),
+    })
+
+    assert.equal(result.isError, true)
+    assert.match(assertToolText(result), /^render_scene: failed: Desktop app exited with code 2/)
+    assert.match(assertToolText(result), /render failed/)
+  } finally {
+    if (previousAppPath === undefined) {
+      delete process.env.HYPERMOTION_APP_PATH
+    } else {
+      process.env.HYPERMOTION_APP_PATH = previousAppPath
+    }
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 function schemaProperty(name: string): JsonSchemaProperty | undefined {
   return renderSceneTool.inputSchema.properties?.[name] as
     | JsonSchemaProperty

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -163,14 +163,26 @@ export async function handleRenderScene(
     fs.mkdirSync(outDir, { recursive: true })
   }
 
-  await driveHeadlessRender({
-    appPath,
-    outputPath,
-    format,
-    quality,
-    fps,
-    scenePath,
-  })
+  try {
+    await driveHeadlessRender({
+      appPath,
+      outputPath,
+      format,
+      quality,
+      fps,
+      scenePath,
+    })
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `render_scene: failed: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      ],
+    }
+  }
 
   return {
     content: [


### PR DESCRIPTION
## Summary
- Return MCP error results when render_scene driver execution fails
- Add regression coverage for a failing desktop driver process

## Tests
- pnpm --dir cli test