### PR TITLE
Tighten CLI stdout helper callback type

### DIFF
--- a/cli/src/testUtils/stdout.ts
+++ b/cli/src/testUtils/stdout.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 type WritableStream = typeof process.stdout | typeof process.stderr
-type CaptureCallback = () => Promise<void> | void
+type CaptureCallback<T> = () => Promise<T> | T
 
 function stringifyChunk(
   chunk: Parameters<typeof process.stdout.write>[0],
@@ -14,7 +14,7 @@ function stringifyChunk(
 
 async function captureStream(
   stream: WritableStream,
-  run: CaptureCallback,
+  run: CaptureCallback<unknown>,
 ): Promise<string> {
   let output = ''
   const write = stream.write
@@ -39,10 +39,14 @@ async function captureStream(
   return output
 }
 
-export async function captureStdout(run: CaptureCallback): Promise<string> {
+export async function captureStdout(
+  run: CaptureCallback<unknown>,
+): Promise<string> {
   return captureStream(process.stdout, run)
 }
 
-export async function captureStderr(run: CaptureCallback): Promise<string> {
+export async function captureStderr(
+  run: CaptureCallback<unknown>,
+): Promise<string> {
   return captureStream(process.stderr, run)
 }


### PR DESCRIPTION
## Summary
- Allow CLI stdout/stderr capture helper callbacks to return any value, matching current `process.stdout.write(...)` test callbacks.
- Keep capture behavior unchanged; the helper still returns only captured output.

## Verification
- `pnpm --dir cli test`
- `pnpm exec eslint cli/src/testUtils/stdout.ts`
- `git diff --check`

## Notes
- `pnpm lint` and `pnpm typecheck` were also run, but both fail on existing unrelated repository issues outside this one-file change.