### PR TITLE
Tighten CLI env helper value type

### DIFF
--- a/cli/src/testUtils/env.ts
+++ b/cli/src/testUtils/env.ts
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 type EnvVarCallback<T> = () => Promise<T> | T
+type EnvVarValue = NodeJS.ProcessEnv[string]
 
 export async function withEnvVar<T>(
   name: string,
-  value: string | undefined,
+  value: EnvVarValue,
   run: EnvVarCallback<T>,
 ): Promise<T> {
   const previous = process.env[name]


### PR DESCRIPTION
## Summary
- Align the CLI test env helper value parameter with Node's ProcessEnv value type.

## Tests
- pnpm --dir cli run build && node --test cli/dist/testUtils/env.test.js
- pnpm --dir cli test