### PR TITLE
Cover validation warning for missing active camera

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -797,6 +797,17 @@ test('validateScene accepts a valid authored scene', () => {
   assert.deepEqual(result.warnings, [])
 })
 
+test('validateScene warns when no active camera is selected', () => {
+  const scene = sampleScene()
+  scene.activeCameraId = null
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, true)
+  assert.deepEqual(result.errors, [])
+  assert.deepEqual(result.warnings, ['scene.activeCameraId is missing'])
+})
+
 test('validateScene rejects unsupported track property ids', () => {
   const scene = {
     ...sampleScene(),


### PR DESCRIPTION
## Summary
- Add focused test coverage that validateScene treats a missing active camera as a warning, not an error.

## Tests
- pnpm --dir cli test