### PR TITLE
Accept uppercase render format flags

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -66,6 +66,25 @@ test('render command infers formats case-insensitively from output extensions', 
   }
 })
 
+test('render command accepts explicit formats case-insensitively', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-explicit-format-'))
+  const outputPath = path.join(dir, 'out.mp4')
+  const appPath = path.join(dir, 'hyper-motion')
+  const calls: HeadlessRenderRequest[] = []
+  try {
+    await renderCommand({
+      locateApp: async () => appPath,
+      driveRender: async (req) => {
+        calls.push(req)
+      },
+    }).parseAsync(['-o', outputPath, '--format', 'WEBM'], { from: 'user' })
+
+    assert.equal(calls[0]?.format, 'webm')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render command reports invalid fps before launching the app', async () => {
   const stderr = await captureStderr(() => {
     return withProcessExitThrow(async () => {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -74,7 +74,7 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
     .action(async (opts: RenderOptions) => {
       const outputPath = path.resolve(opts.output)
 
-      const requestedFormat = opts.format ?? inferFormat(outputPath)
+      const requestedFormat = opts.format?.toLowerCase() ?? inferFormat(outputPath)
       if (!isFormat(requestedFormat)) {
         console.error(`[render] unsupported format: ${requestedFormat} (use ${FORMAT_HELP})`)
         process.exit(1)


### PR DESCRIPTION
## Summary
- Normalize explicit render format flags before validation
- Add CLI coverage for uppercase `--format` values

## Verification
- `pnpm --dir cli test`

## Notes
- Root `pnpm typecheck` and `pnpm lint` still fail on existing unrelated app/UI issues.