### PR TITLE
Accept render quality presets case-insensitively

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -85,6 +85,25 @@ test('render command accepts explicit formats case-insensitively', async () => {
   }
 })
 
+test('render command accepts explicit quality presets case-insensitively', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-explicit-quality-'))
+  const outputPath = path.join(dir, 'out.mp4')
+  const appPath = path.join(dir, 'hyper-motion')
+  const calls: HeadlessRenderRequest[] = []
+  try {
+    await renderCommand({
+      locateApp: async () => appPath,
+      driveRender: async (req) => {
+        calls.push(req)
+      },
+    }).parseAsync(['-o', outputPath, '--quality', '4K'], { from: 'user' })
+
+    assert.equal(calls[0]?.quality, '4k')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render command reports invalid fps before launching the app', async () => {
   const stderr = await captureStderr(() => {
     return withProcessExitThrow(async () => {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -81,7 +81,7 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
       }
       const format = requestedFormat
 
-      const requestedQuality = opts.quality ?? 'comp'
+      const requestedQuality = opts.quality?.toLowerCase() ?? 'comp'
       if (!isQuality(requestedQuality)) {
         console.error(`[render] unsupported quality: ${requestedQuality} (use ${QUALITY_HELP})`)
         process.exit(1)


### PR DESCRIPTION
## Summary
- Normalize CLI render quality presets before validation so values like `4K` behave like `4k`.
- Add a focused render command test for uppercase quality input.

## Tests
- `pnpm --dir cli test`

Ready for review.