### PR TITLE
Treat whitespace app path overrides as unset

### DIFF
--- a/cli/src/electron/locator.test.ts
+++ b/cli/src/electron/locator.test.ts
@@ -73,3 +73,18 @@ test('locator treats an empty HYPERMOTION_APP_PATH as unset', async () => {
     assert.equal(fs.existsSync(locatedPath), true)
   }
 })
+
+test('locator treats a whitespace-only HYPERMOTION_APP_PATH as unset', async () => {
+  let locatedPath: string | null = null
+
+  const stderr = await captureStderr(() =>
+    withEnvVar('HYPERMOTION_APP_PATH', '   ', async () => {
+      locatedPath = await locateDesktopApp()
+    }),
+  )
+
+  assert.equal(stderr, '')
+  if (locatedPath !== null) {
+    assert.equal(fs.existsSync(locatedPath), true)
+  }
+})

--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -24,7 +24,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 
 export async function locateDesktopApp(): Promise<string | null> {
-  const override = process.env.HYPERMOTION_APP_PATH
+  const override = process.env.HYPERMOTION_APP_PATH?.trim()
   if (override) {
     if (isFile(override)) {
       return override


### PR DESCRIPTION
## Summary
- trim HYPERMOTION_APP_PATH before treating it as an explicit desktop app override
- cover whitespace-only overrides with the existing locator unset behavior

## Tests
- pnpm --dir cli run build && node --test cli/dist/electron/locator.test.js
- pnpm test