### PR TITLE
test(cli): cover null process exit codes

### DIFF
--- a/cli/src/testUtils/processExit.test.ts
+++ b/cli/src/testUtils/processExit.test.ts
@@ -99,6 +99,15 @@ test('withProcessExitThrow treats process.exit without a code as success', async
   )
 })
 
+test('withProcessExitThrow treats null process.exit codes as success', async () => {
+  await assert.rejects(
+    withProcessExitThrow(() => {
+      process.exit(null)
+    }),
+    { exitCode: 0 },
+  )
+})
+
 function assertProcessExitError(err: unknown): asserts err is ProcessExitError {
   assert.ok(err instanceof Error)
   assert.ok('exitCode' in err)


### PR DESCRIPTION
## Summary
- add CLI test coverage for null process.exit codes in withProcessExitThrow

## Tests
- pnpm test