### PR TITLE
test: cover nested stdout capture

### DIFF
--- a/cli/src/testUtils/stdout.test.ts
+++ b/cli/src/testUtils/stdout.test.ts
@@ -109,6 +109,23 @@ test('captureStdout restores the writer after async callbacks', async () => {
   assert.equal(process.stdout.write, originalWrite)
 })
 
+test('captureStdout scopes nested captures to the active writer', async () => {
+  const originalWrite = process.stdout.write
+  let innerOutput = ''
+
+  const outerOutput = await captureStdout(async () => {
+    process.stdout.write('before ')
+    innerOutput = await captureStdout(() => {
+      process.stdout.write('inner')
+    })
+    process.stdout.write(' after')
+  })
+
+  assert.equal(innerOutput, 'inner')
+  assert.equal(outerOutput, 'before  after')
+  assert.equal(process.stdout.write, originalWrite)
+})
+
 test('captureStderr restores the writer after async callbacks', async () => {
   const originalWrite = process.stderr.write
 


### PR DESCRIPTION
## Summary
- Add regression coverage for nested stdout capture scoping in the CLI test helper
- Verify nested capture output does not leak into the outer capture and restores the original writer

## Tests
- pnpm --dir cli run build && node --test cli/dist/testUtils/stdout.test.js
- pnpm test