### PR TITLE
chore(cli): name doctor command options type

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -28,6 +28,10 @@ export interface DoctorReport {
   }
 }
 
+type DoctorCommandOptions = {
+  json?: boolean
+}
+
 export async function getDoctorReport(): Promise<DoctorReport> {
   const appPath = await locateDesktopApp()
   return {
@@ -66,7 +70,7 @@ export function doctorCommand(): Command {
   return new Command('doctor')
     .description('Check hyper-motion CLI, desktop app, and agent tool capabilities.')
     .option('--json', 'Output the report as JSON')
-    .action(async (options: { json?: boolean }) => {
+    .action(async (options: DoctorCommandOptions) => {
       const report = await getDoctorReport()
       if (options.json) {
         process.stdout.write(JSON.stringify(report, null, 2) + '\n')


### PR DESCRIPTION
## Summary
- replace the inline doctor command options shape with a named type for consistency with adjacent CLI commands

## Tests
- pnpm --dir cli run build && node --test cli/dist/commands/doctor.test.js cli/dist/mcp/doctor.test.js cli/dist/mcp/capabilities.test.js
- pnpm --dir cli test