### PR TITLE
Share CLI render option type guards

### DIFF
--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -21,8 +21,9 @@ import { driveHeadlessRender, type HeadlessRenderRequest } from '../electron/dri
 import {
   RENDER_FORMATS,
   RENDER_QUALITIES,
+  isRenderFormat,
+  isRenderQuality,
   type RenderFormat,
-  type RenderQuality,
 } from '../renderOptions.js'
 
 const FORMAT_HELP = RENDER_FORMATS.join(' / ')
@@ -75,14 +76,14 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
       const outputPath = path.resolve(opts.output)
 
       const requestedFormat = opts.format?.toLowerCase() ?? inferFormat(outputPath)
-      if (!isFormat(requestedFormat)) {
+      if (!isRenderFormat(requestedFormat)) {
         console.error(`[render] unsupported format: ${requestedFormat} (use ${FORMAT_HELP})`)
         process.exit(1)
       }
       const format = requestedFormat
 
       const requestedQuality = opts.quality?.toLowerCase() ?? 'comp'
-      if (!isQuality(requestedQuality)) {
+      if (!isRenderQuality(requestedQuality)) {
         console.error(`[render] unsupported quality: ${requestedQuality} (use ${QUALITY_HELP})`)
         process.exit(1)
       }
@@ -158,14 +159,6 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
 
 function inferFormat(outPath: string): RenderFormat {
   const ext = path.extname(outPath).toLowerCase().slice(1)
-  if (isFormat(ext)) return ext
+  if (isRenderFormat(ext)) return ext
   return 'mp4'
-}
-
-function isFormat(value: string): value is RenderFormat {
-  return RENDER_FORMATS.includes(value as RenderFormat)
-}
-
-function isQuality(value: string): value is RenderQuality {
-  return RENDER_QUALITIES.includes(value as RenderQuality)
 }

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -20,6 +20,7 @@ import { driveHeadlessRender } from '../../electron/driver.js'
 import {
   RENDER_FORMATS,
   RENDER_QUALITIES,
+  isRenderFormat,
   type RenderFormat,
 } from '../../renderOptions.js'
 
@@ -196,6 +197,6 @@ export async function handleRenderScene(
 
 function inferFormat(outPath: string): RenderFormat {
   const ext = path.extname(outPath).toLowerCase().slice(1)
-  if (RENDER_FORMATS.includes(ext as RenderFormat)) return ext as RenderFormat
+  if (isRenderFormat(ext)) return ext
   return 'mp4'
 }

--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -5,3 +5,11 @@ export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
 
 export type RenderFormat = (typeof RENDER_FORMATS)[number]
 export type RenderQuality = (typeof RENDER_QUALITIES)[number]
+
+export function isRenderFormat(value: string): value is RenderFormat {
+  return RENDER_FORMATS.includes(value as RenderFormat)
+}
+
+export function isRenderQuality(value: string): value is RenderQuality {
+  return RENDER_QUALITIES.includes(value as RenderQuality)
+}


### PR DESCRIPTION
## Summary\n- move render format and quality type guards into the shared CLI render options module\n- reuse the shared format guard in the render command and MCP render tool\n\n## Tests\n- pnpm --dir cli test\n