### PR TITLE
fix(cli): resolve inspect scene paths

### DIFF
--- a/cli/src/commands/inspect.test.ts
+++ b/cli/src/commands/inspect.test.ts
@@ -141,6 +141,36 @@ test('inspect command reports directory inputs', async () => {
   }
 })
 
+test('inspect command reports resolved relative scene paths', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-relative-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const previousCwd = process.cwd()
+  fs.mkdirSync(scenePath)
+  try {
+    process.chdir(dir)
+    const resolvedScenePath = path.resolve('scene.hype')
+    const stderr = await captureStderr(async () => {
+      await assert.rejects(
+        withProcessExitThrow(async () => {
+          inspectCommand().parse(['scene.hype'], { from: 'user' })
+        }),
+        { exitCode: 2 },
+      )
+    })
+
+    assert.match(
+      stderr,
+      new RegExp(
+        `^\\[inspect\\] scene path is not a file: ${escapeRegExp(resolvedScenePath)}$`,
+        'm',
+      ),
+    )
+  } finally {
+    process.chdir(previousCwd)
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('inspect command reports malformed scene files', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-'))
   const scenePath = path.join(dir, 'broken.hype')
@@ -161,3 +191,7 @@ test('inspect command reports malformed scene files', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/cli/src/commands/inspect.ts
+++ b/cli/src/commands/inspect.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander'
 import fs from 'node:fs'
+import path from 'node:path'
 import { inspectScene } from '../scene/build.js'
 
 type InspectCommandOptions = {
@@ -14,28 +15,29 @@ export function inspectCommand(): Command {
     .argument('<scene>', 'Path to a .hype scene file')
     .option('--json', 'Output JSON (default)', true)
     .action((scenePath: string, _options: InspectCommandOptions) => {
+      const resolvedScenePath = path.resolve(scenePath)
       let bytes: Buffer
       let stat: fs.Stats
       try {
-        stat = fs.statSync(scenePath)
+        stat = fs.statSync(resolvedScenePath)
       } catch (err) {
-        console.error(`[inspect] failed to read ${scenePath}: ${err instanceof Error ? err.message : err}`)
+        console.error(`[inspect] failed to read ${resolvedScenePath}: ${err instanceof Error ? err.message : err}`)
         process.exit(2)
       }
       if (!stat.isFile()) {
-        console.error(`[inspect] scene path is not a file: ${scenePath}`)
+        console.error(`[inspect] scene path is not a file: ${resolvedScenePath}`)
         process.exit(2)
       }
       try {
-        bytes = fs.readFileSync(scenePath)
+        bytes = fs.readFileSync(resolvedScenePath)
       } catch (err) {
-        console.error(`[inspect] failed to read ${scenePath}: ${err instanceof Error ? err.message : err}`)
+        console.error(`[inspect] failed to read ${resolvedScenePath}: ${err instanceof Error ? err.message : err}`)
         process.exit(2)
       }
       try {
         process.stdout.write(JSON.stringify(inspectScene(new Uint8Array(bytes)), null, 2) + '\n')
       } catch (err) {
-        console.error(`[inspect] failed to inspect ${scenePath}: ${err instanceof Error ? err.message : err}`)
+        console.error(`[inspect] failed to inspect ${resolvedScenePath}: ${err instanceof Error ? err.message : err}`)
         process.exit(2)
       }
     })


### PR DESCRIPTION
## Summary
- resolve inspect command scene paths before stat/read/error output
- add regression coverage for relative path diagnostics

## Tests
- pnpm --dir cli run build && node --test cli/dist/commands/inspect.test.js
- pnpm test