### PR TITLE
Reject fractional render fps

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -149,6 +149,21 @@ test('render command rejects fps values above the MCP limit before launching the
   assert.match(stderr, /^\[render\] invalid fps: 121$/m)
 })
 
+test('render command rejects fractional fps before launching the app', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        renderCommand().parseAsync(['-o', 'out.mp4', '--fps', '30.5'], {
+          from: 'user',
+        }),
+        { exitCode: 1 },
+      )
+    })
+  })
+
+  assert.match(stderr, /^\[render\] invalid fps: 30\.5$/m)
+})
+
 test('render command reports unsupported formats before launching the app', async () => {
   const stderr = await captureStderr(() => {
     return withProcessExitThrow(async () => {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -90,7 +90,7 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
       const quality = requestedQuality
 
       const fps = Number(opts.fps ?? '30')
-      if (!Number.isFinite(fps) || fps <= 0 || fps > 120) {
+      if (!Number.isInteger(fps) || fps <= 0 || fps > 120) {
         console.error(`[render] invalid fps: ${opts.fps}`)
         process.exit(1)
       }


### PR DESCRIPTION
## Summary
- reject fractional fps values in the CLI render command before launching the app
- add a regression test for fractional fps validation

## Tests
- pnpm --dir cli test