### PR TITLE
Validate MCP render output parent paths

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -135,6 +135,26 @@ test('render_scene reports scene stat failures as MCP errors', async () => {
   }
 })
 
+test('render_scene reports output parent files before locating the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-parent-'))
+  const parentPath = path.join(dir, 'exports')
+  fs.writeFileSync(parentPath, 'not a directory')
+
+  try {
+    const result = await handleRenderScene({
+      output: path.join(parentPath, 'out.mp4'),
+    })
+
+    assert.equal(result.isError, true)
+    assert.equal(
+      assertToolText(result),
+      `render_scene: output directory is not a directory: ${parentPath}`,
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render_scene reports desktop driver failures as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-fail-'))
   const appPath = path.join(dir, 'hyper-motion')

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -144,6 +144,19 @@ export async function handleRenderScene(
     }
   }
 
+  const outDir = path.dirname(outputPath)
+  if (fs.existsSync(outDir) && !fs.statSync(outDir).isDirectory()) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `render_scene: output directory is not a directory: ${outDir}`,
+        },
+      ],
+    }
+  }
+
   const appPath = await locateDesktopApp()
   if (!appPath) {
     return {
@@ -159,7 +172,6 @@ export async function handleRenderScene(
     }
   }
 
-  const outDir = path.dirname(outputPath)
   if (!fs.existsSync(outDir)) {
     fs.mkdirSync(outDir, { recursive: true })
   }


### PR DESCRIPTION
## Summary
- reject MCP render outputs whose parent path is a file before locating the desktop app
- add a regression test for the MCP render_scene handler

## Tests
- pnpm --dir cli test

Note: pnpm typecheck currently fails on existing app-wide TypeScript errors unrelated to this change.