### PR TITLE
Tighten MCP test text helper

### DIFF
--- a/cli/src/testUtils/mcp.ts
+++ b/cli/src/testUtils/mcp.ts
@@ -3,8 +3,16 @@
 import assert from 'node:assert/strict'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
+type ToolTextContent = Extract<CallToolResult['content'][number], { type: 'text' }>
+
 export function assertToolText(result: CallToolResult): string {
   const item = result.content[0]
-  assert.equal(item?.type, 'text')
+  assert.ok(isToolTextContent(item))
   return item.text
+}
+
+function isToolTextContent(
+  item: CallToolResult['content'][number] | undefined,
+): item is ToolTextContent {
+  return item?.type === 'text'
 }


### PR DESCRIPTION
## Summary
- add an explicit text-content type guard for the MCP test helper
- keep helper behavior unchanged while narrowing before reading `.text`

## Tests
- pnpm --dir cli test