### PR TITLE
test(cli): cover null MCP scene JSON

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -171,6 +171,17 @@ test('create_scene rejects array scene JSON', async () => {
   }
 })
 
+test('create_scene rejects null scene JSON', async () => {
+  const result = await handleCreateScene({
+    output: path.join(os.tmpdir(), 'null-scene.hype'),
+    scene: 'null',
+  })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.equal(text, 'create_scene: scene must be an object (or a JSON-encoded object).')
+})
+
 test('create_scene reports malformed scene JSON strings as MCP errors', async () => {
   const result = await handleCreateScene({
     output: path.join(os.tmpdir(), 'malformed-scene.hype'),


### PR DESCRIPTION
## Summary
- Add MCP create_scene coverage for string-encoded null scene payloads
- Verify the existing object-validation error message is preserved

## Tests
- pnpm --dir cli test