### PR TITLE
Handle validate stat failures cleanly

### DIFF
--- a/cli/src/commands/validate.test.ts
+++ b/cli/src/commands/validate.test.ts
@@ -361,6 +361,41 @@ test('validate command reports directories before reading scene bytes', async ()
   }
 })
 
+test('validate command reports stat failures as read errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-stat-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const previousStatSync = fs.statSync
+  try {
+    fs.writeFileSync(scenePath, '')
+    Object.defineProperty(fs, 'statSync', {
+      configurable: true,
+      value: () => {
+        throw new Error('stat failed')
+      },
+    })
+
+    const stderr = await withProcessExitThrow(() => captureStderr(() => {
+      assert.throws(
+        () => {
+          validateCommand().parse([scenePath], { from: 'user' })
+        },
+        { exitCode: 2 },
+      )
+    }))
+
+    assert.equal(
+      stderr,
+      `[validate] failed to read ${path.resolve(scenePath)}: stat failed\n`,
+    )
+  } finally {
+    Object.defineProperty(fs, 'statSync', {
+      configurable: true,
+      value: previousStatSync,
+    })
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('validate command reports malformed scene files', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
   const scenePath = path.join(dir, 'malformed.hype')

--- a/cli/src/commands/validate.ts
+++ b/cli/src/commands/validate.ts
@@ -18,11 +18,12 @@ export function validateCommand(): Command {
       const resolvedScenePath = path.resolve(scenePath)
       let bytes: Buffer
       let result: SceneValidationResult
-      if (fs.existsSync(resolvedScenePath) && !fs.statSync(resolvedScenePath).isFile()) {
-        console.error(`[validate] scene path is not a file: ${resolvedScenePath}`)
-        process.exit(2)
-      }
       try {
+        const stats = fs.statSync(resolvedScenePath)
+        if (!stats.isFile()) {
+          console.error(`[validate] scene path is not a file: ${resolvedScenePath}`)
+          process.exit(2)
+        }
         bytes = fs.readFileSync(resolvedScenePath)
       } catch (err) {
         console.error(


### PR DESCRIPTION
## Summary\n- handle CLI validate stat failures through the existing read-error path\n- add regression coverage for stat failures before scene reads\n\n## Verification\n- pnpm --dir cli run build && node --test cli/dist/commands/validate.test.js\n- pnpm test\n- pnpm exec eslint cli/src/commands/validate.ts cli/src/commands/validate.test.ts\n\nNote: root pnpm lint still fails on pre-existing unrelated app-wide issues (unused vars / React hook rules outside this patch).