### PR TITLE
Handle patch command directory inputs

### DIFF
--- a/cli/src/commands/patch.test.ts
+++ b/cli/src/commands/patch.test.ts
@@ -6,7 +6,8 @@ import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { buildSceneBytes, readSceneSummary } from '../scene/build.js'
-import { captureStdout } from '../testUtils/stdout.js'
+import { withProcessExitThrow } from '../testUtils/processExit.js'
+import { captureStderr, captureStdout } from '../testUtils/stdout.js'
 import { patchCommand } from './patch.js'
 
 test('patch command writes alternate output files', async () => {
@@ -94,6 +95,30 @@ test('patch command overwrites the input scene by default', async () => {
 
     assert.match(stdout, /^Patched .*scene\.hype → .*scene\.hype$/m)
     assert.equal(readSceneSummary(fs.readFileSync(scenePath)).meta.name, 'After')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('patch command reports directories before reading scene bytes', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-patch-dir-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const patchPath = path.join(dir, 'patch.json')
+  fs.mkdirSync(scenePath)
+  fs.writeFileSync(
+    patchPath,
+    JSON.stringify({ ops: [{ op: 'setMeta', patch: { name: 'Patched' } }] }),
+  )
+
+  try {
+    const stderr = await withProcessExitThrow(() => captureStderr(() => {
+      return assert.rejects(
+        patchCommand().parseAsync([scenePath, '--from', patchPath], { from: 'user' }),
+        { exitCode: 2 },
+      )
+    }))
+
+    assert.match(stderr, /^\[patch\] scene path is not a file: .*scene\.hype$/m)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }

--- a/cli/src/commands/patch.ts
+++ b/cli/src/commands/patch.ts
@@ -17,12 +17,24 @@ export function patchCommand(): Command {
     .requiredOption('-f, --from <json>', 'Patch JSON file. Use "-" to read from stdin.')
     .option('-o, --output <path>', 'Path to write. Defaults to overwriting <scene>.')
     .action(async (scenePath: string, options: PatchCommandOptions) => {
+      const resolvedScenePath = path.resolve(scenePath)
       const output = path.resolve(options.output ?? scenePath)
       let sceneBytes: Buffer
+      let stats: fs.Stats
       try {
-        sceneBytes = fs.readFileSync(scenePath)
+        stats = fs.statSync(resolvedScenePath)
       } catch (err) {
-        console.error(`[patch] failed to read ${scenePath}: ${err instanceof Error ? err.message : err}`)
+        console.error(`[patch] failed to read ${resolvedScenePath}: ${err instanceof Error ? err.message : err}`)
+        process.exit(2)
+      }
+      if (!stats.isFile()) {
+        console.error(`[patch] scene path is not a file: ${resolvedScenePath}`)
+        process.exit(2)
+      }
+      try {
+        sceneBytes = fs.readFileSync(resolvedScenePath)
+      } catch (err) {
+        console.error(`[patch] failed to read ${resolvedScenePath}: ${err instanceof Error ? err.message : err}`)
         process.exit(2)
       }
 
@@ -45,7 +57,7 @@ export function patchCommand(): Command {
 
       fs.mkdirSync(path.dirname(output), { recursive: true })
       fs.writeFileSync(output, Buffer.from(next))
-      console.log(`Patched ${scenePath} → ${output}`)
+      console.log(`Patched ${resolvedScenePath} → ${output}`)
     })
 }
 


### PR DESCRIPTION
## Summary
- Resolve patch command scene paths before reading
- Report directory scene inputs as non-files before patch parsing
- Add CLI regression coverage for patch directory inputs

## Tests
- pnpm --dir cli test