### PR TITLE
Handle render_scene output stat failures

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -155,6 +155,39 @@ test('render_scene reports output parent files before locating the app', async (
   }
 })
 
+test('render_scene reports output directory stat failures as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-stat-'))
+  const outDir = path.join(dir, 'exports')
+  fs.mkdirSync(outDir)
+  const previousStatSync = fs.statSync
+
+  try {
+    Object.defineProperty(fs, 'statSync', {
+      configurable: true,
+      value: (targetPath: fs.PathLike) => {
+        if (targetPath === outDir) throw new Error('stat failed')
+        return previousStatSync(targetPath)
+      },
+    })
+
+    const result = await handleRenderScene({
+      output: path.join(outDir, 'out.mp4'),
+    })
+
+    assert.equal(result.isError, true)
+    assert.equal(
+      assertToolText(result),
+      `render_scene: failed to read output directory ${outDir}: stat failed`,
+    )
+  } finally {
+    Object.defineProperty(fs, 'statSync', {
+      configurable: true,
+      value: previousStatSync,
+    })
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render_scene reports desktop driver failures as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-fail-'))
   const appPath = path.join(dir, 'hyper-motion')

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -145,15 +145,33 @@ export async function handleRenderScene(
   }
 
   const outDir = path.dirname(outputPath)
-  if (fs.existsSync(outDir) && !fs.statSync(outDir).isDirectory()) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text' as const,
-          text: `render_scene: output directory is not a directory: ${outDir}`,
-        },
-      ],
+  if (fs.existsSync(outDir)) {
+    let stats: fs.Stats
+    try {
+      stats = fs.statSync(outDir)
+    } catch (err) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: `render_scene: failed to read output directory ${outDir}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          },
+        ],
+      }
+    }
+    if (!stats.isDirectory()) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: `render_scene: output directory is not a directory: ${outDir}`,
+          },
+        ],
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- convert output directory stat failures in render_scene into MCP error responses
- add regression coverage for the output directory stat failure path

## Tests
- pnpm --dir cli test