### PR TITLE
Handle inspect_scene directory inputs

### DIFF
--- a/cli/src/mcp/inspectScene.test.ts
+++ b/cli/src/mcp/inspectScene.test.ts
@@ -34,6 +34,20 @@ test('inspect_scene reports missing files as MCP errors', async () => {
   assert.match(text, /^inspect_scene: failed to read /)
 })
 
+test('inspect_scene rejects directory inputs as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-dir-'))
+
+  try {
+    const result = await handleInspectScene({ scene: dir })
+
+    assert.equal(result.isError, true)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    assert.equal(text, `inspect_scene: scene path is not a file: ${dir}`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('inspect_scene reports malformed scene files as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-mcp-'))
   const scenePath = path.join(dir, 'broken.hype')

--- a/cli/src/mcp/tools/inspectScene.ts
+++ b/cli/src/mcp/tools/inspectScene.ts
@@ -40,6 +40,33 @@ export async function handleInspectScene(
 
   const input: InspectInputData = parsed.data
   let bytes: Buffer
+  let stat: fs.Stats
+  try {
+    stat = fs.statSync(input.scene)
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `inspect_scene: failed to read ${input.scene}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+    }
+  }
+  if (!stat.isFile()) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `inspect_scene: scene path is not a file: ${input.scene}`,
+        },
+      ],
+    }
+  }
   try {
     bytes = fs.readFileSync(input.scene)
   } catch (err) {


### PR DESCRIPTION
## Summary
- return a clear MCP error when inspect_scene receives a directory path
- add coverage for directory inputs in inspect_scene

## Tests
- pnpm test