### PR TITLE
Handle info command stat failures

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -369,6 +369,36 @@ test('info command reports directory inputs as non-files', async () => {
   }
 })
 
+test('info command reports stat failures as read errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const originalStatSync = fs.statSync
+  try {
+    Object.defineProperty(fs, 'statSync', {
+      value: ((statPath: fs.PathLike) => {
+        if (statPath === scenePath) throw new Error('stat failed')
+        return originalStatSync(statPath)
+      }) as typeof fs.statSync,
+    })
+
+    const stderr = await captureStderr(async () => {
+      await withProcessExitThrow(() => {
+        assert.throws(
+          () => {
+            infoCommand().parse([scenePath], { from: 'user' })
+          },
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.match(stderr, /^\[info\] failed to read .*scene\.hype: stat failed/)
+  } finally {
+    Object.defineProperty(fs, 'statSync', { value: originalStatSync })
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('info command reports malformed scene files', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
   const scenePath = path.join(dir, 'malformed.hype')

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -30,11 +30,12 @@ export function infoCommand(): Command {
     .action((scenePath: string, options: InfoCommandOptions) => {
       const resolvedScenePath = path.resolve(scenePath)
       let bytes: Buffer
-      if (fs.existsSync(resolvedScenePath) && !fs.statSync(resolvedScenePath).isFile()) {
-        console.error(`[info] scene path is not a file: ${resolvedScenePath}`)
-        process.exit(2)
-      }
       try {
+        const stats = fs.statSync(resolvedScenePath)
+        if (!stats.isFile()) {
+          console.error(`[info] scene path is not a file: ${resolvedScenePath}`)
+          process.exit(2)
+        }
         bytes = fs.readFileSync(resolvedScenePath)
       } catch (err) {
         console.error(


### PR DESCRIPTION
## Summary\n- route info command stat failures through the existing read-error message and exit code\n- add coverage for the stat failure path\n\n## Tests\n- pnpm --dir cli run build && node --test cli/dist/commands/info.test.js\n- pnpm --dir cli test