### PR TITLE
chore(cli): remove unused inspect options

### DIFF
--- a/cli/src/commands/inspect.ts
+++ b/cli/src/commands/inspect.ts
@@ -5,16 +5,12 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { inspectScene } from '../scene/build.js'
 
-type InspectCommandOptions = {
-  json: boolean
-}
-
 export function inspectCommand(): Command {
   return new Command('inspect')
     .description('Print the full editable scene graph for a .hype file.')
     .argument('<scene>', 'Path to a .hype scene file')
     .option('--json', 'Output JSON (default)', true)
-    .action((scenePath: string, _options: InspectCommandOptions) => {
+    .action((scenePath: string) => {
       const resolvedScenePath = path.resolve(scenePath)
       let bytes: Buffer
       let stat: fs.Stats


### PR DESCRIPTION
## Summary\n- remove the unused inspect command options parameter and dead type\n- keep inspect command behavior unchanged\n\n## Verification\n- pnpm --dir cli test\n- pnpm exec eslint cli/src/commands/inspect.ts\n\nNote: repository-wide pnpm lint still fails on pre-existing unrelated lint errors in files outside this change.