### PR TITLE
test(cli): type render capability payloads

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -16,6 +16,7 @@ import {
   type PatchOperation,
   type PropertyIdJson,
 } from '../scene/build.js'
+import type { RenderFormat, RenderQuality } from '../renderOptions.js'
 import { assertToolText } from '../testUtils/mcp.js'
 
 type CapabilitiesToolPayload = {
@@ -29,8 +30,8 @@ type CapabilitiesToolPayload = {
   patchOperations?: readonly PatchOperation['op'][]
   queryTools?: readonly string[]
   validationTools?: readonly string[]
-  renderFormats?: readonly string[]
-  renderQualities?: readonly string[]
+  renderFormats?: readonly RenderFormat[]
+  renderQualities?: readonly RenderQuality[]
   renderFileSceneInput?: boolean
 }
 
@@ -152,8 +153,12 @@ function parseToolJson(result: CallToolResult): CapabilitiesToolPayload {
       | undefined,
     queryTools: optionalStringArray(parsedObject, 'queryTools'),
     validationTools: optionalStringArray(parsedObject, 'validationTools'),
-    renderFormats: optionalStringArray(parsedObject, 'renderFormats'),
-    renderQualities: optionalStringArray(parsedObject, 'renderQualities'),
+    renderFormats: optionalStringArray(parsedObject, 'renderFormats') as
+      | readonly RenderFormat[]
+      | undefined,
+    renderQualities: optionalStringArray(parsedObject, 'renderQualities') as
+      | readonly RenderQuality[]
+      | undefined,
     renderFileSceneInput: optionalBoolean(parsedObject, 'renderFileSceneInput'),
   }
 }


### PR DESCRIPTION
## Summary\n- Tighten the CLI MCP capabilities test payload type for render formats and quality presets to use exported render option unions.\n\n## Verification\n- pnpm test