### PR TITLE
test(cli): cover open_scene missing app response

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -101,3 +101,25 @@ test('open_scene reports desktop launch failures as MCP errors', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('open_scene reports missing desktop apps as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-app-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  fs.writeFileSync(scenePath, '')
+
+  try {
+    const result = await handleOpenScene(
+      { scene: scenePath },
+      {
+        existsSync: fs.existsSync,
+        statSync: fs.statSync,
+        openScene: async () => false,
+      },
+    )
+
+    assert.equal(result.isError, true)
+    assert.equal(assertToolText(result), 'hyper-motion desktop app not found.')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary\n- add CLI MCP open_scene coverage for the desktop-app-not-found response\n\n## Tests\n- pnpm --dir cli test