### PR TITLE
fix(cli): report open launch failures

### DIFF
--- a/cli/src/commands/open.test.ts
+++ b/cli/src/commands/open.test.ts
@@ -141,3 +141,29 @@ test('open command reports when the desktop app cannot be found', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('open command reports desktop launch failures', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-launch-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const appPath = path.join(dir, 'hyper-motion')
+  fs.writeFileSync(scenePath, '')
+  try {
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          openCommand({
+            locateApp: async () => appPath,
+            spawnApp: () => {
+              throw new Error('launch failed')
+            },
+          }).parseAsync([scenePath], { from: 'user' }),
+          { exitCode: 1 },
+        )
+      })
+    })
+
+    assert.equal(stderr, `[open] failed to open ${scenePath}: launch failed\n`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -56,10 +56,20 @@ export function openCommand(deps: Partial<OpenCommandDeps> = {}): Command {
         console.error('[open] hyper-motion desktop app not found.')
         process.exit(1)
       }
-      const child = commandDeps.spawnApp(appPath, [scenePath], {
-        detached: true,
-        stdio: 'ignore',
-      })
+      let child: Pick<ChildProcess, 'unref'>
+      try {
+        child = commandDeps.spawnApp(appPath, [scenePath], {
+          detached: true,
+          stdio: 'ignore',
+        })
+      } catch (err) {
+        console.error(
+          `[open] failed to open ${scenePath}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        )
+        process.exit(1)
+      }
       child.unref()
       console.log(`Opened ${scenePath}`)
     })


### PR DESCRIPTION
## Summary
- catch desktop app spawn failures in the CLI open command
- report a clean [open] error with exit code 1
- add coverage for launch failures

## Tests
- pnpm --dir cli test -- open.test.ts

Note: repository-wide `pnpm typecheck` currently fails on unrelated existing app TypeScript errors outside the CLI open command.