### PR TITLE
Respect documented verbose flag value

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -260,6 +260,42 @@ test('driveHeadlessRender disables Electron logging by default', async () => {
   }
 })
 
+test('driveHeadlessRender only enables Electron logging for verbose value 1', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(out, process.env.ELECTRON_ENABLE_LOGGING ?? 'missing');",
+      "fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: 0 }));",
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await withEnvVar('HYPERMOTION_VERBOSE', '0', async () => {
+      await driveHeadlessRender({
+        appPath,
+        outputPath,
+        format: 'mp4',
+        quality: 'comp',
+        fps: 30,
+      })
+    })
+
+    assert.equal(fs.readFileSync(outputPath, 'utf-8'), '')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('driveHeadlessRender surfaces JSON error sentinel messages', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
   const appPath = path.join(dir, 'fake-app.mjs')

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -50,6 +50,7 @@ const POST_EXIT_GRACE_MS = 1500
 export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<void> {
   const sentinelPath = `${req.outputPath}.done`
   const errorPath = `${req.outputPath}.error`
+  const verbose = process.env.HYPERMOTION_VERBOSE === '1'
 
   // Clean slate — remove any stale output / sentinels from previous runs
   // so we can't false-positive on old data.
@@ -78,7 +79,7 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
     stdio: ['ignore', 'pipe', 'pipe'],
     env: {
       ...process.env,
-      ELECTRON_ENABLE_LOGGING: process.env.HYPERMOTION_VERBOSE ? '1' : '',
+      ELECTRON_ENABLE_LOGGING: verbose ? '1' : '',
     },
   })
 
@@ -98,7 +99,7 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
   })
   child.stderr.on('data', (chunk: Buffer) => {
     stderr += chunk.toString()
-    if (process.env.HYPERMOTION_VERBOSE) {
+    if (verbose) {
       process.stderr.write(chunk)
     }
   })


### PR DESCRIPTION
## Summary
- Treat HYPERMOTION_VERBOSE as enabled only when set to `1`, matching the CLI docs
- Add a driver regression test for `HYPERMOTION_VERBOSE=0`

## Tests
- `pnpm --dir cli run build && node --test cli/dist/electron/driver.test.js`
- `pnpm --dir cli test`