### PR TITLE
test(cli): cover render format fallback

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -66,6 +66,25 @@ test('render command infers formats case-insensitively from output extensions', 
   }
 })
 
+test('render command defaults to mp4 when output extension is unsupported', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-format-default-'))
+  const outputPath = path.join(dir, 'out.mov')
+  const appPath = path.join(dir, 'hyper-motion')
+  const calls: HeadlessRenderRequest[] = []
+  try {
+    await renderCommand({
+      locateApp: async () => appPath,
+      driveRender: async (req) => {
+        calls.push(req)
+      },
+    }).parseAsync(['-o', outputPath], { from: 'user' })
+
+    assert.equal(calls[0]?.format, 'mp4')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render command accepts explicit formats case-insensitively', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-explicit-format-'))
   const outputPath = path.join(dir, 'out.mp4')


### PR DESCRIPTION
## Summary
- add CLI render test coverage for defaulting unsupported output extensions to mp4

## Tests
- pnpm --dir cli test