### PR TITLE
fix(cli): report output directory stat failures

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -258,6 +258,36 @@ test('render command reports output parent files before launching the app', asyn
   }
 })
 
+test('render command reports output directory stat failures before launching the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-stat-'))
+  const outPath = path.join(dir, 'out.mp4')
+  try {
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          renderCommand({
+            locateApp: async () => path.join(dir, 'hyper-motion'),
+            driveRender: async () => {
+              throw new Error('should not render')
+            },
+            statSync: ((targetPath: fs.PathLike) => {
+              if (targetPath === dir) throw new Error('stat failed')
+              return fs.statSync(targetPath)
+            }) as typeof fs.statSync,
+          }).parseAsync(['-o', outPath], {
+            from: 'user',
+          }),
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.equal(stderr, `[render] failed to read output directory ${dir}: stat failed\n`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render command reports directories before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-dir-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -100,9 +100,22 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
       const outDir = path.dirname(outputPath)
       if (!existsSync(outDir)) {
         mkdirSync(outDir, { recursive: true })
-      } else if (!statSync(outDir).isDirectory()) {
-        console.error(`[render] output directory is not a directory: ${outDir}`)
-        process.exit(2)
+      } else {
+        let outDirStats: fs.Stats
+        try {
+          outDirStats = statSync(outDir)
+        } catch (err) {
+          console.error(
+            `[render] failed to read output directory ${outDir}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          )
+          process.exit(2)
+        }
+        if (!outDirStats.isDirectory()) {
+          console.error(`[render] output directory is not a directory: ${outDir}`)
+          process.exit(2)
+        }
       }
 
       const scenePath = opts.scene ? path.resolve(opts.scene) : undefined


### PR DESCRIPTION
## Summary
- catch render output directory stat failures and report a clean CLI error
- add regression coverage that the desktop app is not launched in that case

## Tests
- pnpm --dir cli test