### PR TITLE
test(cli): cover render scene directory rejection

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -235,6 +235,29 @@ test('render command reports missing scene files before launching the app', asyn
   }
 })
 
+test('render command reports scene directories before launching the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-scene-dir-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const outPath = path.join(dir, 'out.mp4')
+  fs.mkdirSync(scenePath)
+  try {
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          renderCommand().parseAsync(['--scene', scenePath, '-o', outPath], {
+            from: 'user',
+          }),
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.match(stderr, /^\[render\] scene path is not a file: .*scene\.hype$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render command reports output parent files before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-parent-'))
   const parentPath = path.join(dir, 'exports')


### PR DESCRIPTION
## Summary
- add CLI render-command coverage for rejecting directory paths passed via --scene

## Tests
- pnpm --dir cli run build && node --test cli/dist/commands/render.test.js
- pnpm test