### PR TITLE
Normalize render CLI option values

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -123,6 +123,30 @@ test('render command accepts explicit quality presets case-insensitively', async
   }
 })
 
+test('render command trims padded format, quality, and fps values', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-trimmed-options-'))
+  const outputPath = path.join(dir, 'out.mp4')
+  const appPath = path.join(dir, 'hyper-motion')
+  const calls: HeadlessRenderRequest[] = []
+  try {
+    await renderCommand({
+      locateApp: async () => appPath,
+      driveRender: async (req) => {
+        calls.push(req)
+      },
+    }).parseAsync(
+      ['-o', outputPath, '--format', ' webm ', '--quality', ' 4K ', '--fps', ' 60 '],
+      { from: 'user' },
+    )
+
+    assert.equal(calls[0]?.format, 'webm')
+    assert.equal(calls[0]?.quality, '4k')
+    assert.equal(calls[0]?.fps, 60)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render command reports invalid fps before launching the app', async () => {
   const stderr = await captureStderr(() => {
     return withProcessExitThrow(async () => {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -75,21 +75,22 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
     .action(async (opts: RenderOptions) => {
       const outputPath = path.resolve(opts.output)
 
-      const requestedFormat = opts.format?.toLowerCase() ?? inferFormat(outputPath)
+      const requestedFormat = opts.format?.trim().toLowerCase() ?? inferFormat(outputPath)
       if (!isRenderFormat(requestedFormat)) {
         console.error(`[render] unsupported format: ${requestedFormat} (use ${FORMAT_HELP})`)
         process.exit(1)
       }
       const format = requestedFormat
 
-      const requestedQuality = opts.quality?.toLowerCase() ?? 'comp'
+      const requestedQuality = opts.quality?.trim().toLowerCase() ?? 'comp'
       if (!isRenderQuality(requestedQuality)) {
         console.error(`[render] unsupported quality: ${requestedQuality} (use ${QUALITY_HELP})`)
         process.exit(1)
       }
       const quality = requestedQuality
 
-      const fps = Number(opts.fps ?? '30')
+      const fpsInput = opts.fps?.trim() ?? '30'
+      const fps = Number(fpsInput)
       if (!Number.isInteger(fps) || fps <= 0 || fps > 120) {
         console.error(`[render] invalid fps: ${opts.fps}`)
         process.exit(1)


### PR DESCRIPTION
## Summary
- Trim explicit render format and quality values before validation
- Trim fps input before numeric parsing
- Add a regression test for padded render option values

## Tests
- pnpm --dir cli run build && node --test cli/dist/commands/render.test.js
- pnpm test

Note: whole-repo `pnpm typecheck` was checked before the change and currently fails on unrelated app-side type errors on `main`.