### PR TITLE
Share CLI render format inference

### DIFF
--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -21,9 +21,9 @@ import { driveHeadlessRender, type HeadlessRenderRequest } from '../electron/dri
 import {
   RENDER_FORMATS,
   RENDER_QUALITIES,
+  inferRenderFormatFromPath,
   isRenderFormat,
   isRenderQuality,
-  type RenderFormat,
 } from '../renderOptions.js'
 
 const FORMAT_HELP = RENDER_FORMATS.join(' / ')
@@ -75,7 +75,8 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
     .action(async (opts: RenderOptions) => {
       const outputPath = path.resolve(opts.output)
 
-      const requestedFormat = opts.format?.trim().toLowerCase() ?? inferFormat(outputPath)
+      const requestedFormat =
+        opts.format?.trim().toLowerCase() ?? inferRenderFormatFromPath(outputPath)
       if (!isRenderFormat(requestedFormat)) {
         console.error(`[render] unsupported format: ${requestedFormat} (use ${FORMAT_HELP})`)
         process.exit(1)
@@ -172,10 +173,4 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
         process.exit(1)
       }
     })
-}
-
-function inferFormat(outPath: string): RenderFormat {
-  const ext = path.extname(outPath).toLowerCase().slice(1)
-  if (isRenderFormat(ext)) return ext
-  return 'mp4'
 }

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -20,8 +20,7 @@ import { driveHeadlessRender } from '../../electron/driver.js'
 import {
   RENDER_FORMATS,
   RENDER_QUALITIES,
-  isRenderFormat,
-  type RenderFormat,
+  inferRenderFormatFromPath,
 } from '../../renderOptions.js'
 
 const RenderInput = z.object({
@@ -99,7 +98,7 @@ export async function handleRenderScene(
   const input: RenderInputData = parsed.data
   const outputPath = path.resolve(input.output)
   const scenePath = input.scene ? path.resolve(input.scene) : undefined
-  const format = input.format ?? inferFormat(outputPath)
+  const format = input.format ?? inferRenderFormatFromPath(outputPath)
   const quality = input.quality ?? 'comp'
   const fps = input.fps ?? 30
 
@@ -223,10 +222,4 @@ export async function handleRenderScene(
       },
     ],
   }
-}
-
-function inferFormat(outPath: string): RenderFormat {
-  const ext = path.extname(outPath).toLowerCase().slice(1)
-  if (isRenderFormat(ext)) return ext
-  return 'mp4'
 }

--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import path from 'node:path'
+
 export const RENDER_FORMATS = ['mp4', 'webm', 'gif'] as const
 export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
 
@@ -12,4 +14,9 @@ export function isRenderFormat(value: string): value is RenderFormat {
 
 export function isRenderQuality(value: string): value is RenderQuality {
   return RENDER_QUALITIES.includes(value as RenderQuality)
+}
+
+export function inferRenderFormatFromPath(filePath: string): RenderFormat {
+  const ext = path.extname(filePath).toLowerCase().slice(1)
+  return isRenderFormat(ext) ? ext : 'mp4'
 }


### PR DESCRIPTION
## Summary
- add a shared CLI helper for inferring render format from an output path
- reuse it in both the render command and render_scene MCP tool
- remove duplicate local inference helpers

## Verification
- pnpm --dir cli test

Note: repo-wide src/anim/engine.ts(361,7): error TS2322: Type 'TextAnimationConfig | null | undefined' is not assignable to type 'TextAnimationConfig | undefined'.
  Type 'null' is not assignable to type 'TextAnimationConfig | undefined'.
src/anim/engine.ts(368,7): error TS2322: Type 'TextAnimationConfig | null | undefined' is not assignable to type 'TextAnimationConfig | undefined'.
  Type 'null' is not assignable to type 'TextAnimationConfig | undefined'.
src/export/encodeGif.ts(3,52): error TS7016: Could not find a declaration file for module 'gifenc'. '/Users/siddharthponnapalli/.codex/worktrees/4ef2/hyper-motion-electron/node_modules/.pnpm/gifenc@1.0.3/node_modules/gifenc/dist/gifenc.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/gifenc` if it exists or add a new declaration (.d.ts) file containing `declare module 'gifenc';`
src/export/transcodeMp4.ts(141,22): error TS2322: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BlobPart'.
  Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'ArrayBufferView<ArrayBuffer>'.
    Types of property 'buffer' are incompatible.
      Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
        Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
          Types of property '[Symbol.toStringTag]' are incompatible.
            Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.
src/import/figma/layoutMap.ts(35,9): error TS2322: Type '"start" | "center" | "end" | "baseline"' is not assignable to type 'FlexAlign'.
  Type '"baseline"' is not assignable to type 'FlexAlign'.
src/layout/engine.ts(104,17): error TS2554: Expected 2 arguments, but got 1.
src/render3d/ThreeSceneViewport.tsx(368,10): error TS6133: 'queueDomPlaneTexture' is declared but its value is never read.
src/ui/actions.ts(290,37): error TS2345: Argument of type '"componentProperties"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(306,5): error TS2345: Argument of type '"componentProperties"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(321,5): error TS2345: Argument of type '"componentProperties"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(382,36): error TS2345: Argument of type '"overrides"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(406,36): error TS2345: Argument of type '"overrides"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(467,39): error TS2345: Argument of type '"variants"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(471,39): error TS2345: Argument of type '"defaultSelection"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(501,39): error TS2345: Argument of type '"variants"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(502,39): error TS2345: Argument of type '"defaultSelection"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(506,39): error TS2345: Argument of type '"variantOverrides"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(542,7): error TS2345: Argument of type '"variants"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(551,7): error TS2345: Argument of type '"variantOverrides"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(557,41): error TS2345: Argument of type '"defaultSelection"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(590,37): error TS2345: Argument of type '"interactions"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(607,5): error TS2345: Argument of type '"interactions"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(625,5): error TS2345: Argument of type '"interactions"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(646,38): error TS2345: Argument of type '"selection"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/actions.ts(762,47): error TS2345: Argument of type 'Record<string, unknown>' is not assignable to parameter of type 'Appearance'.
  Type 'Record<string, unknown>' is missing the following properties from type 'Appearance': opacity, fill, stroke, cornerRadius, effects
src/ui/actions.ts(762,57): error TS2345: Argument of type 'Appearance' is not assignable to parameter of type 'Record<string, unknown>'.
  Index signature for type 'string' is missing in type 'Appearance'.
src/ui/actions.ts(846,47): error TS2345: Argument of type '{ [x: string]: unknown; }' is not assignable to parameter of type 'Appearance'.
  Type '{ [x: string]: unknown; }' is missing the following properties from type 'Appearance': opacity, fill, stroke, cornerRadius, effects
src/ui/actions.ts(847,20): error TS2345: Argument of type 'Appearance' is not assignable to parameter of type 'Record<string, unknown>'.
  Index signature for type 'string' is missing in type 'Appearance'.
src/ui/Canvas.tsx(2464,13): error TS2322: Type '(e: React.PointerEvent<HTMLDivElement>) => void' is not assignable to type '(e: PointerEvent<HTMLElement>) => void'.
  Types of parameters 'e' and 'e' are incompatible.
    Type 'PointerEvent<HTMLElement>' is not assignable to type 'PointerEvent<HTMLDivElement>'.
      Property 'align' is missing in type 'HTMLElement' but required in type 'HTMLDivElement'.
src/ui/Canvas.tsx(2467,13): error TS2322: Type '(e: React.PointerEvent<HTMLDivElement>) => void' is not assignable to type '(e: PointerEvent<HTMLElement>) => void'.
  Types of parameters 'e' and 'e' are incompatible.
    Type 'PointerEvent<HTMLElement>' is not assignable to type 'PointerEvent<HTMLDivElement>'.
      Property 'align' is missing in type 'HTMLElement' but required in type 'HTMLDivElement'.
src/ui/Canvas.tsx(4583,10): error TS6133: 'AudioChip' is declared but its value is never read.
src/ui/ComponentEditor.tsx(85,38): error TS2345: Argument of type 'SizeAxis | undefined' is not assignable to parameter of type 'SizeAxis'.
  Type 'undefined' is not assignable to type 'SizeAxis'.
src/ui/ComponentEditor.tsx(86,39): error TS2345: Argument of type 'SizeAxis | undefined' is not assignable to parameter of type 'SizeAxis'.
  Type 'undefined' is not assignable to type 'SizeAxis'.
src/ui/ComponentEditor.tsx(373,38): error TS2345: Argument of type '"variantPositions"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/ComponentEditor.tsx(510,9): error TS2322: Type 'RefObject<HTMLElement | null>' is not assignable to type 'Ref<HTMLDivElement> | undefined'.
  Type 'RefObject<HTMLElement | null>' is not assignable to type 'RefObject<HTMLDivElement | null>'.
    Type 'HTMLElement | null' is not assignable to type 'HTMLDivElement | null'.
      Property 'align' is missing in type 'HTMLElement' but required in type 'HTMLDivElement'.
src/ui/ComponentEditor.tsx(794,7): error TS2345: Argument of type '"variants"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/ComponentEditor.tsx(806,7): error TS2345: Argument of type '"defaultSelection"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/ComponentEditor.tsx(813,7): error TS2345: Argument of type '"variantOverrides"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/ComponentEditor.tsx(822,7): error TS2345: Argument of type '"interactions"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/hooks/useFigmaPaste.ts(73,42): error TS2339: Property 'clipboard' does not exist on type '{ invoke: (channel: string, ...args: unknown[]) => Promise<unknown>; on?: ((channel: string, listener: (...args: unknown[]) => void) => () => void) | undefined; }'.
src/ui/hooks/useFigmaPaste.ts(77,18): error TS7006: Parameter 'text' implicitly has an 'any' type.
src/ui/hooks/useFigmaPaste.ts(82,19): error TS7006: Parameter 'err' implicitly has an 'any' type.
src/ui/Inspector.tsx(410,63): error TS2345: Argument of type '"clipsContent"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(846,49): error TS2345: Argument of type '"clipsContent"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(1135,9): error TS6133: 'version' is declared but its value is never read.
src/ui/Inspector.tsx(1164,9): error TS6133: 'liveFocusDistance' is declared but its value is never read.
src/ui/Inspector.tsx(1176,9): error TS6133: 'liveFocusWorldX' is declared but its value is never read.
src/ui/Inspector.tsx(1184,9): error TS6133: 'liveFocusWorldY' is declared but its value is never read.
src/ui/Inspector.tsx(1198,9): error TS6133: 'liveIso' is declared but its value is never read.
src/ui/Inspector.tsx(1203,9): error TS6133: 'liveNearClip' is declared but its value is never read.
src/ui/Inspector.tsx(1205,9): error TS6133: 'liveFarClip' is declared but its value is never read.
src/ui/Inspector.tsx(1368,9): error TS6133: 'patchPreciseFocusPoint' is declared but its value is never read.
src/ui/Inspector.tsx(1878,63): error TS2345: Argument of type '"clipsContent"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(2136,10): error TS6133: 'UniformScaleField' is declared but its value is never read.
src/ui/Inspector.tsx(2627,10): error TS6133: 'InstanceComponentPropertiesSection' is declared but its value is never read.
src/ui/Inspector.tsx(2768,57): error TS2345: Argument of type '"defaultSelection"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(3184,9): error TS6133: 'playhead' is declared but its value is never read.
src/ui/Inspector.tsx(3199,39): error TS2345: Argument of type '"variantTransition"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(3971,40): error TS2345: Argument of type '"fontFamily"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(3984,36): error TS2345: Argument of type '"fontFamily"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(4001,38): error TS2345: Argument of type '"fontFamily"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(4047,42): error TS2345: Argument of type '"fontWeight"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(4056,42): error TS2345: Argument of type '"fontSize"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(4067,42): error TS2345: Argument of type '"lineHeight"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(4076,57): error TS2345: Argument of type '"letterSpacing"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(4090,57): error TS2345: Argument of type '"textAlign"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(4102,49): error TS2345: Argument of type '"color"' is not assignable to parameter of type 'keyof NodeBaseMutable'.
src/ui/Inspector.tsx(5236,48): error TS2345: Argument of type 'Node' is not assignable to parameter of type 'Node | null'.
  Type 'CameraNode' is missing the following properties from type 'Node': baseURI, childNodes, firstChild, isConnected, and 46 more.
src/ui/Inspector.tsx(5236,48): error TS2352: Conversion of type 'EventTarget | null' to type 'Node' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  Type 'EventTarget' is not comparable to type 'Node'.
src/ui/Inspector.tsx(5381,49): error TS2322: Type 'string | null' is not assignable to type 'string'.
  Type 'null' is not assignable to type 'string'.
src/ui/Inspector.tsx(5417,49): error TS2322: Type 'string | null' is not assignable to type 'string'.
  Type 'null' is not assignable to type 'string'.
src/ui/Inspector.tsx(5491,49): error TS2322: Type 'string | null' is not assignable to type 'string'.
  Type 'null' is not assignable to type 'string'.
src/ui/LayersPanel.tsx(504,11): error TS2554: Expected 2 arguments, but got 1.
src/ui/Timeline.tsx(119,9): error TS6133: 'selectedTrackIds' is declared but its value is never read.
src/ui/Timeline.tsx(141,9): error TS6133: 'groupTracksAction' is declared but its value is never read.
src/ui/Timeline.tsx(987,9): error TS6133: 'trackHiddenByCollapsedGroup' is declared but its value is never read.
src/ui/Timeline.tsx(4218,10): error TS6133: 'StatesRow' is declared but its value is never read.
[ELIFECYCLE] Command failed with exit code 2. still fails on unrelated existing app type errors outside this CLI change.