### PR TITLE
Keep capabilities tool description current

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -101,6 +101,12 @@ test('capability tool schemas accept no arguments', () => {
   })
 })
 
+test('get_capabilities description mentions validation and query tools', () => {
+  const getCapabilities = TOOLS.find((tool) => tool.name === 'get_capabilities')
+
+  assert.match(getCapabilities?.description ?? '', /validation\/query tools/)
+})
+
 function parseToolJson(result: CallToolResult): CapabilitiesToolPayload {
   const parsed: unknown = JSON.parse(assertToolText(result))
   assert.equal(typeof parsed, 'object')

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -44,7 +44,8 @@ type KeyframeablePropertiesPayload = {
 
 export const getCapabilitiesTool: Tool = {
   name: 'get_capabilities',
-  description: 'Return supported scene node kinds, patch operations, render formats, and keyframeable properties.',
+  description:
+    'Return supported scene node kinds, patch operations, render formats, validation/query tools, and keyframeable properties.',
   inputSchema: { type: 'object', properties: {}, required: [] },
 }
 


### PR DESCRIPTION
## Summary\n- Update the get_capabilities MCP tool description to mention validation/query tools.\n- Add a focused CLI test assertion so the description stays in sync.\n\n## Verification\n- pnpm --dir cli test\n\nNote: root pnpm typecheck currently fails on unrelated pre-existing app TypeScript errors; this change is verified with the CLI test suite covering the touched MCP code.