### PR TITLE
test(cli): cover primitive scene JSON rejection

### DIFF
--- a/cli/src/commands/create.test.ts
+++ b/cli/src/commands/create.test.ts
@@ -167,3 +167,30 @@ test('create command rejects top-level JSON null', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('create command rejects top-level primitive JSON values', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-create-'))
+  const sourcePath = path.join(dir, 'scene.json')
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    fs.writeFileSync(sourcePath, '"scene"')
+
+    const stderr = await withProcessExitThrow(async () => {
+      return captureStderr(async () => {
+        await assert.rejects(
+          createCommand()
+            .parseAsync([scenePath, '--from', sourcePath], { from: 'user' }),
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.match(
+      stderr,
+      /^\[create\] scene JSON must be an object at the top level\.$/m,
+    )
+    assert.equal(fs.existsSync(scenePath), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add CLI create-command coverage for top-level primitive JSON input
- verify primitive values are rejected before writing a scene file

## Tests
- pnpm --dir cli test
