### PR TITLE
Normalize MCP render preset inputs

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -188,6 +188,46 @@ test('render_scene reports output directory stat failures as MCP errors', async 
   }
 })
 
+test('render_scene normalizes padded format and quality values', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-normalize-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.webm')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const formatArg = process.argv.find((arg) => arg === '--format=webm');",
+      "const qualityArg = process.argv.find((arg) => arg === '--quality=4k');",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out || !formatArg || !qualityArg) process.exit(2);",
+      "fs.writeFileSync(out, 'ok');",
+      "fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: 2 }));",
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    const result = await withEnvVar('HYPERMOTION_APP_PATH', appPath, () =>
+      handleRenderScene({
+        output: outputPath,
+        format: ' WEBM ',
+        quality: ' 4K ',
+      }),
+    )
+
+    assert.equal(result.isError, undefined)
+    assert.equal(
+      assertToolText(result),
+      `Rendered current desktop scene → ${outputPath} (webm · 4k · 30fps)`,
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render_scene reports desktop driver failures as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-fail-'))
   const appPath = path.join(dir, 'hyper-motion')

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -26,11 +26,11 @@ import {
 const RenderInput = z.object({
   output: z.string().describe('Absolute or relative path where the rendered file should be written'),
   format: z
-    .enum(RENDER_FORMATS)
+    .preprocess(normalizeStringOption, z.enum(RENDER_FORMATS))
     .optional()
     .describe('Output format. Defaults to inferred from the output file extension.'),
   quality: z
-    .enum(RENDER_QUALITIES)
+    .preprocess(normalizeStringOption, z.enum(RENDER_QUALITIES))
     .optional()
     .describe('Output resolution preset. `comp` matches the scene canvas size (fastest). Default: comp.'),
   fps: z.number().int().positive().max(120).optional().describe('Frame rate. Default: 30.'),
@@ -42,6 +42,10 @@ const RenderInput = z.object({
     ),
 })
 type RenderInputData = z.infer<typeof RenderInput>
+
+function normalizeStringOption(value: unknown): unknown {
+  return typeof value === 'string' ? value.trim().toLowerCase() : value
+}
 
 export const renderSceneTool: Tool = {
   name: 'render_scene',


### PR DESCRIPTION
## Summary
- Normalize MCP render_scene format and quality string inputs by trimming whitespace and lowercasing before validation
- Add coverage that padded uppercase presets reach the render driver as canonical values

## Tests
- pnpm --dir cli test