### PR TITLE
chore(cli): type capability tool payloads

### DIFF
--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -42,6 +42,8 @@ type KeyframeablePropertiesPayload = {
   keyframeableProperties: typeof PROPERTY_IDS
 }
 
+type CapabilityToolPayload = CapabilitiesPayload | KeyframeablePropertiesPayload
+
 export const getCapabilitiesTool: Tool = {
   name: 'get_capabilities',
   description:
@@ -83,7 +85,7 @@ export async function handleListKeyframeableProperties(): Promise<CallToolResult
   return text(payload)
 }
 
-function text(value: unknown): CallToolResult {
+function text(value: CapabilityToolPayload): CallToolResult {
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }],
   }


### PR DESCRIPTION
## Summary
- narrow the MCP capabilities response serializer to the two supported payload shapes
- keep the runtime JSON output unchanged while making accidental non-capability payloads a compile-time error

## Verification
- pnpm --dir cli test

## Note
- pnpm typecheck currently fails on existing app-level TypeScript errors outside this CLI change.