### PR TITLE
Trim render scene path input

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -147,6 +147,27 @@ test('render command trims padded format, quality, and fps values', async () => 
   }
 })
 
+test('render command trims padded scene paths', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-trimmed-scene-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const outputPath = path.join(dir, 'out.mp4')
+  const appPath = path.join(dir, 'hyper-motion')
+  const calls: HeadlessRenderRequest[] = []
+  fs.writeFileSync(scenePath, 'fake scene')
+  try {
+    await renderCommand({
+      locateApp: async () => appPath,
+      driveRender: async (req) => {
+        calls.push(req)
+      },
+    }).parseAsync(['-o', outputPath, '--scene', ` ${scenePath} `], { from: 'user' })
+
+    assert.equal(calls[0]?.scenePath, scenePath)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render command reports invalid fps before launching the app', async () => {
   const stderr = await captureStderr(() => {
     return withProcessExitThrow(async () => {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -120,7 +120,8 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
         }
       }
 
-      const scenePath = opts.scene ? path.resolve(opts.scene) : undefined
+      const sceneInput = opts.scene?.trim()
+      const scenePath = sceneInput ? path.resolve(sceneInput) : undefined
       if (scenePath && !existsSync(scenePath)) {
         console.error(`[render] scene file not found: ${scenePath}`)
         process.exit(2)


### PR DESCRIPTION
## Summary
- trim padded CLI --scene values before resolving and validating render scene paths
- add command coverage for padded scene path input

## Tests
- pnpm --dir cli test -- --test-name-pattern "render command" (runs full CLI suite; 279 passed)

## Notes
- pnpm typecheck currently fails on unrelated app-wide TypeScript errors outside this CLI change.
- pnpm lint currently fails on unrelated app-wide lint errors outside this CLI change.