### PR TITLE
Handle info directory inputs cleanly

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -363,7 +363,7 @@ test('info command reports directory inputs as non-files', async () => {
       })
     })
 
-    assert.match(stderr, /^\[info\] scene path is not a file: /)
+    assert.equal(stderr, `[info] scene path is not a file: ${dir}\n`)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -30,12 +30,22 @@ export function infoCommand(): Command {
     .action((scenePath: string, options: InfoCommandOptions) => {
       const resolvedScenePath = path.resolve(scenePath)
       let bytes: Buffer
+      let stats: fs.Stats
       try {
-        const stats = fs.statSync(resolvedScenePath)
-        if (!stats.isFile()) {
-          console.error(`[info] scene path is not a file: ${resolvedScenePath}`)
-          process.exit(2)
-        }
+        stats = fs.statSync(resolvedScenePath)
+      } catch (err) {
+        console.error(
+          `[info] failed to read ${resolvedScenePath}: ${
+            err instanceof Error ? err.message : err
+          }`,
+        )
+        process.exit(2)
+      }
+      if (!stats.isFile()) {
+        console.error(`[info] scene path is not a file: ${resolvedScenePath}`)
+        process.exit(2)
+      }
+      try {
         bytes = fs.readFileSync(resolvedScenePath)
       } catch (err) {
         console.error(


### PR DESCRIPTION
## Summary
- Split `hypermotion info` stat and read error handling so directory inputs produce one clear non-file error
- Tighten the directory-input test to assert the exact stderr output

## Tests
- `pnpm --dir cli test`