### PR TITLE
fix(cli): clarify query scene malformed file errors

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -141,7 +141,7 @@ test('query scene MCP handlers report malformed scene files as MCP errors', asyn
       assert.equal(result.isError, true)
       assert.match(
         assertToolText(result),
-        new RegExp(`^${entry.name}: failed to read ${escapeRegExp(scenePath)}:`),
+        new RegExp(`^${entry.name}: ${escapeRegExp(scenePath)} is not a valid \\.hype file:`),
       )
     }
   } finally {

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -146,6 +146,7 @@ export async function handleListCameras(
 }
 
 function read(toolName: QuerySceneToolName, scenePath: string): ReadSceneResult {
+  let bytes: Buffer
   try {
     const stats = fs.statSync(scenePath)
     if (!stats.isFile()) {
@@ -163,7 +164,7 @@ function read(toolName: QuerySceneToolName, scenePath: string): ReadSceneResult 
       }
     }
 
-    return { ok: true, scene: inspectScene(new Uint8Array(fs.readFileSync(scenePath))) }
+    bytes = fs.readFileSync(scenePath)
   } catch (err) {
     return {
       ok: false,
@@ -173,6 +174,25 @@ function read(toolName: QuerySceneToolName, scenePath: string): ReadSceneResult 
           {
             type: 'text' as const,
             text: `${toolName}: failed to read ${scenePath}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          },
+        ],
+      },
+    }
+  }
+
+  try {
+    return { ok: true, scene: inspectScene(new Uint8Array(bytes)) }
+  } catch (err) {
+    return {
+      ok: false,
+      result: {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: `${toolName}: ${scenePath} is not a valid .hype file: ${
               err instanceof Error ? err.message : String(err)
             }`,
           },


### PR DESCRIPTION
## Summary\n- report malformed .hype contents from query-scene MCP tools as invalid scene files instead of read failures\n- update the existing malformed-file query scene test expectation\n\n## Tests\n- pnpm --dir cli run build && node --test cli/dist/mcp/queryScene.test.js\n- pnpm --dir cli test