### PR TITLE
fix(cli): report render output mkdir failures

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -326,6 +326,39 @@ test('render command reports output parent files before launching the app', asyn
   }
 })
 
+test('render command reports output directory creation failures before launching the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-mkdir-'))
+  const outPath = path.join(dir, 'exports', 'out.mp4')
+  try {
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          renderCommand({
+            locateApp: async () => path.join(dir, 'hyper-motion'),
+            driveRender: async () => {
+              throw new Error('should not render')
+            },
+            mkdirSync: ((targetPath: fs.PathLike) => {
+              if (targetPath === path.dirname(outPath)) throw new Error('mkdir failed')
+              return fs.mkdirSync(targetPath, { recursive: true })
+            }) as typeof fs.mkdirSync,
+          }).parseAsync(['-o', outPath], {
+            from: 'user',
+          }),
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.equal(
+      stderr,
+      `[render] failed to create output directory ${path.dirname(outPath)}: mkdir failed\n`,
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render command reports output directory stat failures before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-stat-'))
   const outPath = path.join(dir, 'out.mp4')

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -101,7 +101,16 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
       // post-render write doesn't fail on a missing parent.
       const outDir = path.dirname(outputPath)
       if (!existsSync(outDir)) {
-        mkdirSync(outDir, { recursive: true })
+        try {
+          mkdirSync(outDir, { recursive: true })
+        } catch (err) {
+          console.error(
+            `[render] failed to create output directory ${outDir}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          )
+          process.exit(2)
+        }
       } else {
         let outDirStats: fs.Stats
         try {


### PR DESCRIPTION
## Summary
- report output directory creation failures as render command errors
- cover the mkdir failure path before desktop app launch

## Tests
- pnpm test