### PR TITLE
chore(cli): tighten stdout capture callback type

### DIFF
--- a/cli/src/testUtils/stdout.ts
+++ b/cli/src/testUtils/stdout.ts
@@ -14,7 +14,7 @@ function stringifyChunk(
 
 async function captureStream(
   stream: WritableStream,
-  run: CaptureCallback<unknown>,
+  run: CaptureCallback<void>,
 ): Promise<string> {
   let output = ''
   const write = stream.write
@@ -40,13 +40,13 @@ async function captureStream(
 }
 
 export async function captureStdout(
-  run: CaptureCallback<unknown>,
+  run: CaptureCallback<void>,
 ): Promise<string> {
   return captureStream(process.stdout, run)
 }
 
 export async function captureStderr(
-  run: CaptureCallback<unknown>,
+  run: CaptureCallback<void>,
 ): Promise<string> {
   return captureStream(process.stderr, run)
 }


### PR DESCRIPTION
## Summary
- tighten the CLI stdout/stderr capture helper callback type to `void`
- keep the helper API aligned with its side-effect-only usage in tests

## Tests
- pnpm --dir cli test