### PR TITLE
test(cli): cover trimmed desktop app override

### DIFF
--- a/cli/src/electron/locator.test.ts
+++ b/cli/src/electron/locator.test.ts
@@ -24,6 +24,21 @@ test('locator returns an existing HYPERMOTION_APP_PATH override', async () => {
   }
 })
 
+test('locator trims whitespace around HYPERMOTION_APP_PATH overrides', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-spaces-'))
+  const appPath = path.join(dir, 'hyper-motion')
+
+  try {
+    fs.writeFileSync(appPath, '')
+
+    await withEnvVar('HYPERMOTION_APP_PATH', `  ${appPath}  `, async () => {
+      assert.equal(await locateDesktopApp(), appPath)
+    })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('locator rejects a missing HYPERMOTION_APP_PATH override', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-missing-'))
   const missingPath = path.join(dir, 'hyper-motion')


### PR DESCRIPTION
## Summary
- add focused CLI locator coverage for padded HYPERMOTION_APP_PATH overrides

## Tests
- pnpm --dir cli run build && node --test cli/dist/electron/locator.test.js
- pnpm test