### PR TITLE
Validate scene parent field types

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1003,6 +1003,22 @@ test('validateScene rejects node children that are not arrays', () => {
   ])
 })
 
+test('validateScene rejects node parents that are not strings or null', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const nodes = scene.get('nodes') as Y.Map<Y.Map<unknown>>
+  nodes.get('title')?.set('parent', 42)
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'node root lists child title, but child\'s parent is 42',
+    'node title parent must be a string or null',
+  ])
+})
+
 test('validateScene rejects node ids that do not match their map key', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -889,6 +889,9 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
       errors.push(`node ${id} has unsupported kind: ${String(node.kind)}`)
     }
     const parent = typeof node.parent === 'string' ? node.parent : null
+    if (node.parent !== undefined && node.parent !== null && typeof node.parent !== 'string') {
+      errors.push(`node ${id} parent must be a string or null`)
+    }
     if (node.kind === 'camera' && parent) {
       errors.push(`camera node ${id} must be scene-level with parent: null`)
     }


### PR DESCRIPTION
## Summary
- reject malformed saved scene nodes whose parent field is neither a string nor null
- add validator coverage for non-string parent fields

## Tests
- pnpm test