### PR TITLE
Clarify Windows support roadmap wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ codesign --force --deep --sign - /Applications/hyper-motion.app
 Then double-click. Full reasoning + alternatives in the
 [main README's install section](https://github.com/psiddharthdesign/hypermotion#install-macos).
 
-Windows build is not shipping yet — coming in a later v0.1.x release.
+Windows build is not shipping yet — track upcoming platform support in releases.
 
 The CLI uses the installed desktop app to actually run renders — it
 doesn't ship its own render engine. If the app isn't installed, the CLI

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Safari / Brave / Chrome add to downloaded files, and
 downloaded one). Apple Developer signing + notarization — which removes
 both steps entirely — is on the v0.2 roadmap.
 
-> Windows build is not shipping yet. Coming in a later v0.1.x release.
+> Windows build is not shipping yet. Track upcoming platform support in releases.
 
 ### Build from source
 


### PR DESCRIPTION
## Summary
- remove stale v0.1.x promise from Windows support wording
- keep the current docs status that Windows builds are not shipping yet

## Tests
- pnpm test