### PR TITLE
Resolve CLI create output paths consistently

### DIFF
--- a/cli/src/commands/create.test.ts
+++ b/cli/src/commands/create.test.ts
@@ -43,7 +43,10 @@ test('create command makes nested output directories', async () => {
 
     const summary = readSceneSummary(fs.readFileSync(scenePath))
 
-    assert.match(stdout, /^Wrote .+scene\.hype \(.*1 layer, 0 tracks\)$/m)
+    assert.match(
+      stdout,
+      new RegExp(`^Wrote ${escapeRegExp(scenePath)} \\(.*1 layer, 0 tracks\\)$`, 'm'),
+    )
     assert.equal(summary.meta.name, 'Nested Create')
     assert.deepEqual(summary.meta.canvas, { width: 320, height: 180 })
     assert.equal(summary.root, 'root')
@@ -106,13 +109,20 @@ test('create command reports authored layer and track counts', async () => {
 
     const summary = readSceneSummary(fs.readFileSync(scenePath))
 
-    assert.match(stdout, /^Wrote .+scene\.hype \(.*1 layer, 1 track\)$/m)
+    assert.match(
+      stdout,
+      new RegExp(`^Wrote ${escapeRegExp(scenePath)} \\(.*1 layer, 1 track\\)$`, 'm'),
+    )
     assert.equal(summary.layerCount, 1)
     assert.equal(summary.trackCount, 1)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
 
 test('create command rejects top-level JSON arrays', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-create-'))

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -110,7 +110,8 @@ export function createCommand(): Command {
       // Make sure the output's parent directory exists. Tools and
       // agents tend to specify deeply-nested paths; we don't want a
       // simple ENOENT to obscure the real error.
-      const outDir = path.dirname(path.resolve(output))
+      const outputPath = path.resolve(output)
+      const outDir = path.dirname(outputPath)
       try {
         fs.mkdirSync(outDir, { recursive: true })
       } catch (err) {
@@ -123,10 +124,10 @@ export function createCommand(): Command {
       }
 
       try {
-        fs.writeFileSync(output, Buffer.from(bytes))
+        fs.writeFileSync(outputPath, Buffer.from(bytes))
       } catch (err) {
         console.error(
-          `[create] failed to write ${output}: ${
+          `[create] failed to write ${outputPath}: ${
             err instanceof Error ? err.message : err
           }`,
         )
@@ -137,7 +138,7 @@ export function createCommand(): Command {
       const layers = summary.layerCount
       const tracks = summary.trackCount
       console.log(
-        `Wrote ${output} (${formatBytes(bytes.length)}, ${layers} layer${layers === 1 ? '' : 's'}, ${tracks} track${tracks === 1 ? '' : 's'})`,
+        `Wrote ${outputPath} (${formatBytes(bytes.length)}, ${layers} layer${layers === 1 ? '' : 's'}, ${tracks} track${tracks === 1 ? '' : 's'})`,
       )
     })
 }


### PR DESCRIPTION
## Summary
- resolve the CLI create output path once and use that path for mkdir, write, errors, and success output
- tighten create-command tests to assert the exact written path

## Verification
- pnpm --dir cli test
- pnpm test

Note: pnpm lint was attempted but the current app lint baseline has pre-existing errors outside this change (for example React hook lint errors in src/render/RenderWindowApp.tsx, src/render3d/ThreeSceneViewport.tsx, src/ui/Canvas.tsx, and others).