### PR TITLE
Harden process exit test assertion

### DIFF
--- a/cli/src/testUtils/processExit.test.ts
+++ b/cli/src/testUtils/processExit.test.ts
@@ -111,4 +111,10 @@ test('withProcessExitThrow treats null process.exit codes as success', async () 
 function assertProcessExitError(err: unknown): asserts err is ProcessExitError {
   assert.ok(err instanceof Error)
   assert.ok('exitCode' in err)
+  assert.ok(
+    err.exitCode === undefined ||
+      err.exitCode === null ||
+      typeof err.exitCode === 'number' ||
+      typeof err.exitCode === 'string',
+  )
 }


### PR DESCRIPTION
## Summary
- tighten the CLI process-exit test helper assertion to verify the captured exit code shape

## Tests
- pnpm --dir cli run build && node --test cli/dist/testUtils/processExit.test.js
- pnpm test