### PR TITLE
fix(cli): trim MCP render scene paths

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -228,6 +228,47 @@ test('render_scene normalizes padded format and quality values', async () => {
   }
 })
 
+test('render_scene normalizes padded scene paths', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-scene-normalize-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+  const scenePath = path.join(dir, 'scene.hype')
+
+  fs.writeFileSync(scenePath, '')
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const sceneArg = process.argv.find((arg) => arg.startsWith('--scene='));",
+      "const out = outArg?.slice('--out='.length);",
+      "const scene = sceneArg?.slice('--scene='.length);",
+      `if (!out || scene !== ${JSON.stringify(scenePath)}) process.exit(2);`,
+      "fs.writeFileSync(out, 'ok');",
+      "fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: 2 }));",
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    const result = await withEnvVar('HYPERMOTION_APP_PATH', appPath, () =>
+      handleRenderScene({
+        output: outputPath,
+        scene: ` ${scenePath} `,
+      }),
+    )
+
+    assert.equal(result.isError, undefined)
+    assert.equal(
+      assertToolText(result),
+      `Rendered ${scenePath} → ${outputPath} (mp4 · comp · 30fps)`,
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render_scene reports desktop driver failures as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-fail-'))
   const appPath = path.join(dir, 'hyper-motion')

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -101,7 +101,8 @@ export async function handleRenderScene(
 
   const input: RenderInputData = parsed.data
   const outputPath = path.resolve(input.output)
-  const scenePath = input.scene ? path.resolve(input.scene) : undefined
+  const sceneInput = input.scene?.trim()
+  const scenePath = sceneInput ? path.resolve(sceneInput) : undefined
   const format = input.format ?? inferRenderFormatFromPath(outputPath)
   const quality = input.quality ?? 'comp'
   const fps = input.fps ?? 30


### PR DESCRIPTION
## Summary
- Trim optional MCP render_scene scene paths before resolving them
- Add coverage that padded scene paths are forwarded cleanly to the render driver

## Tests
- pnpm --dir cli test