### PR TITLE
chore: refresh preload event comment

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -42,9 +42,8 @@ contextBridge.exposeInMainWorld('hypermotion', {
   // future feature.
   invoke: (channel: string, ...args: unknown[]) =>
     ipcRenderer.invoke(channel, ...args),
-  // Event subscription. Returns an unsubscribe function. Used by the
-  // headless export driver to receive `export:headless-trigger` events
-  // when the running editor handles a second-instance render request.
+  // Event subscription. Returns an unsubscribe function. Used by export
+  // flows to receive headless triggers and render-window progress events.
   on: (
     channel: string,
     listener: (...args: unknown[]) => void,


### PR DESCRIPTION
## Summary
- update the preload bridge event subscription comment to mention render-window progress events

## Verification
- pnpm exec eslint electron/preload.ts

## Notes
- pnpm lint currently fails on pre-existing repository-wide lint issues outside this change.
- pnpm typecheck currently fails on pre-existing repository-wide type errors outside this change.