### PR TITLE
fix(cli): report render output mkdir failures

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -188,6 +188,38 @@ test('render_scene reports output directory stat failures as MCP errors', async 
   }
 })
 
+test('render_scene reports output directory creation failures as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-mkdir-'))
+  const outDir = path.join(dir, 'exports')
+  const previousMkdirSync = fs.mkdirSync
+
+  try {
+    Object.defineProperty(fs, 'mkdirSync', {
+      configurable: true,
+      value: (targetPath: fs.PathLike, options?: fs.MakeDirectoryOptions) => {
+        if (targetPath === outDir) throw new Error('mkdir failed')
+        return previousMkdirSync(targetPath, options)
+      },
+    })
+
+    const result = await handleRenderScene({
+      output: path.join(outDir, 'out.mp4'),
+    })
+
+    assert.equal(result.isError, true)
+    assert.equal(
+      assertToolText(result),
+      'render_scene: failed to create output directory: mkdir failed',
+    )
+  } finally {
+    Object.defineProperty(fs, 'mkdirSync', {
+      configurable: true,
+      value: previousMkdirSync,
+    })
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render_scene normalizes padded format and quality values', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-normalize-'))
   const appPath = path.join(dir, 'fake-app.mjs')

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -179,6 +179,24 @@ export async function handleRenderScene(
     }
   }
 
+  if (!fs.existsSync(outDir)) {
+    try {
+      fs.mkdirSync(outDir, { recursive: true })
+    } catch (err) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: `render_scene: failed to create output directory: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          },
+        ],
+      }
+    }
+  }
+
   const appPath = await locateDesktopApp()
   if (!appPath) {
     return {
@@ -192,10 +210,6 @@ export async function handleRenderScene(
         },
       ],
     }
-  }
-
-  if (!fs.existsSync(outDir)) {
-    fs.mkdirSync(outDir, { recursive: true })
   }
 
   try {


### PR DESCRIPTION
## Summary
- return a structured MCP error when render_scene cannot create the output directory
- add regression coverage for output directory creation failures

## Tests
- pnpm --dir cli test