### PR TITLE
Document text animation fields in create_scene

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -116,6 +116,24 @@ test('create_scene description lists supported layout property ids', () => {
   }
 })
 
+test('create_scene description mentions text animation track fields', () => {
+  const description = createSceneTool.description
+  if (typeof description !== 'string') {
+    throw new Error('create_scene description is missing')
+  }
+
+  for (const field of [
+    'textAnimation',
+    'applyTo',
+    'startTime',
+    'easingPresetId',
+    'travelDistance',
+    'blurRadius',
+  ]) {
+    assert.match(description, new RegExp(field))
+  }
+})
+
 test('create_scene description stays in sync with supported property ids', () => {
   const description = createSceneTool.description
   if (typeof description !== 'string') {

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -78,7 +78,8 @@ export const createSceneTool: Tool = {
     "Components can define variants, defaultSelection, variantOverrides, timelines, and interactions. " +
     "Instances point at componentId and carry selection, overrides, and instance-local interaction additions. " +
     "Component timelines are local tracks triggered by interactions, e.g. onClick -> playTimeline, and are scoped per instance.\n" +
-    "Tracks: { id, nodeId, propertyId, keyframes?: [{ id, time, value, easingOut? }], defaultEasing? } — omitted keyframes default to [].\n" +
+    "Tracks: { id, nodeId, propertyId, keyframes?: [{ id, time, value, easingOut? }], defaultEasing?, textAnimation? } — omitted keyframes default to [].\n" +
+    "Text animation tracks can include textAnimation with mode, applyTo, order, delay, smoothing, duration, startTime, acceleration, easingPresetId, easingStrength, direction, travelDistance, and blurRadius.\n" +
     "Camera nodes can include focalLength, fieldOfView, pointOfInterestX/Y/Z, nearClip, farClip, " +
     "depthOfField, focusMode, focusWorldX/Y/Z, focusTargetNodeId, focusDistance, focusRadius, focusFalloff, aperture, iso, blurLevel, " +
     "blurQuality, and showFocusPlane. Hyper Motion currently supports only one camera node per scene; " +


### PR DESCRIPTION
## Summary
- mention the supported textAnimation track field in the create_scene MCP description
- add a focused test that keeps the description aligned with text animation fields

## Tests
- pnpm --dir cli test