### PR TITLE
test(cli): cover extensionless render fallback

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -17,4 +17,5 @@ test('inferRenderFormatFromPath normalizes extension casing', () => {
 test('inferRenderFormatFromPath falls back to mp4 for unknown extensions', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.mov'), 'mp4')
   assert.equal(inferRenderFormatFromPath('/tmp/demo'), 'mp4')
+  assert.equal(inferRenderFormatFromPath('/tmp/demo.'), 'mp4')
 })


### PR DESCRIPTION
## Summary
- add a render option assertion for output paths that end with a trailing dot
- keeps extensionless or unknown output paths pinned to the mp4 fallback behavior

## Tests
- pnpm run build && node --test dist/renderOptions.test.js
- pnpm test