### PR TITLE
docs: remove stale Lottie export claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ properties (variant state, opacity, scale, gap, padding) — not raw `x`
 and `y`. When the design moves, the animation survives.
 
 Plus everything you expect from a Jitter-class tool: a real timeline,
-in/out presets, easing curves, 3D camera with depth-of-field, MP4 / WebM
-/ GIF / Lottie export.
+in/out presets, easing curves, 3D camera with depth-of-field, and MP4 /
+WebM / GIF export.
 
 ## Status — v0.1.11 research preview
 


### PR DESCRIPTION
## Summary\n- remove the stale README intro claim that Hyper Motion currently exports Lottie\n- keep the listed export formats aligned with the supported MP4, WebM, and GIF paths\n\n## Tests\n- pnpm test