### PR TITLE
test(cli): cover trimmed open scene paths

### DIFF
--- a/cli/src/commands/open.test.ts
+++ b/cli/src/commands/open.test.ts
@@ -76,6 +76,27 @@ test('open command resolves relative scene paths before launching the app', asyn
   }
 })
 
+test('open command trims padded scene paths before launching the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-trimmed-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const appPath = path.join(dir, 'hyper-motion')
+  const spawnCalls: Array<{ command: string; args: readonly string[] }> = []
+  fs.writeFileSync(scenePath, '')
+  try {
+    await openCommand({
+      locateApp: async () => appPath,
+      spawnApp: (command, args) => {
+        spawnCalls.push({ command, args })
+        return { unref: () => {} } satisfies Pick<ChildProcess, 'unref'>
+      },
+    }).parseAsync([`  ${scenePath}  `], { from: 'user' })
+
+    assert.deepEqual(spawnCalls, [{ command: appPath, args: [scenePath] }])
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('open command reports missing scene files before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-'))
   const scenePath = path.join(dir, 'missing.hype')

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -31,7 +31,7 @@ export function openCommand(deps: Partial<OpenCommandDeps> = {}): Command {
     .description('Open a .hype scene file in the hyper-motion desktop app.')
     .argument('<scene>', 'Path to a .hype scene file')
     .action(async (scene: string) => {
-      const scenePath = path.resolve(scene)
+      const scenePath = path.resolve(scene.trim())
       if (!commandDeps.existsSync(scenePath)) {
         console.error(`[open] scene file not found: ${scenePath}`)
         process.exit(2)


### PR DESCRIPTION
## Summary\n- trim padded scene arguments in the CLI open command before resolving the path\n- add a regression test that verifies the normalized path is passed to the desktop app\n\n## Tests\n- pnpm --dir cli test