### PR TITLE
docs(cli): clarify create_scene JSON input comment

### DIFF
--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -127,8 +127,8 @@ export async function handleCreateScene(
   }
 
   // Accept the scene either as an inline object or a JSON string.
-  // Most MCP clients send objects, but some (and human users via the
-  // CLI's inspector) find string-encoded JSON easier to construct.
+  // Most MCP clients send objects, but some agents and scripts find
+  // string-encoded JSON easier to construct and pass through stdio.
   const input: CreateInputData = parsed.data
   let scene: SceneJson
   try {


### PR DESCRIPTION
## Summary\n- Clarifies the create_scene handler comment for string-encoded JSON inputs.\n- Removes a stale reference to the CLI inspector in this MCP path.\n\n## Verification\n- pnpm --dir cli test