### PR TITLE
Normalize invalid fps error output

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -221,6 +221,21 @@ test('render command reports non-numeric fps before launching the app', async ()
   assert.match(stderr, /^\[render\] invalid fps: fast$/m)
 })
 
+test('render command reports trimmed invalid fps values', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        renderCommand().parseAsync(['-o', 'out.mp4', '--fps', ' 30.5 '], {
+          from: 'user',
+        }),
+        { exitCode: 1 },
+      )
+    })
+  })
+
+  assert.match(stderr, /^\[render\] invalid fps: 30\.5$/m)
+})
+
 test('render command rejects fps values above the MCP limit before launching the app', async () => {
   const stderr = await captureStderr(() => {
     return withProcessExitThrow(async () => {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -93,7 +93,7 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
       const fpsInput = opts.fps?.trim() ?? '30'
       const fps = Number(fpsInput)
       if (!Number.isInteger(fps) || fps <= 0 || fps > 120) {
-        console.error(`[render] invalid fps: ${opts.fps}`)
+        console.error(`[render] invalid fps: ${fpsInput}`)
         process.exit(1)
       }
 


### PR DESCRIPTION
## Summary
- print the normalized fps input when render command validation fails
- add a regression test for padded invalid fps values

## Tests
- pnpm --dir cli test