### PR TITLE
fix(cli): trim MCP open scene paths

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -145,3 +145,30 @@ test('open_scene reports opened scene paths', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('open_scene trims padded scene paths before opening', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-trimmed-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const openedPaths: string[] = []
+  fs.writeFileSync(scenePath, '')
+
+  try {
+    const result = await handleOpenScene(
+      { scene: ` ${scenePath} ` },
+      {
+        existsSync: fs.existsSync,
+        statSync: fs.statSync,
+        openScene: async (pathToOpen) => {
+          openedPaths.push(pathToOpen)
+          return true
+        },
+      },
+    )
+
+    assert.equal(result.isError, undefined)
+    assert.deepEqual(openedPaths, [scenePath])
+    assert.equal(assertToolText(result), `Opened ${scenePath}`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -52,7 +52,7 @@ export async function handleOpenScene(
   }
 
   const input: OpenInputData = parsed.data
-  const scenePath = path.resolve(input.scene)
+  const scenePath = path.resolve(input.scene.trim())
   if (!deps.existsSync(scenePath)) {
     return {
       isError: true,


### PR DESCRIPTION
## Summary\n- trim whitespace around MCP open_scene scene paths before resolving\n- add coverage that padded paths open as the canonical scene path\n\n## Tests\n- pnpm test