### PR TITLE
fix(cli): trim create scene output paths

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -223,6 +223,24 @@ test('create_scene rejects relative output paths', async () => {
   assert.equal(text, 'create_scene: output must be an absolute path.')
 })
 
+test('create_scene trims output paths before writing', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-create-trim-'))
+  const scenePath = path.join(dir, 'trimmed-scene.hype')
+
+  try {
+    const result = await handleCreateScene({
+      output: `  ${scenePath}  `,
+      open: false,
+      scene: { nodes: {} },
+    })
+
+    assert.equal(result.isError, undefined)
+    assert.equal(fs.existsSync(scenePath), true)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('create_scene reports persisted layer and track counts', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-create-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -183,7 +183,7 @@ export async function handleCreateScene(
   // Make sure the output's parent directory exists. Agents tend to
   // specify deep paths and we don't want a simple ENOENT to obscure
   // the actual failure.
-  const outputPath = input.output
+  const outputPath = input.output.trim()
   if (!path.isAbsolute(outputPath)) {
     return {
       isError: true,


### PR DESCRIPTION
## Summary
- trim whitespace around create_scene MCP output paths before validation and writing
- add a regression test covering padded output paths

## Tests
- pnpm test