### PR TITLE
Clarify empty render option errors

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -281,6 +281,21 @@ test('render command reports unsupported formats before launching the app', asyn
   assert.match(stderr, /^\[render\] unsupported format: mov \(use mp4 \/ webm \/ gif\)$/m)
 })
 
+test('render command reports empty explicit formats clearly', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        renderCommand().parseAsync(['-o', 'out.mp4', '--format', '   '], {
+          from: 'user',
+        }),
+        { exitCode: 1 },
+      )
+    })
+  })
+
+  assert.match(stderr, /^\[render\] unsupported format: <empty> \(use mp4 \/ webm \/ gif\)$/m)
+})
+
 test('render command reports unsupported quality before launching the app', async () => {
   const stderr = await captureStderr(() => {
     return withProcessExitThrow(async () => {
@@ -294,6 +309,21 @@ test('render command reports unsupported quality before launching the app', asyn
   })
 
   assert.match(stderr, /^\[render\] unsupported quality: draft \(use comp \/ 720p \/ 2k \/ 4k\)$/m)
+})
+
+test('render command reports empty explicit quality presets clearly', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        renderCommand().parseAsync(['-o', 'out.mp4', '--quality', '   '], {
+          from: 'user',
+        }),
+        { exitCode: 1 },
+      )
+    })
+  })
+
+  assert.match(stderr, /^\[render\] unsupported quality: <empty> \(use comp \/ 720p \/ 2k \/ 4k\)$/m)
 })
 
 test('render command reports missing scene files before launching the app', async () => {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -28,6 +28,7 @@ import {
 
 const FORMAT_HELP = RENDER_FORMATS.join(' / ')
 const QUALITY_HELP = RENDER_QUALITIES.join(' / ')
+const EMPTY_OPTION_LABEL = '<empty>'
 
 interface RenderOptions {
   output: string
@@ -78,14 +79,18 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
       const requestedFormat =
         opts.format?.trim().toLowerCase() ?? inferRenderFormatFromPath(outputPath)
       if (!isRenderFormat(requestedFormat)) {
-        console.error(`[render] unsupported format: ${requestedFormat} (use ${FORMAT_HELP})`)
+        console.error(
+          `[render] unsupported format: ${formatOptionValue(requestedFormat)} (use ${FORMAT_HELP})`,
+        )
         process.exit(1)
       }
       const format = requestedFormat
 
       const requestedQuality = opts.quality?.trim().toLowerCase() ?? 'comp'
       if (!isRenderQuality(requestedQuality)) {
-        console.error(`[render] unsupported quality: ${requestedQuality} (use ${QUALITY_HELP})`)
+        console.error(
+          `[render] unsupported quality: ${formatOptionValue(requestedQuality)} (use ${QUALITY_HELP})`,
+        )
         process.exit(1)
       }
       const quality = requestedQuality
@@ -183,4 +188,8 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
         process.exit(1)
       }
     })
+}
+
+function formatOptionValue(value: string): string {
+  return value === '' ? EMPTY_OPTION_LABEL : value
 }


### PR DESCRIPTION
## Summary
- report blank explicit render format/quality values as `<empty>`
- add CLI coverage for whitespace-only `--format` and `--quality` inputs

## Tests
- `pnpm test`