### PR TITLE
Clarify info_scene path description

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -18,6 +18,12 @@ test('info_scene input schema exposes required scene path', () => {
   })
 })
 
+test('info_scene description does not require absolute paths', () => {
+  const description = infoSceneTool.description ?? ''
+  assert.match(description, /Pass the path to the \.hype file\./)
+  assert.doesNotMatch(description, /absolute path/i)
+})
+
 test('info_scene reports invalid arguments as MCP errors', async () => {
   const result = await handleInfoScene({ scene: 42 })
 

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -22,7 +22,7 @@ export const infoSceneTool: Tool = {
   description:
     'Read a hyper-motion .hype scene file and return a structured summary ' +
     '(canvas size, duration, frame rate, layer count, track count, section ' +
-    'count, keyframe count). Pass the absolute path to the .hype file.',
+    'count, keyframe count). Pass the path to the .hype file.',
   inputSchema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary
- clarify that the info_scene MCP tool accepts a .hype file path without requiring it to be absolute
- add a focused test to keep the tool description from regressing

## Tests
- pnpm --dir cli run build && node --test cli/dist/mcp/infoScene.test.js
- pnpm test