### PR TITLE
docs(cli): clarify future Windows locator support

### DIFF
--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -7,8 +7,8 @@
  *
  *   macOS   — Check `/Applications/hyper-motion.app/Contents/MacOS/hyper-motion`
  *             then `~/Applications/...`. Future: query `mdfind`.
- *   Windows — Check `%ProgramFiles%\hyper-motion\hyper-motion.exe` and
- *             `%LOCALAPPDATA%\Programs\hyper-motion\hyper-motion.exe`.
+ *   Windows — Reserved for the future Windows build; check expected
+ *             installer locations once that build ships.
  *   Linux   — Check common binary/AppImage install locations:
  *             `/opt/hyper-motion`, `/usr/bin`, `~/Applications`, and
  *             `~/.local/bin`.


### PR DESCRIPTION
## Summary\n- clarify that Windows locator paths are reserved for the future Windows build\n- keep the existing search behavior unchanged\n\n## Verification\n- pnpm --dir cli run build && node --test cli/dist/electron/locator.test.js\n- pnpm test\n\nNote: pnpm typecheck still fails on existing app TypeScript errors outside this comment-only change.