### PR TITLE
Cover MCP text assertion helper

### DIFF
--- a/cli/src/testUtils/mcp.test.ts
+++ b/cli/src/testUtils/mcp.test.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { assertToolText } from './mcp.js'
+
+test('assertToolText returns the first MCP text content item', () => {
+  const result: CallToolResult = {
+    content: [{ type: 'text', text: 'hello' }],
+  }
+
+  assert.equal(assertToolText(result), 'hello')
+})
+
+test('assertToolText reports missing text content clearly', () => {
+  const result: CallToolResult = { content: [] }
+
+  assert.throws(
+    () => assertToolText(result),
+    /expected first MCP content item to be text/,
+  )
+})

--- a/cli/src/testUtils/mcp.ts
+++ b/cli/src/testUtils/mcp.ts
@@ -7,7 +7,7 @@ type ToolTextContent = Extract<CallToolResult['content'][number], { type: 'text'
 
 export function assertToolText(result: CallToolResult): string {
   const item = result.content[0]
-  assert.ok(isToolTextContent(item))
+  assert.ok(isToolTextContent(item), 'expected first MCP content item to be text')
   return item.text
 }
 


### PR DESCRIPTION
## Summary
- add focused coverage for the MCP text assertion test helper
- include a clearer assertion failure message when the first MCP content item is not text

## Tests
- pnpm --dir cli test