### PR TITLE
test(cli): cover dotted render output names

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -25,6 +25,7 @@ test('inferRenderFormatFromPath uses supported file extensions', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.mp4'), 'mp4')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.webm'), 'webm')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.gif'), 'gif')
+  assert.equal(inferRenderFormatFromPath('/tmp/demo.final.mp4'), 'mp4')
 })
 
 test('inferRenderFormatFromPath normalizes extension casing', () => {


### PR DESCRIPTION
## Summary
- add coverage for render format inference when output filenames contain extra dots before the extension

## Tests
- pnpm --dir cli test