### PR TITLE
test(cli): cover serve mode guard

### DIFF
--- a/cli/src/commands/serve.test.ts
+++ b/cli/src/commands/serve.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { withProcessExitThrow } from '../testUtils/processExit.js'
+import { captureStderr } from '../testUtils/stdout.js'
+import { serveCommand } from './serve.js'
+
+test('serve command requires an explicit server mode', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(serveCommand().parseAsync([], { from: 'user' }), {
+        exitCode: 1,
+      })
+    })
+  })
+
+  assert.match(stderr, /^\[serve\] no mode specified\. Use --mcp/m)
+})


### PR DESCRIPTION
## Summary\n- add a focused CLI test for the serve command's explicit mode guard\n\n## Tests\n- pnpm --dir cli test