### PR TITLE
Validate keyframe ids and times

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1083,6 +1083,25 @@ test('validateScene rejects track keyframes that are not arrays', () => {
   ])
 })
 
+test('validateScene rejects malformed keyframe ids and times', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const tracks = scene.get('tracks') as Y.Map<Y.Map<unknown>>
+  tracks.get('fade-title')?.set('keyframes', [
+    { time: 0, value: 0 },
+    { id: 'end', time: Number.NaN, value: 1 },
+  ])
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'track fade-title keyframe 0 id must be a string',
+    'track fade-title keyframe end time must be a finite number',
+  ])
+})
+
 test('validateScene rejects section ids that do not match their map key', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -937,6 +937,15 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
     }
     if (!Array.isArray(track.keyframes)) {
       errors.push(`track ${id} keyframes must be an array`)
+    } else {
+      track.keyframes.forEach((rawKeyframe, index) => {
+        const keyframe = asRecord(rawKeyframe)
+        const label = typeof keyframe.id === 'string' ? keyframe.id : `#${index}`
+        if (typeof keyframe.id !== 'string') errors.push(`track ${id} keyframe ${index} id must be a string`)
+        if (typeof keyframe.time !== 'number' || !Number.isFinite(keyframe.time)) {
+          errors.push(`track ${id} keyframe ${label} time must be a finite number`)
+        }
+      })
     }
     if (typeof track.propertyId !== 'string' || !isPropertyId(track.propertyId)) {
       errors.push(`track ${id} has unsupported propertyId: ${String(track.propertyId)}`)


### PR DESCRIPTION
## Summary
- validate keyframe ids and times in saved scene validation
- add focused validator coverage for malformed keyframe metadata

## Tests
- pnpm --dir cli test