### PR TITLE
Validate duplicate keyframe ids

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1102,6 +1102,24 @@ test('validateScene rejects malformed keyframe ids and times', () => {
   ])
 })
 
+test('validateScene rejects duplicate keyframe ids within a track', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const tracks = scene.get('tracks') as Y.Map<Y.Map<unknown>>
+  tracks.get('fade-title')?.set('keyframes', [
+    { id: 'intro', time: 0, value: 0 },
+    { id: 'intro', time: 0.5, value: 1 },
+  ])
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'track fade-title has duplicate keyframe id: intro',
+  ])
+})
+
 test('validateScene rejects section ids that do not match their map key', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -938,10 +938,13 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
     if (!Array.isArray(track.keyframes)) {
       errors.push(`track ${id} keyframes must be an array`)
     } else {
+      const seenKeyframes = new Set<string>()
       track.keyframes.forEach((rawKeyframe, index) => {
         const keyframe = asRecord(rawKeyframe)
         const label = typeof keyframe.id === 'string' ? keyframe.id : `#${index}`
         if (typeof keyframe.id !== 'string') errors.push(`track ${id} keyframe ${index} id must be a string`)
+        else if (seenKeyframes.has(keyframe.id)) errors.push(`track ${id} has duplicate keyframe id: ${keyframe.id}`)
+        else seenKeyframes.add(keyframe.id)
         if (typeof keyframe.time !== 'number' || !Number.isFinite(keyframe.time)) {
           errors.push(`track ${id} keyframe ${label} time must be a finite number`)
         }


### PR DESCRIPTION
## Summary
- Reject duplicate keyframe IDs within a single track during CLI scene validation
- Add focused validation coverage for the duplicate-keyframe case

## Tests
- pnpm --dir cli test
- pnpm test