### PR TITLE
docs(cli): clarify Windows locator paths

### DIFF
--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -7,8 +7,7 @@
  *
  *   macOS   — Check `/Applications/hyper-motion.app/Contents/MacOS/hyper-motion`
  *             then `~/Applications/...`. Future: query `mdfind`.
- *   Windows — Reserved for the future Windows build; check expected
- *             installer locations once that build ships.
+ *   Windows — Check expected Program Files and per-user installer locations.
  *   Linux   — Check common binary/AppImage install locations:
  *             `/opt/hyper-motion`, `/usr/bin`, `~/Applications`, and
  *             `~/.local/bin`.


### PR DESCRIPTION
## Summary
- Update the CLI desktop app locator comment so the Windows strategy matches the paths the code already checks.

## Tests
- pnpm --dir cli test

Note: root `pnpm typecheck` still fails on the existing baseline TypeScript errors documented in README.