### PR TITLE
Validate create_scene output before building

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -235,6 +235,17 @@ test('create_scene rejects relative output paths', async () => {
   assert.equal(text, 'create_scene: output must be an absolute path.')
 })
 
+test('create_scene validates output paths before building scene bytes', async () => {
+  const result = await handleCreateScene({
+    output: 'relative-scene.hype',
+    scene: { nodes: null },
+  })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.equal(text, 'create_scene: output must be an absolute path.')
+})
+
 test('create_scene trims output paths before writing', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-create-trim-'))
   const scenePath = path.join(dir, 'trimmed-scene.hype')

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -162,6 +162,22 @@ export async function handleCreateScene(
     }
   }
 
+  // Make sure the output's parent directory exists. Agents tend to
+  // specify deep paths and we don't want a simple ENOENT to obscure
+  // the actual failure.
+  const outputPath = input.output.trim()
+  if (!path.isAbsolute(outputPath)) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: 'create_scene: output must be an absolute path.',
+        },
+      ],
+    }
+  }
+
   // Build the Y.Doc bytes.
   let bytes: Uint8Array
   try {
@@ -175,22 +191,6 @@ export async function handleCreateScene(
           text: `create_scene: failed to build scene: ${
             err instanceof Error ? err.message : String(err)
           }`,
-        },
-      ],
-    }
-  }
-
-  // Make sure the output's parent directory exists. Agents tend to
-  // specify deep paths and we don't want a simple ENOENT to obscure
-  // the actual failure.
-  const outputPath = input.output.trim()
-  if (!path.isAbsolute(outputPath)) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text' as const,
-          text: 'create_scene: output must be an absolute path.',
         },
       ],
     }


### PR DESCRIPTION
## Summary
- Validate the MCP create_scene output path before building scene bytes
- Add a regression test for invalid output paths taking precedence over scene build errors

## Tests
- pnpm test