### PR TITLE
Reject empty render output paths

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -191,6 +191,23 @@ test('render command trims padded scene paths', async () => {
   }
 })
 
+test('render command rejects empty output paths before launching the app', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        renderCommand({
+          locateApp: async () => {
+            throw new Error('should not locate app')
+          },
+        }).parseAsync(['-o', '   '], { from: 'user' }),
+        { exitCode: 1 },
+      )
+    })
+  })
+
+  assert.equal(stderr, '[render] output path is required\n')
+})
+
 test('render command reports invalid fps before launching the app', async () => {
   const stderr = await captureStderr(() => {
     return withProcessExitThrow(async () => {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -74,7 +74,12 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
       'Path to a .hype scene file to forward to the desktop app',
     )
     .action(async (opts: RenderOptions) => {
-      const outputPath = path.resolve(opts.output)
+      const outputInput = opts.output.trim()
+      if (!outputInput) {
+        console.error('[render] output path is required')
+        process.exit(1)
+      }
+      const outputPath = path.resolve(outputInput)
 
       const requestedFormat =
         opts.format?.trim().toLowerCase() ?? inferRenderFormatFromPath(outputPath)

--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -50,6 +50,15 @@ test('render_scene reports invalid arguments as MCP errors', async () => {
   assert.match(assertToolText(result), /^render_scene: invalid arguments/)
 })
 
+test('render_scene rejects empty output paths as MCP errors', async () => {
+  const result = await handleRenderScene({
+    output: '   ',
+  })
+
+  assert.equal(result.isError, true)
+  assert.equal(assertToolText(result), 'render_scene: output path is required')
+})
+
 test('render_scene rejects fractional fps values as MCP errors', async () => {
   const result = await handleRenderScene({
     output: 'demo.mp4',

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -100,7 +100,19 @@ export async function handleRenderScene(
   }
 
   const input: RenderInputData = parsed.data
-  const outputPath = path.resolve(input.output.trim())
+  const outputInput = input.output.trim()
+  if (!outputInput) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: 'render_scene: output path is required',
+        },
+      ],
+    }
+  }
+  const outputPath = path.resolve(outputInput)
   const sceneInput = input.scene?.trim()
   const scenePath = sceneInput ? path.resolve(sceneInput) : undefined
   const format = input.format ?? inferRenderFormatFromPath(outputPath)


### PR DESCRIPTION
## Summary
- reject whitespace-only render output paths in the CLI before resolving them
- return a clear MCP error for whitespace-only render_scene output values
- cover both paths with focused tests

## Tests
- pnpm --dir cli test