### PR TITLE
Harden render option guards

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -13,12 +13,16 @@ test('render option guards accept supported values only', () => {
   assert.equal(isRenderFormat('webm'), true)
   assert.equal(isRenderFormat('gif'), true)
   assert.equal(isRenderFormat('mov'), false)
+  assert.equal(isRenderFormat(undefined), false)
+  assert.equal(isRenderFormat(60), false)
 
   assert.equal(isRenderQuality('comp'), true)
   assert.equal(isRenderQuality('720p'), true)
   assert.equal(isRenderQuality('2k'), true)
   assert.equal(isRenderQuality('4k'), true)
   assert.equal(isRenderQuality('1080p'), false)
+  assert.equal(isRenderQuality(undefined), false)
+  assert.equal(isRenderQuality(60), false)
 })
 
 test('inferRenderFormatFromPath uses supported file extensions', () => {

--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -8,12 +8,12 @@ export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
 export type RenderFormat = (typeof RENDER_FORMATS)[number]
 export type RenderQuality = (typeof RENDER_QUALITIES)[number]
 
-export function isRenderFormat(value: string): value is RenderFormat {
-  return RENDER_FORMATS.includes(value as RenderFormat)
+export function isRenderFormat(value: unknown): value is RenderFormat {
+  return typeof value === 'string' && RENDER_FORMATS.includes(value as RenderFormat)
 }
 
-export function isRenderQuality(value: string): value is RenderQuality {
-  return RENDER_QUALITIES.includes(value as RenderQuality)
+export function isRenderQuality(value: unknown): value is RenderQuality {
+  return typeof value === 'string' && RENDER_QUALITIES.includes(value as RenderQuality)
 }
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {


### PR DESCRIPTION
## Summary
- Accept unknown inputs in render format and quality guards before narrowing to supported values
- Cover non-string guard inputs in the existing render options test

## Tests
- pnpm --dir cli test