### PR TITLE
Handle URL suffixes in render format inference

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -36,6 +36,11 @@ test('inferRenderFormatFromPath normalizes extension casing', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.WEBM'), 'webm')
 })
 
+test('inferRenderFormatFromPath ignores URL-style suffixes', () => {
+  assert.equal(inferRenderFormatFromPath('/tmp/demo.gif?download=1'), 'gif')
+  assert.equal(inferRenderFormatFromPath('/tmp/demo.webm#preview'), 'webm')
+})
+
 test('inferRenderFormatFromPath falls back to mp4 for unknown extensions', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.mov'), 'mp4')
   assert.equal(inferRenderFormatFromPath('/tmp/demo'), 'mp4')

--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -17,6 +17,7 @@ export function isRenderQuality(value: unknown): value is RenderQuality {
 }
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {
-  const ext = path.extname(filePath).toLowerCase().slice(1)
+  const cleanPath = filePath.split(/[?#]/, 1)[0] ?? filePath
+  const ext = path.extname(cleanPath).toLowerCase().slice(1)
   return isRenderFormat(ext) ? ext : 'mp4'
 }


### PR DESCRIPTION
## Summary
- Strip URL-style query/hash suffixes before inferring render format from an output path
- Add unit coverage for suffix handling

## Tests
- pnpm --dir cli run build && node --test cli/dist/renderOptions.test.js
- pnpm --dir cli test