### PR TITLE
Trim paths before inferring render format

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -36,6 +36,10 @@ test('inferRenderFormatFromPath normalizes extension casing', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.WEBM'), 'webm')
 })
 
+test('inferRenderFormatFromPath trims surrounding whitespace', () => {
+  assert.equal(inferRenderFormatFromPath(' /tmp/demo.gif '), 'gif')
+})
+
 test('inferRenderFormatFromPath ignores URL-style suffixes', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.gif?download=1'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.webm#preview'), 'webm')

--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -17,7 +17,7 @@ export function isRenderQuality(value: unknown): value is RenderQuality {
 }
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {
-  const cleanPath = filePath.split(/[?#]/, 1)[0] ?? filePath
+  const cleanPath = (filePath.split(/[?#]/, 1)[0] ?? filePath).trim()
   const ext = path.extname(cleanPath).toLowerCase().slice(1)
   return isRenderFormat(ext) ? ext : 'mp4'
 }


### PR DESCRIPTION
## Summary\n- trim surrounding whitespace before inferring render output format from the output path\n- add a focused CLI unit test for padded output paths\n\n## Tests\n- pnpm --dir cli test