### PR TITLE
test(cli): cover combined render output suffixes

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -43,6 +43,7 @@ test('inferRenderFormatFromPath trims surrounding whitespace', () => {
 test('inferRenderFormatFromPath ignores URL-style suffixes', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.gif?download=1'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.webm#preview'), 'webm')
+  assert.equal(inferRenderFormatFromPath('/tmp/demo.mp4?download=1#preview'), 'mp4')
 })
 
 test('inferRenderFormatFromPath falls back to mp4 for unknown extensions', () => {


### PR DESCRIPTION
## Summary\n- Add render format inference coverage for output paths with both query and fragment suffixes.\n\n## Verification\n- pnpm --dir cli test