### PR TITLE
Validate scene section bounds

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1158,6 +1158,35 @@ test('validateScene rejects section ids that do not match their map key', () => 
   ])
 })
 
+test('validateScene rejects malformed section bounds', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const sections = scene.get('sections') as Y.Map<Record<string, unknown>>
+  sections.set('bad-start', {
+    id: 'bad-start',
+    name: 'Bad start',
+    color: '#2563eb',
+    start: Number.NaN,
+    end: 1,
+  })
+  sections.set('reversed', {
+    id: 'reversed',
+    name: 'Reversed',
+    color: '#2563eb',
+    start: 2,
+    end: 1,
+  })
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'section bad-start start must be a finite number',
+    'section reversed end must be greater than or equal to start',
+  ])
+})
+
 test('buildSceneBytes preserves variant selection keyframe values', () => {
   const scene = sampleScene()
   scene.tracks = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -960,6 +960,14 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
   for (const [id, raw] of Object.entries(sections)) {
     const section = asRecord(raw)
     if (section.id !== id) errors.push(`section map key ${id} does not match section id: ${String(section.id)}`)
+    if (typeof section.start !== 'number' || !Number.isFinite(section.start)) {
+      errors.push(`section ${id} start must be a finite number`)
+    }
+    if (typeof section.end !== 'number' || !Number.isFinite(section.end)) {
+      errors.push(`section ${id} end must be a finite number`)
+    } else if (typeof section.start === 'number' && Number.isFinite(section.start) && section.end < section.start) {
+      errors.push(`section ${id} end must be greater than or equal to start`)
+    }
   }
 
   return { ok: errors.length === 0, errors, warnings }


### PR DESCRIPTION
## Summary
- validate scene section start/end values are finite numbers
- reject sections whose end precedes start
- add focused CLI scene validation coverage

## Tests
- pnpm --dir cli test