### PR TITLE
test(cli): cover unsupported validate node kinds

### DIFF
--- a/cli/src/commands/validate.test.ts
+++ b/cli/src/commands/validate.test.ts
@@ -322,6 +322,52 @@ test('validate command rejects duplicate child entries', async () => {
   }
 })
 
+test('validate command rejects unsupported node kinds', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const previousExitCode = process.exitCode
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Validate Unsupported Kind',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: ['shape'],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+          shape: {
+            id: 'shape',
+            kind: 'polygon',
+            parent: 'root',
+            children: [],
+          },
+        },
+      } as unknown as Parameters<typeof buildSceneBytes>[0]),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await validateCommand().exitOverride().parseAsync([scenePath], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^Scene is invalid$/m)
+    assert.match(stdout, /^error: node shape has unsupported kind: polygon$/m)
+    assert.equal(process.exitCode, 1)
+  } finally {
+    process.exitCode = previousExitCode
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('validate command reports missing scene files', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
   const scenePath = path.join(dir, 'missing.hype')


### PR DESCRIPTION
## Summary
- Add CLI validate-command coverage for unsupported scene node kinds.

## Tests
- pnpm --dir cli test