### PR TITLE
test(cli): cover stale output cleanup on render errors

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -301,6 +301,7 @@ test('driveHeadlessRender surfaces JSON error sentinel messages', async () => {
   const appPath = path.join(dir, 'fake-app.mjs')
   const outputPath = path.join(dir, 'out.mp4')
 
+  fs.writeFileSync(outputPath, 'stale output')
   fs.writeFileSync(
     appPath,
     [
@@ -325,6 +326,7 @@ test('driveHeadlessRender surfaces JSON error sentinel messages', async () => {
       }),
       /encoder reported JSON failure/,
     )
+    assert.equal(fs.existsSync(outputPath), false)
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- extend the JSON error sentinel driver test to seed stale output before render
- assert stale output is removed when the render reports an error

## Tests
- pnpm --dir cli test