### PR TITLE
chore(cli): clarify capabilities tool description

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -111,10 +111,14 @@ test('capability tool schemas accept no arguments', () => {
   })
 })
 
-test('get_capabilities description mentions validation and query tools', () => {
+test('get_capabilities description mentions agent-facing capability groups', () => {
   const getCapabilities = TOOLS.find((tool) => tool.name === 'get_capabilities')
+  const description = getCapabilities?.description ?? ''
 
-  assert.match(getCapabilities?.description ?? '', /validation\/query tools/)
+  assert.match(description, /render formats\/qualities/)
+  assert.match(description, /saved-scene render support/)
+  assert.match(description, /validation\/query tools/)
+  assert.match(description, /keyframeable properties/)
 })
 
 function parseToolJson(result: CallToolResult): CapabilitiesToolPayload {

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -47,7 +47,7 @@ type CapabilityToolPayload = CapabilitiesPayload | KeyframeablePropertiesPayload
 export const getCapabilitiesTool: Tool = {
   name: 'get_capabilities',
   description:
-    'Return supported scene node kinds, patch operations, render formats, validation/query tools, and keyframeable properties.',
+    'Return supported scene node kinds, patch operations, render formats/qualities, saved-scene render support, validation/query tools, and keyframeable properties.',
   inputSchema: { type: 'object', properties: {}, required: [] },
 }
 


### PR DESCRIPTION
## Summary\n- Clarify get_capabilities MCP tool description to mention render quality presets, saved-scene render support, and keyframeable properties\n- Expand the focused capabilities description test to keep the agent-facing contract aligned\n\n## Tests\n- pnpm --dir cli run build && node --test cli/dist/mcp/capabilities.test.js\n- pnpm test