### PR TITLE
fix(cli): trim validate scene paths

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -39,17 +39,18 @@ export async function handleValidateScene(
   }
 
   const input: ValidateInputData = parsed.data
+  const scenePath = input.scene.trim()
   let bytes: Buffer
   let stat: fs.Stats
   try {
-    stat = fs.statSync(input.scene)
+    stat = fs.statSync(scenePath)
   } catch (err) {
     return {
       isError: true,
       content: [
         {
           type: 'text' as const,
-          text: `validate_scene: failed to read ${input.scene}: ${
+          text: `validate_scene: failed to read ${scenePath}: ${
             err instanceof Error ? err.message : String(err)
           }`,
         },
@@ -62,20 +63,20 @@ export async function handleValidateScene(
       content: [
         {
           type: 'text' as const,
-          text: `validate_scene: scene path is not a file: ${input.scene}`,
+          text: `validate_scene: scene path is not a file: ${scenePath}`,
         },
       ],
     }
   }
   try {
-    bytes = fs.readFileSync(input.scene)
+    bytes = fs.readFileSync(scenePath)
   } catch (err) {
     return {
       isError: true,
       content: [
         {
           type: 'text' as const,
-          text: `validate_scene: failed to read ${input.scene}: ${
+          text: `validate_scene: failed to read ${scenePath}: ${
             err instanceof Error ? err.message : String(err)
           }`,
         },
@@ -100,7 +101,7 @@ export async function handleValidateScene(
       content: [
         {
           type: 'text' as const,
-          text: `validate_scene: ${input.scene} doesn't look like a valid .hype file: ${
+          text: `validate_scene: ${scenePath} doesn't look like a valid .hype file: ${
             err instanceof Error ? err.message : String(err)
           }`,
         },

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -138,6 +138,41 @@ test('validate_scene returns validation JSON for readable scenes', async () => {
   }
 })
 
+test('validate_scene trims padded scene paths before reading', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-trimmed-'))
+  const scenePath = path.join(dir, 'scene.hype')
+
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Validate Trimmed MCP',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const result = await handleValidateScene({ scene: `  ${scenePath}\n` })
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+
+    assert.equal(result.isError, undefined)
+    assert.equal(JSON.parse(text).ok, true)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('validate_scene marks structurally invalid scenes as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-invalid-'))
   const scenePath = path.join(dir, 'invalid.hype')


### PR DESCRIPTION
## Summary
- Trim padded scene paths in the validate_scene MCP handler before filesystem reads
- Add coverage for padded validate_scene paths

## Verification
- pnpm --dir cli test

Note: pnpm typecheck was attempted before this CLI-only change and currently fails on unrelated existing app-wide TypeScript errors.