### PR TITLE
chore(cli): include render output directory in MCP errors

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -218,7 +218,7 @@ test('render_scene reports output directory creation failures as MCP errors', as
     assert.equal(result.isError, true)
     assert.equal(
       assertToolText(result),
-      'render_scene: failed to create output directory: mkdir failed',
+      `render_scene: failed to create output directory ${outDir}: mkdir failed`,
     )
   } finally {
     Object.defineProperty(fs, 'mkdirSync', {

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -200,7 +200,7 @@ export async function handleRenderScene(
         content: [
           {
             type: 'text' as const,
-            text: `render_scene: failed to create output directory: ${
+            text: `render_scene: failed to create output directory ${outDir}: ${
               err instanceof Error ? err.message : String(err)
             }`,
           },


### PR DESCRIPTION
## Summary
- Include the output directory path when render_scene cannot create the export directory
- Update the MCP render_scene test expectation for the clearer diagnostic

## Tests
- pnpm --dir cli test