### PR TITLE
docs(cli): clarify saved scene render behavior

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -45,8 +45,8 @@ hypermotion render --scene intro.hype -o intro.mp4
 Quality presets: `comp` (matches the scene canvas — fastest), `720p`,
 `2k` (2560×1440), `4k` (3840×2160). Default: `comp`.
 
-Render targets whichever scene is currently loaded in your desktop app.
-To script a scene from JSON, build a `.hype` file with
+Without `--scene`, render targets whichever scene is currently loaded in
+your desktop app. To script a scene from JSON, build a `.hype` file with
 `hypermotion create`, inspect it with `hypermotion info`, and pass it to
 the installed desktop app with `hypermotion render --scene <path>`.
 


### PR DESCRIPTION
## Summary
- Clarify that the CLI renders the current desktop scene only when `--scene` is omitted.

## Tests
- pnpm test

Note: `pnpm typecheck` was checked before the docs edit and still has unrelated baseline errors on `origin/main`.