### PR TITLE
test(cli): keep render option guard coverage in sync

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -6,20 +6,21 @@ import {
   inferRenderFormatFromPath,
   isRenderFormat,
   isRenderQuality,
+  RENDER_FORMATS,
+  RENDER_QUALITIES,
 } from './renderOptions.js'
 
 test('render option guards accept supported values only', () => {
-  assert.equal(isRenderFormat('mp4'), true)
-  assert.equal(isRenderFormat('webm'), true)
-  assert.equal(isRenderFormat('gif'), true)
+  for (const format of RENDER_FORMATS) {
+    assert.equal(isRenderFormat(format), true)
+  }
   assert.equal(isRenderFormat('mov'), false)
   assert.equal(isRenderFormat(undefined), false)
   assert.equal(isRenderFormat(60), false)
 
-  assert.equal(isRenderQuality('comp'), true)
-  assert.equal(isRenderQuality('720p'), true)
-  assert.equal(isRenderQuality('2k'), true)
-  assert.equal(isRenderQuality('4k'), true)
+  for (const quality of RENDER_QUALITIES) {
+    assert.equal(isRenderQuality(quality), true)
+  }
   assert.equal(isRenderQuality('1080p'), false)
   assert.equal(isRenderQuality(undefined), false)
   assert.equal(isRenderQuality(60), false)


### PR DESCRIPTION
## Summary
- use exported render format and quality lists in the render option guard test
- keeps the supported-value assertions in sync with the CLI option source of truth

## Tests
- pnpm --dir cli test