### PR TITLE
docs: update GIF export pipeline comment

### DIFF
--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -12,7 +12,7 @@
  *   - webm → tab capture: getDisplayMedia + MediaRecorder records the
  *            rendered tab in real time. Bound to screen pixel ratio
  *            but real-time speed.
- *   - gif  → native render: html-to-image → gifenc. 720p · 24fps
+ *   - gif  → native render: capturePage → gifenc. 720p · 24fps
  *            default; quality picker still applies.
  *
  * Public surface:


### PR DESCRIPTION
## Summary
- Update the export module overview so the GIF pipeline describes the current capturePage -> gifenc path.
- Preserve the existing behavior; this is a comment-only maintenance change.

## Verification
- PASS: pnpm exec eslint src/export/index.ts
- NOTE: pnpm lint currently fails on unrelated pre-existing issues across the app.
- NOTE: pnpm typecheck currently fails on unrelated pre-existing issues across the app.