### PR TITLE
test(cli): accept capture callback returns

### DIFF
--- a/cli/src/testUtils/stdout.test.ts
+++ b/cli/src/testUtils/stdout.test.ts
@@ -78,6 +78,24 @@ test('captureStderr invokes write callbacks', async () => {
   assert.equal(callbackCalled, true)
 })
 
+test('captureStdout accepts callbacks that return values', async () => {
+  const output = await captureStdout(() => {
+    process.stdout.write('render complete')
+    return 'ignored'
+  })
+
+  assert.equal(output, 'render complete')
+})
+
+test('captureStderr accepts callbacks that return values', async () => {
+  const output = await captureStderr(() => {
+    process.stderr.write('render failed')
+    return 'ignored'
+  })
+
+  assert.equal(output, 'render failed')
+})
+
 test('captureStdout restores the writer after sync callbacks', async () => {
   const originalWrite = process.stdout.write
 

--- a/cli/src/testUtils/stdout.ts
+++ b/cli/src/testUtils/stdout.ts
@@ -17,7 +17,7 @@ function stringifyChunk(
 
 async function captureStream(
   stream: WritableStream,
-  run: CaptureCallback<void>,
+  run: CaptureCallback<unknown>,
 ): Promise<string> {
   let output = ''
   const write = stream.write
@@ -43,13 +43,13 @@ async function captureStream(
 }
 
 export async function captureStdout(
-  run: CaptureCallback<void>,
+  run: CaptureCallback<unknown>,
 ): Promise<string> {
   return captureStream(process.stdout, run)
 }
 
 export async function captureStderr(
-  run: CaptureCallback<void>,
+  run: CaptureCallback<unknown>,
 ): Promise<string> {
   return captureStream(process.stderr, run)
 }


### PR DESCRIPTION
## Summary\n- Widen CLI stdout/stderr capture helpers so callbacks may return values\n- Add focused coverage for value-returning capture callbacks\n\n## Verification\n- pnpm --dir cli test -- stdout.test.ts\n\n## Notes\n- Repo-wide pnpm typecheck and pnpm lint still fail on existing app-level issues outside this change.