### PR TITLE
fix(cli): trim create output paths

### DIFF
--- a/cli/src/commands/create.test.ts
+++ b/cli/src/commands/create.test.ts
@@ -120,6 +120,40 @@ test('create command reports authored layer and track counts', async () => {
   }
 })
 
+test('create command trims padded output paths', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-create-trimmed-output-'))
+  const sourcePath = path.join(dir, 'scene.json')
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    fs.writeFileSync(
+      sourcePath,
+      JSON.stringify({
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    await captureStdout(async () => {
+      await createCommand()
+        .exitOverride()
+        .parseAsync([` ${scenePath} `, '--from', sourcePath], { from: 'user' })
+    })
+
+    assert.equal(fs.existsSync(scenePath), true)
+    assert.equal(fs.existsSync(path.join(dir, ` ${path.basename(scenePath)} `)), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -110,7 +110,7 @@ export function createCommand(): Command {
       // Make sure the output's parent directory exists. Tools and
       // agents tend to specify deeply-nested paths; we don't want a
       // simple ENOENT to obscure the real error.
-      const outputPath = path.resolve(output)
+      const outputPath = path.resolve(output.trim())
       const outDir = path.dirname(outputPath)
       try {
         fs.mkdirSync(outDir, { recursive: true })


### PR DESCRIPTION
## Summary
- Trim padded output paths in the CLI create command before resolving the destination
- Add a regression test covering padded create output arguments

## Verification
- pnpm test
- pnpm --dir cli test