### PR TITLE
docs(cli): clarify MCP serve mode

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -95,7 +95,7 @@ What works today:
 - `hypermotion info out.hype` — prints scene metadata.
 - `hypermotion inspect`, `patch`, `validate`, and `open` — inspect,
   modify, verify, and launch saved `.hype` scenes.
-- `hypermotion doctor` and `serve` — check local setup and run the MCP server.
+- `hypermotion doctor` and `serve --mcp` — check local setup and run the MCP server.
 - `hypermotion-mcp` — registers + responds to MCP clients.
 - MCP tools for scene authoring, inspection, patching, validation,
   querying, opening, rendering, diagnostics, and capability discovery.

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -7,7 +7,7 @@
  *
  *   `hypermotion <subcommand>` — interactive CLI for humans (render, create,
  *                                  info, inspect, patch, validate, open,
- *                                  doctor, serve).
+ *                                  doctor, serve --mcp).
  *   `hypermotion-mcp`          — dedicated MCP server binary used by AI
  *                                  coding agents (Claude Code, Codex) over
  *                                  stdio.


### PR DESCRIPTION
## Summary
- clarify that the CLI MCP server mode is invoked with `serve --mcp`
- keep the README quick-reference aligned with the CLI entry-point comment and doctor output

## Tests
- `pnpm --dir cli test`