### PR TITLE
fix(cli): reject malformed active camera ids

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -918,6 +918,18 @@ test('validateScene rejects non-camera active camera ids', () => {
   ])
 })
 
+test('validateScene rejects non-string active camera ids', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  doc.getMap<unknown>('scene').set('activeCameraId', 42)
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, ['scene.activeCameraId must be a string'])
+  assert.deepEqual(result.warnings, [])
+})
+
 test('validateScene rejects active camera ids pointing to missing nodes', () => {
   const scene = sampleScene()
   scene.activeCameraId = 'missing-camera'

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -880,7 +880,9 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
     errors.push(`scene.root must be scene-level with parent: null: ${root}`)
   }
 
-  if (!activeCameraId) warnings.push('scene.activeCameraId is missing')
+  if (data.activeCameraId !== undefined && data.activeCameraId !== null && typeof data.activeCameraId !== 'string') {
+    errors.push('scene.activeCameraId must be a string')
+  } else if (!activeCameraId) warnings.push('scene.activeCameraId is missing')
   else if (!nodes[activeCameraId]) errors.push(`scene.activeCameraId points to missing node: ${activeCameraId}`)
   else if (asRecord(nodes[activeCameraId]).kind !== 'camera') {
     errors.push(`scene.activeCameraId is not a camera node: ${activeCameraId}`)


### PR DESCRIPTION
## Summary
- reject non-null, non-string activeCameraId values during scene validation
- add a regression test for malformed saved scene data

## Tests
- pnpm --dir cli test
- pnpm test