### PR TITLE
Validate scene root id type

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -906,6 +906,17 @@ test('validateScene rejects non-frame root nodes', () => {
   assert.deepEqual(result.errors, ['scene.root is not a frame node: title'])
 })
 
+test('validateScene rejects non-string root ids', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  doc.getMap<unknown>('scene').set('root', 42)
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, ['scene.root must be a string'])
+})
+
 test('validateScene rejects non-camera active camera ids', () => {
   const scene = sampleScene()
   scene.activeCameraId = 'title'

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -872,7 +872,9 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
   const root = typeof data.root === 'string' ? data.root : ''
   const activeCameraId = typeof data.activeCameraId === 'string' ? data.activeCameraId : ''
 
-  if (!root) errors.push('scene.root is missing')
+  if (data.root !== undefined && typeof data.root !== 'string') {
+    errors.push('scene.root must be a string')
+  } else if (!root) errors.push('scene.root is missing')
   else if (!nodes[root]) errors.push(`scene.root points to missing node: ${root}`)
   else if (asRecord(nodes[root]).kind !== 'frame') {
     errors.push(`scene.root is not a frame node: ${root}`)


### PR DESCRIPTION
## Summary
- report non-string scene.root values as an explicit validation error
- add CLI scene validation coverage for malformed root ids

## Tests
- pnpm --dir cli run build && node --test cli/dist/scene/build.test.js
- pnpm test
