### PR TITLE
chore(cli): preserve capture helper callback types

### DIFF
--- a/cli/src/testUtils/stdout.ts
+++ b/cli/src/testUtils/stdout.ts
@@ -42,14 +42,10 @@ async function captureStream(
   return output
 }
 
-export async function captureStdout(
-  run: CaptureCallback<unknown>,
-): Promise<string> {
+export async function captureStdout<T>(run: CaptureCallback<T>): Promise<string> {
   return captureStream(process.stdout, run)
 }
 
-export async function captureStderr(
-  run: CaptureCallback<unknown>,
-): Promise<string> {
+export async function captureStderr<T>(run: CaptureCallback<T>): Promise<string> {
   return captureStream(process.stderr, run)
 }


### PR DESCRIPTION
## Summary
- Preserve generic callback return types on CLI stdout/stderr capture helpers.
- No runtime behavior change; this keeps the test utility API typed consistently with its generic callback type.

## Tests
- pnpm --dir cli test
