### PR TITLE
Validate scene node entry objects

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -966,6 +966,24 @@ test('validateScene rejects unsupported node kinds', () => {
   assert.deepEqual(result.errors, ['node title has unsupported kind: shape'])
 })
 
+test('validateScene rejects node entries that are not objects', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const nodes = scene.get('nodes') as Y.Map<unknown>
+  nodes.set('title', 'text')
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    "node root lists child title, but child's parent is undefined",
+    'node title must be an object',
+    'node map key title does not match node id: undefined',
+    'node title has unsupported kind: undefined',
+  ])
+})
+
 test('validateScene rejects root nodes with parents', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -892,6 +892,7 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
 
   for (const [id, raw] of Object.entries(nodes)) {
     const node = asRecord(raw)
+    if (!isPlainObject(raw)) errors.push(`node ${id} must be an object`)
     if (node.id !== id) errors.push(`node map key ${id} does not match node id: ${String(node.id)}`)
     if (typeof node.kind !== 'string' || !isNodeKind(node.kind)) {
       errors.push(`node ${id} has unsupported kind: ${String(node.kind)}`)


### PR DESCRIPTION
## Summary
- report a direct validation error when a scene node map entry is not an object
- add regression coverage for malformed node entries

## Tests
- pnpm --dir cli test