### PR TITLE
Reject non-object scene sections

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1239,6 +1239,7 @@ test('validateScene rejects section entries that are not objects', () => {
 
   assert.equal(result.ok, false)
   assert.deepEqual(result.errors, [
+    'section intro must be an object',
     'section map key intro does not match section id: undefined',
     'section intro start must be a finite number',
     'section intro end must be a finite number',

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -964,6 +964,7 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
   const sections = asRecord(data.sections)
   for (const [id, raw] of Object.entries(sections)) {
     const section = asRecord(raw)
+    if (!isPlainObject(raw)) errors.push(`section ${id} must be an object`)
     if (section.id !== id) errors.push(`section map key ${id} does not match section id: ${String(section.id)}`)
     if (typeof section.start !== 'number' || !Number.isFinite(section.start)) {
       errors.push(`section ${id} start must be a finite number`)


### PR DESCRIPTION
## Summary
- report an explicit validation error when a scene section entry is not an object
- update the existing section validation test expectation

## Tests
- pnpm --dir cli run build && node --test cli/dist/scene/build.test.js
- pnpm --dir cli test