### PR TITLE
fix(cli): validate section label fields

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1241,8 +1241,32 @@ test('validateScene rejects section entries that are not objects', () => {
   assert.deepEqual(result.errors, [
     'section intro must be an object',
     'section map key intro does not match section id: undefined',
+    'section intro name must be a string',
+    'section intro color must be a string',
     'section intro start must be a finite number',
     'section intro end must be a finite number',
+  ])
+})
+
+test('validateScene rejects malformed section labels', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const sections = scene.get('sections') as Y.Map<Record<string, unknown>>
+  sections.set('bad-labels', {
+    id: 'bad-labels',
+    name: 42,
+    color: null,
+    start: 0,
+    end: 1,
+  })
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'section bad-labels name must be a string',
+    'section bad-labels color must be a string',
   ])
 })
 

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -966,6 +966,8 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
     const section = asRecord(raw)
     if (!isPlainObject(raw)) errors.push(`section ${id} must be an object`)
     if (section.id !== id) errors.push(`section map key ${id} does not match section id: ${String(section.id)}`)
+    if (typeof section.name !== 'string') errors.push(`section ${id} name must be a string`)
+    if (typeof section.color !== 'string') errors.push(`section ${id} color must be a string`)
     if (typeof section.start !== 'number' || !Number.isFinite(section.start)) {
       errors.push(`section ${id} start must be a finite number`)
     }


### PR DESCRIPTION
## Summary
- validate section name and color fields in saved .hype scene sections
- add regression coverage for malformed section labels

## Tests
- pnpm --dir cli test