### PR TITLE
fix(cli): reject non-object track entries

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1155,6 +1155,25 @@ test('validateScene rejects track ids that do not match their map key', () => {
   ])
 })
 
+test('validateScene rejects track entries that are not objects', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  const tracks = scene.get('tracks') as Y.Map<unknown>
+  tracks.set('fade-title', 'fade')
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'track fade-title must be an object',
+    'track map key fade-title does not match track id: undefined',
+    'track fade-title points to missing node: undefined',
+    'track fade-title keyframes must be an array',
+    'track fade-title has unsupported propertyId: undefined',
+  ])
+})
+
 test('validateScene rejects track keyframes that are not arrays', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -935,6 +935,7 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
 
   for (const [id, raw] of Object.entries(tracks)) {
     const track = asRecord(raw)
+    if (!isPlainObject(raw)) errors.push(`track ${id} must be an object`)
     if (track.id !== id) errors.push(`track map key ${id} does not match track id: ${String(track.id)}`)
     const nodeId = track.nodeId
     if (typeof nodeId !== 'string' || !nodes[nodeId]) {


### PR DESCRIPTION
## Summary
- add a direct validateScene error when a track map entry is not an object
- cover malformed saved track entries with a Yjs document regression test

## Tests
- pnpm --dir cli test
- pnpm test