### PR TITLE
fix(cli): validate keyframe values

### DIFF
--- a/cli/src/commands/validate.test.ts
+++ b/cli/src/commands/validate.test.ts
@@ -368,6 +368,59 @@ test('validate command rejects unsupported node kinds', async () => {
   }
 })
 
+test('validate command rejects missing keyframe values', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const previousExitCode = process.exitCode
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Validate Keyframe Value',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+        tracks: {
+          fade: {
+            id: 'fade',
+            nodeId: 'root',
+            propertyId: 'appearance.opacity',
+            keyframes: [
+              { id: 'start', time: 0 } as { id: string; time: number; value: number },
+            ],
+          },
+        },
+      }),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await validateCommand().exitOverride().parseAsync([scenePath], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^Scene is invalid$/m)
+    assert.match(
+      stdout,
+      /^error: track fade keyframe start value must be JSON-compatible$/m,
+    )
+    assert.equal(process.exitCode, 1)
+  } finally {
+    process.exitCode = previousExitCode
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('validate command reports missing scene files', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
   const scenePath = path.join(dir, 'missing.hype')

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -948,12 +948,16 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
       track.keyframes.forEach((rawKeyframe, index) => {
         const keyframe = asRecord(rawKeyframe)
         const label = typeof keyframe.id === 'string' ? keyframe.id : `#${index}`
-        if (!isPlainObject(rawKeyframe)) errors.push(`track ${id} keyframe ${index} must be an object`)
+        const keyframeIsObject = isPlainObject(rawKeyframe)
+        if (!keyframeIsObject) errors.push(`track ${id} keyframe ${index} must be an object`)
         if (typeof keyframe.id !== 'string') errors.push(`track ${id} keyframe ${index} id must be a string`)
         else if (seenKeyframes.has(keyframe.id)) errors.push(`track ${id} has duplicate keyframe id: ${keyframe.id}`)
         else seenKeyframes.add(keyframe.id)
         if (typeof keyframe.time !== 'number' || !Number.isFinite(keyframe.time)) {
           errors.push(`track ${id} keyframe ${label} time must be a finite number`)
+        }
+        if (keyframeIsObject && (!('value' in keyframe) || !isJsonValue(keyframe.value))) {
+          errors.push(`track ${id} keyframe ${label} value must be JSON-compatible`)
         }
       })
     }
@@ -988,6 +992,15 @@ function isNodeKind(value: string): value is NodeKindJson {
 
 function isPropertyId(value: string): value is PropertyIdJson {
   return PROPERTY_ID_SET.has(value)
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null) return true
+  if (typeof value === 'string' || typeof value === 'boolean') return true
+  if (typeof value === 'number') return Number.isFinite(value)
+  if (Array.isArray(value)) return value.every(isJsonValue)
+  if (!isPlainObject(value)) return false
+  return Object.values(value).every(isJsonValue)
 }
 
 export function applyScenePatch(bytes: Uint8Array, patch: ScenePatch | PatchOperation[]): Uint8Array {


### PR DESCRIPTION
## Summary
- reject missing or non-JSON-compatible keyframe values during scene validation
- cover the CLI validate command for missing keyframe values

## Tests
- pnpm --dir cli test