### PR TITLE
fix(cli): validate scene collection shapes

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -917,6 +917,26 @@ test('validateScene rejects non-string root ids', () => {
   assert.deepEqual(result.errors, ['scene.root must be a string'])
 })
 
+test('validateScene rejects non-object scene collections', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  const scene = doc.getMap<unknown>('scene')
+  scene.set('nodes', [])
+  scene.set('tracks', 'fade-title')
+  scene.set('sections', null)
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'scene.nodes must be an object',
+    'scene.tracks must be an object',
+    'scene.sections must be an object',
+    'scene.root points to missing node: root',
+    'scene.activeCameraId points to missing node: camera',
+  ])
+})
+
 test('validateScene rejects non-camera active camera ids', () => {
   const scene = sampleScene()
   scene.activeCameraId = 'title'

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -872,6 +872,16 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
   const root = typeof data.root === 'string' ? data.root : ''
   const activeCameraId = typeof data.activeCameraId === 'string' ? data.activeCameraId : ''
 
+  if (data.nodes !== undefined && !isPlainObject(data.nodes)) {
+    errors.push('scene.nodes must be an object')
+  }
+  if (data.tracks !== undefined && !isPlainObject(data.tracks)) {
+    errors.push('scene.tracks must be an object')
+  }
+  if (data.sections !== undefined && !isPlainObject(data.sections)) {
+    errors.push('scene.sections must be an object')
+  }
+
   if (data.root !== undefined && typeof data.root !== 'string') {
     errors.push('scene.root must be a string')
   } else if (!root) errors.push('scene.root is missing')


### PR DESCRIPTION
## Summary
- report explicit validation errors when top-level scene collections are non-object values
- add a focused validator regression test for malformed nodes/tracks/sections containers

## Tests
- pnpm test -- --test-name-pattern "validateScene rejects non-object scene collections|validateScene rejects non-string root ids"