### PR TITLE
fix(cli): validate scene parent cycles

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1017,6 +1017,8 @@ test('validateScene rejects root nodes with parents', () => {
   assert.deepEqual(result.errors, [
     'scene.root must be scene-level with parent: null: root',
     'node root parent title does not list it as a child',
+    'node root has a parent cycle through root',
+    'node title has a parent cycle through title',
   ])
 })
 
@@ -1067,6 +1069,37 @@ test('validateScene rejects duplicate child references', () => {
 
   assert.equal(result.ok, false)
   assert.deepEqual(result.errors, ['node root lists duplicate child: title'])
+})
+
+test('validateScene rejects parent cycles', () => {
+  const scene = sampleScene()
+  scene.nodes = {
+    ...scene.nodes,
+    loopA: {
+      id: 'loopA',
+      kind: 'frame',
+      parent: 'loopB',
+      children: ['loopB'],
+      size: { width: 100, height: 100 },
+      layout: { mode: 'none' },
+    },
+    loopB: {
+      id: 'loopB',
+      kind: 'frame',
+      parent: 'loopA',
+      children: ['loopA'],
+      size: { width: 100, height: 100 },
+      layout: { mode: 'none' },
+    },
+  }
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'node loopA has a parent cycle through loopA',
+    'node loopB has a parent cycle through loopB',
+  ])
 })
 
 test('validateScene rejects non-object keyframes', () => {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -936,6 +936,19 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
     }
   }
 
+  for (const id of Object.keys(nodes)) {
+    const seenParents = new Set<string>([id])
+    let current = asRecord(nodes[id]).parent
+    while (typeof current === 'string') {
+      if (seenParents.has(current)) {
+        errors.push(`node ${id} has a parent cycle through ${current}`)
+        break
+      }
+      seenParents.add(current)
+      current = asRecord(nodes[current]).parent
+    }
+  }
+
   const cameraIds = Object.entries(nodes)
     .filter(([, raw]) => asRecord(raw).kind === 'camera')
     .map(([id]) => id)


### PR DESCRIPTION
## Summary\n- reject parent cycles in CLI scene validation\n- add a focused validateScene regression test\n\n## Verification\n- pnpm --dir cli test\n\nNote: repo-wide `pnpm typecheck` still fails on existing app TypeScript errors outside this CLI validator change.