### PR TITLE
fix(cli): clarify non-string child validation

### DIFF
--- a/cli/src/commands/validate.test.ts
+++ b/cli/src/commands/validate.test.ts
@@ -322,6 +322,46 @@ test('validate command rejects duplicate child entries', async () => {
   }
 })
 
+test('validate command rejects non-string child entries', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const previousExitCode = process.exitCode
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Validate Child Type',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [123],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      } as unknown as Parameters<typeof buildSceneBytes>[0]),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await validateCommand().exitOverride().parseAsync([scenePath], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^Scene is invalid$/m)
+    assert.match(stdout, /^error: node root child must be a string: 123$/m)
+    assert.equal(process.exitCode, 1)
+  } finally {
+    process.exitCode = previousExitCode
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('validate command rejects unsupported node kinds', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1143,7 +1143,7 @@ test('validateScene rejects non-string child references', () => {
   const result = validateScene(Y.encodeStateAsUpdate(doc))
 
   assert.equal(result.ok, false)
-  assert.deepEqual(result.errors, ['node root has missing child: 42'])
+  assert.deepEqual(result.errors, ['node root child must be a string: 42'])
 })
 
 test('validateScene rejects node children that are not arrays', () => {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -927,7 +927,8 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
     const children = Array.isArray(node.children) ? node.children : []
     const seenChildren = new Set<string>()
     for (const child of children) {
-      if (typeof child !== 'string' || !nodes[child]) errors.push(`node ${id} has missing child: ${String(child)}`)
+      if (typeof child !== 'string') errors.push(`node ${id} child must be a string: ${String(child)}`)
+      else if (!nodes[child]) errors.push(`node ${id} has missing child: ${child}`)
       else if (seenChildren.has(child)) errors.push(`node ${id} lists duplicate child: ${child}`)
       else if (asRecord(nodes[child]).parent !== id) {
         errors.push(`node ${id} lists child ${child}, but child's parent is ${String(asRecord(nodes[child]).parent)}`)


### PR DESCRIPTION
## Summary
- report non-string scene child references with a specific validation error
- cover the CLI validate command and lower-level validator expectation

## Tests
- pnpm test