### PR TITLE
docs: align camera example with default focal length

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,7 @@ A single-frame artboard with a title:
       "id": "camera",
       "kind": "camera",
       "parent": null,
+      "focalLength": 1000,
       "transform": { "x": 480, "y": 270, "z": 0, "rotation": 0, "scaleX": 1, "scaleY": 1 }
     }
   }


### PR DESCRIPTION
## Summary\n- Add the default camera focalLength to the AGENTS.md minimal scene example so it matches the surrounding authoring guidance.\n\n## Tests\n- pnpm --dir cli test