### PR TITLE
Tighten render option guards

### DIFF
--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -5,15 +5,18 @@ import path from 'node:path'
 export const RENDER_FORMATS = ['mp4', 'webm', 'gif'] as const
 export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
 
+const RENDER_FORMAT_SET: ReadonlySet<unknown> = new Set(RENDER_FORMATS)
+const RENDER_QUALITY_SET: ReadonlySet<unknown> = new Set(RENDER_QUALITIES)
+
 export type RenderFormat = (typeof RENDER_FORMATS)[number]
 export type RenderQuality = (typeof RENDER_QUALITIES)[number]
 
 export function isRenderFormat(value: unknown): value is RenderFormat {
-  return typeof value === 'string' && RENDER_FORMATS.includes(value as RenderFormat)
+  return typeof value === 'string' && RENDER_FORMAT_SET.has(value)
 }
 
 export function isRenderQuality(value: unknown): value is RenderQuality {
-  return typeof value === 'string' && RENDER_QUALITIES.includes(value as RenderQuality)
+  return typeof value === 'string' && RENDER_QUALITY_SET.has(value)
 }
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {


### PR DESCRIPTION
## Summary
- replace render option guard array assertions with readonly lookup sets
- keep supported format and quality exports unchanged

## Tests
- pnpm --dir cli test