### PR TITLE
Validate authored node positions

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -877,6 +877,20 @@ test('validateScene rejects unsupported track property ids', () => {
   ])
 })
 
+test('validateScene rejects unsupported node positions', () => {
+  const scene = sampleScene()
+  const title = scene.nodes?.title
+  if (!title) throw new Error('missing sample title')
+  title.position = 'floating' as typeof title.position
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'node title has unsupported position: floating',
+  ])
+})
+
 test('validateScene rejects tracks targeting missing nodes', () => {
   const scene = sampleScene()
   scene.tracks = {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -41,6 +41,7 @@ export interface SceneJson {
 }
 
 export type TextAlignJson = 'start' | 'center' | 'end'
+export type NodePositionJson = 'flow' | 'absolute'
 
 export type NodeKindJson =
   | 'frame'
@@ -68,6 +69,7 @@ export const NODE_KINDS = [
 ] as const satisfies readonly NodeKindJson[]
 
 const NODE_KIND_SET: ReadonlySet<string> = new Set(NODE_KINDS)
+const NODE_POSITION_SET: ReadonlySet<string> = new Set(['flow', 'absolute'])
 
 export interface SizeJson extends Record<string, unknown> {
   width?: number | 'hug' | 'fill'
@@ -150,7 +152,7 @@ export interface NodeJson {
   children?: string[]
   visible?: boolean
   locked?: boolean
-  position?: 'flow' | 'absolute'
+  position?: NodePositionJson
   isMask?: boolean
   componentSourceId?: string | null
   workspaceOnly?: boolean
@@ -907,6 +909,9 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
     if (typeof node.kind !== 'string' || !isNodeKind(node.kind)) {
       errors.push(`node ${id} has unsupported kind: ${String(node.kind)}`)
     }
+    if (node.position !== undefined && (typeof node.position !== 'string' || !isNodePosition(node.position))) {
+      errors.push(`node ${id} has unsupported position: ${String(node.position)}`)
+    }
     const parent = typeof node.parent === 'string' ? node.parent : null
     if (node.parent !== undefined && node.parent !== null && typeof node.parent !== 'string') {
       errors.push(`node ${id} parent must be a string or null`)
@@ -1012,6 +1017,10 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
 
 function isNodeKind(value: string): value is NodeKindJson {
   return NODE_KIND_SET.has(value)
+}
+
+function isNodePosition(value: string): value is NodePositionJson {
+  return NODE_POSITION_SET.has(value)
 }
 
 function isPropertyId(value: string): value is PropertyIdJson {


### PR DESCRIPTION
## Summary
- add a typed node position alias for authored scene JSON
- reject unsupported node.position values during CLI scene validation
- cover the invalid position path in scene builder tests

## Tests
- pnpm --dir cli test