### PR TITLE
test(cli): trim query scene paths

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -149,6 +149,45 @@ test('query scene MCP handlers report malformed scene files as MCP errors', asyn
   }
 })
 
+test('query scene MCP handlers trim padded scene paths before reading', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-trimmed-query-'))
+  const scenePath = path.join(dir, 'scene.hype')
+
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: { name: 'Trimmed Query', canvas: { width: 320, height: 180 } },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const result = await handleListLayers({ scene: `  ${scenePath}\n` })
+    const payload = JSON.parse(assertToolText(result)) as {
+      root: string
+      layers: Array<{ id: string }>
+    }
+
+    assert.equal(result.isError, undefined)
+    assert.equal(payload.root, 'root')
+    assert.deepEqual(
+      payload.layers.map((layer) => layer.id),
+      ['root'],
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('query scene MCP handlers return layers, tracks, and cameras', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-query-mcp-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -151,22 +151,23 @@ export async function handleListCameras(
 }
 
 function read(toolName: QuerySceneToolName, scenePath: string): ReadSceneResult {
+  const normalizedScenePath = scenePath.trim()
   let bytes: Buffer
   try {
-    const stats = fs.statSync(scenePath)
+    const stats = fs.statSync(normalizedScenePath)
     if (!stats.isFile()) {
       return {
         ok: false,
-        result: errorText(`${toolName}: scene path is not a file: ${scenePath}`),
+        result: errorText(`${toolName}: scene path is not a file: ${normalizedScenePath}`),
       }
     }
 
-    bytes = fs.readFileSync(scenePath)
+    bytes = fs.readFileSync(normalizedScenePath)
   } catch (err) {
     return {
       ok: false,
       result: errorText(
-        `${toolName}: failed to read ${scenePath}: ${
+        `${toolName}: failed to read ${normalizedScenePath}: ${
           err instanceof Error ? err.message : String(err)
         }`,
       ),
@@ -179,7 +180,7 @@ function read(toolName: QuerySceneToolName, scenePath: string): ReadSceneResult 
     return {
       ok: false,
       result: errorText(
-        `${toolName}: ${scenePath} is not a valid .hype file: ${
+        `${toolName}: ${normalizedScenePath} is not a valid .hype file: ${
           err instanceof Error ? err.message : String(err)
         }`,
       ),


### PR DESCRIPTION
## Summary
- Trim padded scene paths before MCP query scene tools read .hype files
- Add coverage for padded query scene paths

## Verification
- pnpm --dir cli test