### PR TITLE
Document relative render output paths

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -25,6 +25,13 @@ test('render_scene input schema exposes fps bounds', () => {
   assert.equal(fpsProperty?.maximum, 120)
 })
 
+test('render_scene input schema documents relative output paths', () => {
+  const outputProperty = schemaProperty('output')
+
+  assert.equal(outputProperty?.type, 'string')
+  assert.match(String(outputProperty?.description), /relative output file path/)
+})
+
 test('render_scene input schema exposes render preset enums', () => {
   const formatProperty = schemaProperty('format')
   const qualityProperty = schemaProperty('quality')

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -56,7 +56,10 @@ export const renderSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      output: { type: 'string', description: 'Output file path' },
+      output: {
+        type: 'string',
+        description: 'Absolute or relative output file path.',
+      },
       format: {
         type: 'string',
         enum: [...RENDER_FORMATS],


### PR DESCRIPTION
## Summary
- Clarify that the MCP render_scene output path accepts absolute or relative paths
- Add a schema test so the documented output path contract stays in sync

## Tests
- pnpm --dir cli test
- pnpm test