### PR TITLE
Handle empty query scene paths

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -93,6 +93,24 @@ test('query scene MCP handlers report missing scene files as MCP errors', async 
   }
 })
 
+test('query scene MCP handlers reject empty scene paths clearly', async () => {
+  const cases: Array<{
+    name: string
+    run: () => Promise<CallToolResult>
+  }> = [
+    { name: 'list_layers', run: () => handleListLayers({ scene: '  ' }) },
+    { name: 'get_layer', run: () => handleGetLayer({ scene: '\n', nodeId: 'title' }) },
+    { name: 'list_tracks', run: () => handleListTracks({ scene: '\t' }) },
+    { name: 'list_cameras', run: () => handleListCameras({ scene: '' }) },
+  ]
+
+  for (const entry of cases) {
+    const result = await entry.run()
+    assert.equal(result.isError, true)
+    assert.equal(assertToolText(result), `${entry.name}: scene path is required`)
+  }
+})
+
 test('query scene MCP handlers report directories as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-directory-query-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -152,6 +152,13 @@ export async function handleListCameras(
 
 function read(toolName: QuerySceneToolName, scenePath: string): ReadSceneResult {
   const normalizedScenePath = scenePath.trim()
+  if (!normalizedScenePath) {
+    return {
+      ok: false,
+      result: errorText(`${toolName}: scene path is required`),
+    }
+  }
+
   let bytes: Buffer
   try {
     const stats = fs.statSync(normalizedScenePath)


### PR DESCRIPTION
## Summary
- Return a clear MCP error when query-scene tools receive an empty scene path after trimming
- Add focused coverage for list_layers, get_layer, list_tracks, and list_cameras

## Tests
- pnpm --dir cli run build && node --test cli/dist/mcp/queryScene.test.js
- pnpm test

Note: app-wide pnpm typecheck currently fails on unrelated existing main-branch TypeScript errors; CLI build and tests pass.