### PR TITLE
Cover uppercase render format query inference

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -46,6 +46,7 @@ test('inferRenderFormatFromPath ignores URL-style suffixes', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.webm#preview'), 'webm')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.mp4?download=1#preview'), 'mp4')
   assert.equal(inferRenderFormatFromPath(' /tmp/demo.webm?download=1 '), 'webm')
+  assert.equal(inferRenderFormatFromPath('/tmp/demo.GIF?download=1'), 'gif')
 })
 
 test('inferRenderFormatFromPath falls back to mp4 for unknown extensions', () => {


### PR DESCRIPTION
## Summary
- add coverage for uppercase render format extensions with URL-style suffixes

## Verification
- pnpm --dir cli test