### PR TITLE
Trim scene names in info output

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -256,6 +256,42 @@ test('info command falls back for blank scene names', async () => {
   }
 })
 
+test('info command trims padded scene names', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: '  Padded Name  ',
+          canvas: { width: 400, height: 300 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 400, height: 300 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await infoCommand().exitOverride().parseAsync([scenePath], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^Scene: Padded Name$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('info command replaces non-finite canvas numbers with placeholders', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -112,6 +112,9 @@ function printableCanvasValue(value: unknown): number | '?' {
 }
 
 function printableSceneName(value: unknown): string {
-  if (typeof value === 'string' && value.trim().length > 0) return value
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.length > 0) return trimmed
+  }
   return '(unnamed)'
 }


### PR DESCRIPTION
## Summary
- trim padded scene names in human-readable `hypermotion info` output
- add CLI coverage for padded scene names

## Tests
- `pnpm --dir cli test`