### PR TITLE
Handle extension-only render outputs

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -37,6 +37,11 @@ test('inferRenderFormatFromPath normalizes extension casing', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.WEBM'), 'webm')
 })
 
+test('inferRenderFormatFromPath recognizes extension-only output filenames', () => {
+  assert.equal(inferRenderFormatFromPath('.gif'), 'gif')
+  assert.equal(inferRenderFormatFromPath('/tmp/.WEBM'), 'webm')
+})
+
 test('inferRenderFormatFromPath trims surrounding whitespace', () => {
   assert.equal(inferRenderFormatFromPath(' /tmp/demo.gif '), 'gif')
 })

--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -21,6 +21,11 @@ export function isRenderQuality(value: unknown): value is RenderQuality {
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {
   const cleanPath = (filePath.split(/[?#]/, 1)[0] ?? filePath).trim()
-  const ext = path.extname(cleanPath).toLowerCase().slice(1)
+  const basename = path.basename(cleanPath)
+  const ext = (
+    path.extname(cleanPath) || (basename.startsWith('.') ? basename : '')
+  )
+    .toLowerCase()
+    .slice(1)
   return isRenderFormat(ext) ? ext : 'mp4'
 }


### PR DESCRIPTION
## Summary
- infer render formats from extension-only output names like `.gif` and `/tmp/.WEBM`
- add focused coverage for extension-only render output filenames

## Tests
- `pnpm --dir cli run build && node --test cli/dist/renderOptions.test.js`
- `pnpm --dir cli test`