### PR TITLE
fix(cli): trim info scene paths

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -292,6 +292,57 @@ test('info command trims padded scene names', async () => {
   }
 })
 
+test('info command trims padded scene paths', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Trimmed Path',
+          canvas: { width: 400, height: 300 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 400, height: 300 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await infoCommand().exitOverride().parseAsync([`  ${scenePath}\n`], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^Scene: Trimmed Path$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('info command rejects empty scene paths clearly', async () => {
+  const stderr = await captureStderr(async () => {
+    await withProcessExitThrow(() => {
+      assert.throws(
+        () => {
+          infoCommand().parse(['  '], { from: 'user' })
+        },
+        { exitCode: 2 },
+      )
+    })
+  })
+
+  assert.equal(stderr, '[info] scene path is required\n')
+})
+
 test('info command replaces non-finite canvas numbers with placeholders', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -28,7 +28,13 @@ export function infoCommand(): Command {
     .argument('<scene>', 'Path to a .hype scene file')
     .option('--json', 'Output the summary as JSON for scripting')
     .action((scenePath: string, options: InfoCommandOptions) => {
-      const resolvedScenePath = path.resolve(scenePath)
+      const trimmedScenePath = scenePath.trim()
+      if (!trimmedScenePath) {
+        console.error('[info] scene path is required')
+        process.exit(2)
+      }
+
+      const resolvedScenePath = path.resolve(trimmedScenePath)
       let bytes: Buffer
       let stats: fs.Stats
       try {


### PR DESCRIPTION
## Summary
- Trim surrounding whitespace from `hypermotion info` scene path arguments before resolving them
- Report whitespace-only scene paths as a clear `[info] scene path is required` error
- Add focused CLI coverage for padded and empty info scene paths

## Tests
- `pnpm --dir cli run build && pnpm --dir cli exec node --test dist/commands/info.test.js`
- `pnpm test`