### PR TITLE
Cover unknown extension-only render outputs

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -40,6 +40,7 @@ test('inferRenderFormatFromPath normalizes extension casing', () => {
 test('inferRenderFormatFromPath recognizes extension-only output filenames', () => {
   assert.equal(inferRenderFormatFromPath('.gif'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/.WEBM'), 'webm')
+  assert.equal(inferRenderFormatFromPath('.mov'), 'mp4')
 })
 
 test('inferRenderFormatFromPath trims surrounding whitespace', () => {


### PR DESCRIPTION
## Summary
- Add a CLI render option test covering unknown extension-only output names such as .mov.
- Locks in the existing fallback behavior to MP4 for unsupported extensions.

## Tests
- pnpm --dir cli run build && node --test cli/dist/renderOptions.test.js
- pnpm test