### PR TITLE
Remove stale Figma plugin lint suppressions

### DIFF
--- a/figma-plugin/src/ui.ts
+++ b/figma-plugin/src/ui.ts
@@ -115,7 +115,6 @@ copyBtn.addEventListener('click', () => {
       await navigator.clipboard.write([item])
       return true
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn('[hyper-motion] modern clipboard write failed', err)
       return false
     }
@@ -151,7 +150,6 @@ copyBtn.addEventListener('click', () => {
     try {
       fallbackOk = await tryFallbackWrite()
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn('[hyper-motion] fallback clipboard write failed', err)
     }
     if (fallbackOk) {
@@ -230,7 +228,6 @@ function copyViaExecCommand(text: string): boolean {
   try {
     ok = document.execCommand('copy')
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.warn('[hyper-motion] execCommand copy failed', err)
   } finally {
     document.body.removeChild(ta)


### PR DESCRIPTION
## Summary
- remove obsolete eslint-disable comments around Figma plugin clipboard warning logs

## Verification
- pnpm exec eslint figma-plugin/src/ui.ts
- pnpm --dir cli test

Notes: root lint and root typecheck still have existing baseline failures outside this change.