### PR TITLE
Cover malformed render output fallbacks

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -61,4 +61,7 @@ test('inferRenderFormatFromPath falls back to mp4 for unknown extensions', () =>
   assert.equal(inferRenderFormatFromPath('/tmp/demo.mov'), 'mp4')
   assert.equal(inferRenderFormatFromPath('/tmp/demo'), 'mp4')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.'), 'mp4')
+  assert.equal(inferRenderFormatFromPath('   '), 'mp4')
+  assert.equal(inferRenderFormatFromPath('?download=1'), 'mp4')
+  assert.equal(inferRenderFormatFromPath('#preview'), 'mp4')
 })


### PR DESCRIPTION
## Summary
- add render option tests for whitespace-only and suffix-only output paths falling back to mp4

## Tests
- pnpm --dir cli test
- pnpm test