### PR TITLE
Preserve capture helper callback types

### DIFF
--- a/cli/src/testUtils/stdout.ts
+++ b/cli/src/testUtils/stdout.ts
@@ -15,9 +15,9 @@ function stringifyChunk(
   return chunk.toString()
 }
 
-async function captureStream(
+async function captureStream<T>(
   stream: WritableStream,
-  run: CaptureCallback<unknown>,
+  run: CaptureCallback<T>,
 ): Promise<string> {
   let output = ''
   const write = stream.write


### PR DESCRIPTION
## Summary
- Preserve the generic callback type through the CLI stdout/stderr capture helper.

## Tests
- pnpm --dir cli test