### PR TITLE
Clarify render command scene support

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -33,6 +33,11 @@ test('render format inference handles case and unknown extensions', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/preview.mov'), 'mp4')
 })
 
+test('render command description mentions saved scene support', () => {
+  assert.match(renderCommand().description(), /saved \.hype scene/)
+  assert.match(renderCommand().description(), /current desktop scene/)
+})
+
 test('render command forwards saved scene paths to the driver', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-ok-'))
   const scenePath = path.join(dir, 'scene with spaces.hype')

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -3,8 +3,9 @@
 /**
  * `hypermotion render -o <out>`
  *
- * Renders the user's current hyper-motion scene (whatever was last
- * persisted to IndexedDB by the desktop app) to MP4, WebM, or GIF.
+ * Renders a saved `.hype` scene, or the user's current hyper-motion scene
+ * (whatever was last persisted to IndexedDB by the desktop app), to MP4,
+ * WebM, or GIF.
  * Internally shells out to the installed desktop app, which opens an
  * off-screen window, loads the scene, runs the export pipeline, and
  * writes the rendered file to `<out>`.
@@ -55,7 +56,7 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
 
   return new Command('render')
     .description(
-      "Render the current scene (whatever's loaded in the desktop app) " +
+      'Render a saved .hype scene, or the current desktop scene, ' +
         'to MP4, WebM, or GIF.',
     )
     .requiredOption('-o, --output <path>', 'Output file path')


### PR DESCRIPTION
## Summary
- Update the render command module docs and CLI description to mention saved .hype scene rendering.
- Add a focused test so the render command description stays aligned with --scene support.

## Tests
- pnpm --dir cli run build && node --test cli/dist/commands/render.test.js
- pnpm --dir cli test