### PR TITLE
Validate blank MCP query node ids

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -65,6 +65,23 @@ test('query scene MCP handlers report invalid arguments as MCP errors', async ()
   }
 })
 
+test('query scene MCP handlers reject blank node ids clearly', async () => {
+  const cases: Array<{
+    name: string
+    run: () => Promise<CallToolResult>
+  }> = [
+    { name: 'get_layer', run: () => handleGetLayer({ scene: '/tmp/scene.hype', nodeId: '  ' }) },
+    { name: 'list_tracks', run: () => handleListTracks({ scene: '/tmp/scene.hype', nodeId: '\n' }) },
+  ]
+
+  for (const entry of cases) {
+    const result = await entry.run()
+    assert.equal(result.isError, true)
+    assert.match(assertToolText(result), new RegExp(`^${entry.name}: invalid arguments`))
+    assert.match(assertToolText(result), /nodeId is required/)
+  }
+})
+
 test('query scene MCP handlers report missing scene files as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-missing-query-'))
   const missingScene = path.join(dir, 'missing.hype')
@@ -330,6 +347,15 @@ test('query scene MCP handlers return layers, tracks, and cameras', async () => 
     assert.deepEqual(
       literalTracksPayload.tracks.map((track) => track.id),
       ['fade-literal-title'],
+    )
+
+    const paddedTracksResult = await handleListTracks({ scene: scenePath, nodeId: ' title ' })
+    const paddedTracksPayload = JSON.parse(assertToolText(paddedTracksResult)) as {
+      tracks: Array<{ id: string; nodeId: string; propertyId: string }>
+    }
+    assert.deepEqual(
+      paddedTracksPayload.tracks.map((track) => track.id),
+      ['fade-title'],
     )
 
     const allTracksResult = await handleListTracks({ scene: scenePath })

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -6,8 +6,9 @@ import fs from 'node:fs'
 import { inspectScene } from '../../scene/build.js'
 
 const SceneInput = z.object({ scene: z.string() })
-const LayerInput = z.object({ scene: z.string(), nodeId: z.string() })
-const TrackInput = z.object({ scene: z.string(), nodeId: z.string().optional() })
+const NodeIdInput = z.string().trim().min(1, 'nodeId is required')
+const LayerInput = z.object({ scene: z.string(), nodeId: NodeIdInput })
+const TrackInput = z.object({ scene: z.string(), nodeId: NodeIdInput.optional() })
 type SceneInputData = z.infer<typeof SceneInput>
 type LayerInputData = z.infer<typeof LayerInput>
 type TrackInputData = z.infer<typeof TrackInput>


### PR DESCRIPTION
## Summary
- reject blank `nodeId` values for `get_layer` and filtered `list_tracks` MCP queries
- trim padded `nodeId` inputs before matching tracks
- add focused MCP query tests for blank and padded node ids

## Tests
- `pnpm test`

Note: `pnpm typecheck` currently fails on unrelated main-branch app type errors; the repository test command passes.