### PR TITLE
Cover non-text MCP helper content

### DIFF
--- a/cli/src/testUtils/mcp.test.ts
+++ b/cli/src/testUtils/mcp.test.ts
@@ -21,3 +21,14 @@ test('assertToolText reports missing text content clearly', () => {
     /expected first MCP content item to be text/,
   )
 })
+
+test('assertToolText rejects non-text first content items', () => {
+  const result: CallToolResult = {
+    content: [{ type: 'image', data: 'base64-png', mimeType: 'image/png' }],
+  }
+
+  assert.throws(
+    () => assertToolText(result),
+    /expected first MCP content item to be text/,
+  )
+})


### PR DESCRIPTION
## Summary
- add MCP helper coverage for non-text first content items

## Tests
- pnpm --dir cli test