### PR TITLE
Clarify headless scene render scope

### DIFF
--- a/src/headlessExport.ts
+++ b/src/headlessExport.ts
@@ -21,9 +21,8 @@
  * `exportScene()` with an `onBlob` interceptor that ships bytes back to
  * main via `export:headless-done`.
  *
- * Current scope: renders the user's CURRENT scene from IndexedDB. Future
- * file-based headless rendering will honor `--scene <path>` for `.hype`
- * files.
+ * Current scope: renders either the user's CURRENT scene from IndexedDB
+ * or a saved `.hype` file provided as `--scene <path>`.
  */
 
 import {


### PR DESCRIPTION
## Summary
- Update the renderer-side headless export header comment to reflect current saved .hype scene support via --scene.

## Verification
- pnpm exec eslint src/headlessExport.ts (passes with existing warning-level unused eslint-disable notes)
- pnpm typecheck (fails on existing unrelated repository-wide TypeScript errors, including src/anim/engine.ts, src/export/encodeGif.ts, src/ui/actions.ts, and others)