### PR TITLE
fix(cli): reject primitive patch json

### DIFF
--- a/cli/src/commands/patch.test.ts
+++ b/cli/src/commands/patch.test.ts
@@ -123,3 +123,47 @@ test('patch command reports directories before reading scene bytes', async () =>
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('patch command rejects top-level primitive JSON values', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-patch-primitive-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const patchPath = path.join(dir, 'patch.json')
+
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Original',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+    fs.writeFileSync(patchPath, '"patch"')
+
+    const stderr = await withProcessExitThrow(() => captureStderr(() => {
+      return assert.rejects(
+        patchCommand().parseAsync([scenePath, '--from', patchPath], { from: 'user' }),
+        { exitCode: 2 },
+      )
+    }))
+
+    assert.match(
+      stderr,
+      /^\[patch\] patch JSON must be an array or object at the top level\.$/m,
+    )
+    assert.equal(readSceneSummary(fs.readFileSync(scenePath)).meta.name, 'Original')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/commands/patch.ts
+++ b/cli/src/commands/patch.ts
@@ -46,6 +46,10 @@ export function patchCommand(): Command {
         console.error(`[patch] failed to read patch: ${err instanceof Error ? err.message : err}`)
         process.exit(2)
       }
+      if (typeof patch !== 'object' || patch == null) {
+        console.error('[patch] patch JSON must be an array or object at the top level.')
+        process.exit(2)
+      }
 
       let next: Uint8Array
       try {


### PR DESCRIPTION
## Summary
- reject primitive or null patch JSON before applying CLI patch operations
- add coverage that the input scene is left unchanged for primitive patch JSON

## Tests
- pnpm --dir cli test -- --test-name-pattern='patch command'
- pnpm test