### PR TITLE
Clarify CLI image fill fit type

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -81,6 +81,8 @@ export interface GradientStopJson {
   color: string
 }
 
+export type ImageFillFitJson = 'cover' | 'contain' | 'fill' | 'tile'
+
 export type FillJson =
   | { kind: 'solid'; color: string }
   | { kind: 'linear'; stops: GradientStopJson[]; angle: number }
@@ -101,7 +103,7 @@ export type FillJson =
   | {
       kind: 'image'
       src: string
-      fit: 'cover' | 'contain' | 'fill' | 'tile'
+      fit: ImageFillFitJson
     }
 
 export type StrokeStyleJson = 'solid' | 'dashed' | 'dotted'


### PR DESCRIPTION
## Summary
- Add an explicit CLI type alias for image fill fit values
- Keep image fill fit values distinct from media node fit values

## Verification
- pnpm test
- pnpm --dir cli test

Note: root `pnpm typecheck` still fails on existing app-wide TypeScript errors unrelated to this CLI type-only change.