### PR TITLE
test(cli): avoid global fs patching in render scene tests

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -16,6 +16,7 @@ type JsonSchemaProperty = {
   maximum?: number
   description?: string
 }
+type RenderSceneDeps = NonNullable<Parameters<typeof handleRenderScene>[1]>
 
 test('render_scene input schema exposes fps bounds', () => {
   const fpsProperty = schemaProperty('fps')
@@ -122,20 +123,19 @@ test('render_scene reports scene stat failures as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-stat-'))
   const scenePath = path.join(dir, 'scene.hype')
   fs.writeFileSync(scenePath, '')
-  const previousStatSync = fs.statSync
 
   try {
-    Object.defineProperty(fs, 'statSync', {
-      configurable: true,
-      value: () => {
-        throw new Error('stat failed')
+    const result = await handleRenderScene(
+      {
+        output: path.join(dir, 'out.mp4'),
+        scene: scenePath,
       },
-    })
-
-    const result = await handleRenderScene({
-      output: path.join(dir, 'out.mp4'),
-      scene: scenePath,
-    })
+      testDeps({
+        statSync: () => {
+          throw new Error('stat failed')
+        },
+      }),
+    )
 
     assert.equal(result.isError, true)
     assert.equal(
@@ -143,10 +143,6 @@ test('render_scene reports scene stat failures as MCP errors', async () => {
       `render_scene: failed to read ${scenePath}: stat failed`,
     )
   } finally {
-    Object.defineProperty(fs, 'statSync', {
-      configurable: true,
-      value: previousStatSync,
-    })
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
@@ -175,20 +171,19 @@ test('render_scene reports output directory stat failures as MCP errors', async 
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-stat-'))
   const outDir = path.join(dir, 'exports')
   fs.mkdirSync(outDir)
-  const previousStatSync = fs.statSync
 
   try {
-    Object.defineProperty(fs, 'statSync', {
-      configurable: true,
-      value: (targetPath: fs.PathLike) => {
-        if (targetPath === outDir) throw new Error('stat failed')
-        return previousStatSync(targetPath)
+    const result = await handleRenderScene(
+      {
+        output: path.join(outDir, 'out.mp4'),
       },
-    })
-
-    const result = await handleRenderScene({
-      output: path.join(outDir, 'out.mp4'),
-    })
+      testDeps({
+        statSync: (targetPath: fs.PathLike) => {
+          if (targetPath === outDir) throw new Error('stat failed')
+          return fs.statSync(targetPath)
+        },
+      }),
+    )
 
     assert.equal(result.isError, true)
     assert.equal(
@@ -196,10 +191,6 @@ test('render_scene reports output directory stat failures as MCP errors', async 
       `render_scene: failed to read output directory ${outDir}: stat failed`,
     )
   } finally {
-    Object.defineProperty(fs, 'statSync', {
-      configurable: true,
-      value: previousStatSync,
-    })
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
@@ -207,20 +198,19 @@ test('render_scene reports output directory stat failures as MCP errors', async 
 test('render_scene reports output directory creation failures as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-mkdir-'))
   const outDir = path.join(dir, 'exports')
-  const previousMkdirSync = fs.mkdirSync
 
   try {
-    Object.defineProperty(fs, 'mkdirSync', {
-      configurable: true,
-      value: (targetPath: fs.PathLike, options?: fs.MakeDirectoryOptions) => {
-        if (targetPath === outDir) throw new Error('mkdir failed')
-        return previousMkdirSync(targetPath, options)
+    const result = await handleRenderScene(
+      {
+        output: path.join(outDir, 'out.mp4'),
       },
-    })
-
-    const result = await handleRenderScene({
-      output: path.join(outDir, 'out.mp4'),
-    })
+      testDeps({
+        mkdirSync: (targetPath: fs.PathLike, options?: fs.MakeDirectoryOptions) => {
+          if (targetPath === outDir) throw new Error('mkdir failed')
+          return fs.mkdirSync(targetPath, options)
+        },
+      }),
+    )
 
     assert.equal(result.isError, true)
     assert.equal(
@@ -228,10 +218,6 @@ test('render_scene reports output directory creation failures as MCP errors', as
       `render_scene: failed to create output directory ${outDir}: mkdir failed`,
     )
   } finally {
-    Object.defineProperty(fs, 'mkdirSync', {
-      configurable: true,
-      value: previousMkdirSync,
-    })
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
@@ -379,4 +365,15 @@ function schemaProperty(name: string): JsonSchemaProperty | undefined {
   return renderSceneTool.inputSchema.properties?.[name] as
     | JsonSchemaProperty
     | undefined
+}
+
+function testDeps(overrides: Partial<RenderSceneDeps>): RenderSceneDeps {
+  return {
+    existsSync: fs.existsSync,
+    statSync: fs.statSync,
+    mkdirSync: fs.mkdirSync,
+    locateApp: async () => null,
+    render: async () => {},
+    ...overrides,
+  }
 }

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -42,6 +42,21 @@ const RenderInput = z.object({
     ),
 })
 type RenderInputData = z.infer<typeof RenderInput>
+type RenderSceneDeps = {
+  existsSync: typeof fs.existsSync
+  statSync: (path: fs.PathLike) => fs.Stats
+  mkdirSync: (path: fs.PathLike, options: { recursive: true }) => string | undefined
+  locateApp: typeof locateDesktopApp
+  render: typeof driveHeadlessRender
+}
+
+const defaultDeps: RenderSceneDeps = {
+  existsSync: fs.existsSync,
+  statSync: fs.statSync,
+  mkdirSync: fs.mkdirSync,
+  locateApp: locateDesktopApp,
+  render: driveHeadlessRender,
+}
 
 function normalizeStringOption(value: unknown): unknown {
   return typeof value === 'string' ? value.trim().toLowerCase() : value
@@ -88,6 +103,7 @@ export const renderSceneTool: Tool = {
 
 export async function handleRenderScene(
   args: Record<string, unknown>,
+  deps: RenderSceneDeps = defaultDeps,
 ): Promise<CallToolResult> {
   const parsed = RenderInput.safeParse(args)
   if (!parsed.success) {
@@ -122,7 +138,7 @@ export async function handleRenderScene(
   const quality = input.quality ?? 'comp'
   const fps = input.fps ?? 30
 
-  if (scenePath && !fs.existsSync(scenePath)) {
+  if (scenePath && !deps.existsSync(scenePath)) {
     return {
       isError: true,
       content: [
@@ -136,7 +152,7 @@ export async function handleRenderScene(
   if (scenePath) {
     let stats: fs.Stats
     try {
-      stats = fs.statSync(scenePath)
+      stats = deps.statSync(scenePath)
     } catch (err) {
       return {
         isError: true,
@@ -164,10 +180,10 @@ export async function handleRenderScene(
   }
 
   const outDir = path.dirname(outputPath)
-  if (fs.existsSync(outDir)) {
+  if (deps.existsSync(outDir)) {
     let stats: fs.Stats
     try {
-      stats = fs.statSync(outDir)
+      stats = deps.statSync(outDir)
     } catch (err) {
       return {
         isError: true,
@@ -194,9 +210,9 @@ export async function handleRenderScene(
     }
   }
 
-  if (!fs.existsSync(outDir)) {
+  if (!deps.existsSync(outDir)) {
     try {
-      fs.mkdirSync(outDir, { recursive: true })
+      deps.mkdirSync(outDir, { recursive: true })
     } catch (err) {
       return {
         isError: true,
@@ -212,7 +228,7 @@ export async function handleRenderScene(
     }
   }
 
-  const appPath = await locateDesktopApp()
+  const appPath = await deps.locateApp()
   if (!appPath) {
     return {
       isError: true,
@@ -228,7 +244,7 @@ export async function handleRenderScene(
   }
 
   try {
-    await driveHeadlessRender({
+    await deps.render({
       appPath,
       outputPath,
       format,


### PR DESCRIPTION
## Summary
- inject render_scene filesystem/app dependencies with runtime defaults
- update failure-path render_scene tests to avoid monkey-patching global fs methods

## Tests
- pnpm --dir cli test -- renderScene
- pnpm test