### PR TITLE
chore(cli): tighten render option set types

### DIFF
--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -5,8 +5,8 @@ import path from 'node:path'
 export const RENDER_FORMATS = ['mp4', 'webm', 'gif'] as const
 export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
 
-const RENDER_FORMAT_SET: ReadonlySet<unknown> = new Set(RENDER_FORMATS)
-const RENDER_QUALITY_SET: ReadonlySet<unknown> = new Set(RENDER_QUALITIES)
+const RENDER_FORMAT_SET: ReadonlySet<string> = new Set(RENDER_FORMATS)
+const RENDER_QUALITY_SET: ReadonlySet<string> = new Set(RENDER_QUALITIES)
 
 export type RenderFormat = (typeof RENDER_FORMATS)[number]
 export type RenderQuality = (typeof RENDER_QUALITIES)[number]


### PR DESCRIPTION
## Summary
- tighten the internal render format/quality set types from unknown to string
- keep runtime guard behavior unchanged

## Tests
- pnpm --dir cli test
- pnpm test