### PR TITLE
Clarify CLI comp quality help

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -38,6 +38,12 @@ test('render command description mentions saved scene support', () => {
   assert.match(renderCommand().description(), /current desktop scene/)
 })
 
+test('render command quality help describes comp output size', () => {
+  const qualityOption = renderCommand().options.find((option) => option.long === '--quality')
+
+  assert.equal(qualityOption?.description, 'Quality: comp (match scene canvas) | 720p | 2k | 4k')
+})
+
 test('render command forwards saved scene paths to the driver', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-ok-'))
   const scenePath = path.join(dir, 'scene with spaces.hype')

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -66,7 +66,7 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
     )
     .option(
       '-q, --quality <quality>',
-      'Quality: comp (match comp) | 720p | 2k | 4k',
+      'Quality: comp (match scene canvas) | 720p | 2k | 4k',
       'comp',
     )
     .option('--fps <n>', 'Frame rate', '30')


### PR DESCRIPTION
## Summary
- clarify the render command's `comp` quality help text to say it matches the scene canvas
- add a small command metadata test to keep the help text from regressing

## Tests
- `pnpm --dir cli test -- --test-name-pattern "render command"`
- `pnpm test`