### PR TITLE
fix(cli): reject blank open scene paths

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -25,6 +25,13 @@ test('open_scene reports invalid arguments as MCP errors', async () => {
   assert.match(assertToolText(result), /^open_scene: invalid arguments/)
 })
 
+test('open_scene rejects empty scene paths as MCP errors', async () => {
+  const result = await handleOpenScene({ scene: '   ' })
+
+  assert.equal(result.isError, true)
+  assert.equal(assertToolText(result), 'open_scene: scene path is required')
+})
+
 test('open_scene reports missing files as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-missing-'))
   const missingScene = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -52,7 +52,15 @@ export async function handleOpenScene(
   }
 
   const input: OpenInputData = parsed.data
-  const scenePath = path.resolve(input.scene.trim())
+  const trimmedScene = input.scene.trim()
+  if (!trimmedScene) {
+    return {
+      isError: true,
+      content: [{ type: 'text' as const, text: 'open_scene: scene path is required' }],
+    }
+  }
+
+  const scenePath = path.resolve(trimmedScene)
   if (!deps.existsSync(scenePath)) {
     return {
       isError: true,


### PR DESCRIPTION
## Summary
- Reject all-whitespace MCP open_scene paths before resolving them
- Add a regression test for the blank scene path error

## Tests
- pnpm --dir cli run build && node --test cli/dist/mcp/openScene.test.js
- pnpm test