### PR TITLE
Add typed CLI node position constants

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -68,8 +68,13 @@ export const NODE_KINDS = [
   'camera',
 ] as const satisfies readonly NodeKindJson[]
 
+export const NODE_POSITIONS = [
+  'flow',
+  'absolute',
+] as const satisfies readonly NodePositionJson[]
+
 const NODE_KIND_SET: ReadonlySet<string> = new Set(NODE_KINDS)
-const NODE_POSITION_SET: ReadonlySet<string> = new Set(['flow', 'absolute'])
+const NODE_POSITION_SET: ReadonlySet<string> = new Set(NODE_POSITIONS)
 
 export interface SizeJson extends Record<string, unknown> {
   width?: number | 'hug' | 'fill'


### PR DESCRIPTION
## Summary\n- Add a typed NODE_POSITIONS constant for CLI scene node positions\n- Reuse it for validation set construction so future literals are checked against NodePositionJson\n\n## Verification\n- pnpm --dir cli test