### PR TITLE
fix(cli): reject blank info scene paths

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -32,6 +32,14 @@ test('info_scene reports invalid arguments as MCP errors', async () => {
   assert.match(text, /^info_scene: invalid arguments/)
 })
 
+test('info_scene rejects empty scene paths as MCP errors', async () => {
+  const result = await handleInfoScene({ scene: '   ' })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.equal(text, 'info_scene: scene path is required')
+})
+
 test('info_scene returns a structured scene summary', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-scene-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -49,7 +49,13 @@ export async function handleInfoScene(
   }
 
   const input: InfoInputData = parsed.data
-  const scenePath = input.scene
+  const scenePath = input.scene.trim()
+  if (!scenePath) {
+    return {
+      isError: true,
+      content: [{ type: 'text' as const, text: 'info_scene: scene path is required' }],
+    }
+  }
   let bytes: Buffer
   try {
     const stats = fs.statSync(scenePath)


### PR DESCRIPTION
## Summary
- reject whitespace-only paths in the info_scene MCP handler before filesystem access
- add focused coverage for the blank-path error

## Tests
- pnpm --dir cli run build && node --test cli/dist/mcp/infoScene.test.js
- pnpm test