### PR TITLE
test(cli): cover trimmed app path overrides

### DIFF
--- a/cli/src/electron/locator.test.ts
+++ b/cli/src/electron/locator.test.ts
@@ -24,6 +24,21 @@ test('locator returns an existing HYPERMOTION_APP_PATH override', async () => {
   }
 })
 
+test('locator trims a valid HYPERMOTION_APP_PATH override', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-trim-'))
+  const appPath = path.join(dir, 'hyper-motion')
+
+  try {
+    fs.writeFileSync(appPath, '')
+
+    await withEnvVar('HYPERMOTION_APP_PATH', `  ${appPath}  `, async () => {
+      assert.equal(await locateDesktopApp(), appPath)
+    })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('locator rejects a missing HYPERMOTION_APP_PATH override', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-missing-'))
   const missingPath = path.join(dir, 'hyper-motion')


### PR DESCRIPTION
## Summary
- Add locator coverage for valid HYPERMOTION_APP_PATH values with surrounding whitespace

## Verification
- pnpm --dir cli run build && node --test cli/dist/electron/locator.test.js
- pnpm --dir cli test