### PR TITLE
Reject blank validate_scene MCP paths

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -40,6 +40,12 @@ export async function handleValidateScene(
 
   const input: ValidateInputData = parsed.data
   const scenePath = input.scene.trim()
+  if (!scenePath) {
+    return {
+      isError: true,
+      content: [{ type: 'text' as const, text: 'validate_scene: scene path is required' }],
+    }
+  }
   let bytes: Buffer
   let stat: fs.Stats
   try {

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -26,6 +26,14 @@ test('validate_scene reports invalid arguments as MCP errors', async () => {
   assert.match(text, /^validate_scene: invalid arguments/)
 })
 
+test('validate_scene rejects empty scene paths as MCP errors', async () => {
+  const result = await handleValidateScene({ scene: '   ' })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.equal(text, 'validate_scene: scene path is required')
+})
+
 test('validate_scene reports missing files as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-missing-'))
   const missingScene = path.join(dir, 'scene.hype')


### PR DESCRIPTION
## Summary
- Reject whitespace-only `validate_scene` MCP scene paths before filesystem access
- Add a focused MCP test for the blank path error

## Tests
- `pnpm --dir cli test -- validateScene`
- `pnpm test`