### PR TITLE
test(cli): cover info read failures

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -486,6 +486,41 @@ test('info command reports stat failures as read errors', async () => {
   }
 })
 
+test('info command reports read failures after stat succeeds', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-read-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const originalReadFileSync = fs.readFileSync
+  try {
+    fs.writeFileSync(scenePath, '')
+    Object.defineProperty(fs, 'readFileSync', {
+      configurable: true,
+      value: ((readPath: fs.PathOrFileDescriptor) => {
+        if (readPath === scenePath) throw new Error('read failed')
+        return originalReadFileSync(readPath)
+      }) as typeof fs.readFileSync,
+    })
+
+    const stderr = await captureStderr(async () => {
+      await withProcessExitThrow(() => {
+        assert.throws(
+          () => {
+            infoCommand().parse([scenePath], { from: 'user' })
+          },
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.equal(
+      stderr,
+      `[info] failed to read ${path.resolve(scenePath)}: read failed\n`,
+    )
+  } finally {
+    Object.defineProperty(fs, 'readFileSync', { value: originalReadFileSync })
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('info command reports malformed scene files', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
   const scenePath = path.join(dir, 'malformed.hype')


### PR DESCRIPTION
## Summary
- Add CLI info command coverage for read failures that occur after stat succeeds
- Keep behavior aligned with existing validate command coverage

## Tests
- pnpm --dir cli test