### PR TITLE
fix(cli): prefix open scene path errors

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -40,7 +40,7 @@ test('open_scene reports missing files as MCP errors', async () => {
     const result = await handleOpenScene({ scene: missingScene })
 
     assert.equal(result.isError, true)
-    assert.equal(assertToolText(result), `Scene file not found: ${missingScene}`)
+    assert.equal(assertToolText(result), `open_scene: scene file not found: ${missingScene}`)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }
@@ -55,7 +55,7 @@ test('open_scene reports directories as MCP errors', async () => {
     const result = await handleOpenScene({ scene: sceneDir })
 
     assert.equal(result.isError, true)
-    assert.equal(assertToolText(result), `Scene path is not a file: ${sceneDir}`)
+    assert.equal(assertToolText(result), `open_scene: scene path is not a file: ${sceneDir}`)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -64,7 +64,7 @@ export async function handleOpenScene(
   if (!deps.existsSync(scenePath)) {
     return {
       isError: true,
-      content: [{ type: 'text' as const, text: `Scene file not found: ${scenePath}` }],
+      content: [{ type: 'text' as const, text: `open_scene: scene file not found: ${scenePath}` }],
     }
   }
   let stats: fs.Stats
@@ -86,7 +86,7 @@ export async function handleOpenScene(
   if (!stats.isFile()) {
     return {
       isError: true,
-      content: [{ type: 'text' as const, text: `Scene path is not a file: ${scenePath}` }],
+      content: [{ type: 'text' as const, text: `open_scene: scene path is not a file: ${scenePath}` }],
     }
   }
   let opened: boolean


### PR DESCRIPTION
## Summary
- Prefix open_scene missing-file and directory errors with the MCP tool name
- Update open_scene MCP unit expectations

## Tests
- pnpm test