### PR TITLE
Tighten CLI node patch value type

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -509,7 +509,7 @@ export type PatchOperation =
   | { op: 'createNode'; node: NodeJson }
   | { op: 'deleteNode'; nodeId: string }
   | { op: 'setNode'; nodeId: string; patch: JsonObject }
-  | { op: 'setNodeProperty'; nodeId: string; key: string; value: unknown }
+  | { op: 'setNodeProperty'; nodeId: string; key: string; value: JsonValue }
   | { op: 'appendChild'; parentId: string; nodeId: string }
   | { op: 'moveChild'; parentId: string; nodeId: string; toIndex: number }
   | { op: 'setTrack'; track: TrackJson }


### PR DESCRIPTION
## Summary
- restrict CLI setNodeProperty patch values to JSON-compatible scene values

## Verification
- pnpm --dir cli test

Note: root `pnpm typecheck` still fails on existing app-wide TypeScript errors unrelated to this CLI type-only change.