### PR TITLE
test(cli): cover MCP serve mode

### DIFF
--- a/cli/src/commands/serve.test.ts
+++ b/cli/src/commands/serve.test.ts
@@ -17,3 +17,15 @@ test('serve command requires an explicit server mode', async () => {
 
   assert.match(stderr, /^\[serve\] no mode specified\. Use --mcp/m)
 })
+
+test('serve command starts the MCP server in MCP mode', async () => {
+  let calls = 0
+
+  await serveCommand({
+    startServer: async () => {
+      calls += 1
+    },
+  }).parseAsync(['--mcp'], { from: 'user' })
+
+  assert.equal(calls, 1)
+})

--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -16,7 +16,13 @@
 import { Command } from 'commander'
 import { startMcpServer } from '../mcp/server.js'
 
-export function serveCommand(): Command {
+interface ServeCommandDeps {
+  startServer?: () => Promise<void>
+}
+
+export function serveCommand(deps: ServeCommandDeps = {}): Command {
+  const startServer = deps.startServer ?? startMcpServer
+
   return new Command('serve')
     .description('Start a server (MCP over stdio, for AI agents).')
     .option('--mcp', 'Run as a Model Context Protocol server over stdio')
@@ -25,6 +31,6 @@ export function serveCommand(): Command {
         console.error('[serve] no mode specified. Use --mcp to start the MCP server.')
         process.exit(1)
       }
-      await startMcpServer()
+      await startServer()
     })
 }


### PR DESCRIPTION
## Summary
- Add a tiny dependency injection point for the CLI serve command's MCP server starter
- Cover the positive `hypermotion serve --mcp` path without starting the real stdio server

## Verification
- `pnpm --dir cli run build && node --test cli/dist/commands/serve.test.js`
- `pnpm test`