### PR TITLE
test(cli): require single MCP text content item

### DIFF
--- a/cli/src/testUtils/mcp.test.ts
+++ b/cli/src/testUtils/mcp.test.ts
@@ -5,7 +5,7 @@ import test from 'node:test'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { assertToolText } from './mcp.js'
 
-test('assertToolText returns the first MCP text content item', () => {
+test('assertToolText returns the only MCP text content item', () => {
   const result: CallToolResult = {
     content: [{ type: 'text', text: 'hello' }],
   }
@@ -13,12 +13,26 @@ test('assertToolText returns the first MCP text content item', () => {
   assert.equal(assertToolText(result), 'hello')
 })
 
+test('assertToolText rejects extra content items', () => {
+  const result: CallToolResult = {
+    content: [
+      { type: 'text', text: 'hello' },
+      { type: 'text', text: 'extra' },
+    ],
+  }
+
+  assert.throws(
+    () => assertToolText(result),
+    /expected exactly one MCP content item/,
+  )
+})
+
 test('assertToolText reports missing text content clearly', () => {
   const result: CallToolResult = { content: [] }
 
   assert.throws(
     () => assertToolText(result),
-    /expected first MCP content item to be text/,
+    /expected exactly one MCP content item/,
   )
 })
 

--- a/cli/src/testUtils/mcp.ts
+++ b/cli/src/testUtils/mcp.ts
@@ -6,6 +6,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 type ToolTextContent = Extract<CallToolResult['content'][number], { type: 'text' }>
 
 export function assertToolText(result: CallToolResult): string {
+  assert.equal(result.content.length, 1, 'expected exactly one MCP content item')
   const item = result.content[0]
   assert.ok(isToolTextContent(item), 'expected first MCP content item to be text')
   return item.text


### PR DESCRIPTION
## Summary
- tighten the CLI MCP test helper to require exactly one text content item
- add coverage for extra MCP content items

## Tests
- pnpm --dir cli test