### PR TITLE
Handle blank inspect scene paths

### DIFF
--- a/cli/src/mcp/inspectScene.test.ts
+++ b/cli/src/mcp/inspectScene.test.ts
@@ -26,6 +26,14 @@ test('inspect_scene reports invalid arguments as MCP errors', async () => {
   assert.match(text, /^inspect_scene: invalid arguments/)
 })
 
+test('inspect_scene rejects blank scene paths as MCP errors', async () => {
+  const result = await handleInspectScene({ scene: '   ' })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.equal(text, 'inspect_scene: scene path is required')
+})
+
 test('inspect_scene reports missing files as MCP errors', async () => {
   const result = await handleInspectScene({ scene: '/tmp/hypermotion-missing-inspect-scene.hype' })
 

--- a/cli/src/mcp/tools/inspectScene.ts
+++ b/cli/src/mcp/tools/inspectScene.ts
@@ -3,6 +3,7 @@
 import { z } from 'zod'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
+import path from 'node:path'
 import { inspectScene } from '../../scene/build.js'
 
 const InspectInput = z.object({
@@ -39,17 +40,26 @@ export async function handleInspectScene(
   }
 
   const input: InspectInputData = parsed.data
+  const trimmedScene = input.scene.trim()
+  if (!trimmedScene) {
+    return {
+      isError: true,
+      content: [{ type: 'text' as const, text: 'inspect_scene: scene path is required' }],
+    }
+  }
+
+  const scenePath = path.resolve(trimmedScene)
   let bytes: Buffer
   let stat: fs.Stats
   try {
-    stat = fs.statSync(input.scene)
+    stat = fs.statSync(scenePath)
   } catch (err) {
     return {
       isError: true,
       content: [
         {
           type: 'text' as const,
-          text: `inspect_scene: failed to read ${input.scene}: ${
+          text: `inspect_scene: failed to read ${scenePath}: ${
             err instanceof Error ? err.message : String(err)
           }`,
         },
@@ -62,20 +72,20 @@ export async function handleInspectScene(
       content: [
         {
           type: 'text' as const,
-          text: `inspect_scene: scene path is not a file: ${input.scene}`,
+          text: `inspect_scene: scene path is not a file: ${scenePath}`,
         },
       ],
     }
   }
   try {
-    bytes = fs.readFileSync(input.scene)
+    bytes = fs.readFileSync(scenePath)
   } catch (err) {
     return {
       isError: true,
       content: [
         {
           type: 'text' as const,
-          text: `inspect_scene: failed to read ${input.scene}: ${
+          text: `inspect_scene: failed to read ${scenePath}: ${
             err instanceof Error ? err.message : String(err)
           }`,
         },
@@ -98,7 +108,7 @@ export async function handleInspectScene(
       content: [
         {
           type: 'text' as const,
-          text: `inspect_scene: failed to inspect ${input.scene}: ${
+          text: `inspect_scene: failed to inspect ${scenePath}: ${
             err instanceof Error ? err.message : String(err)
           }`,
         },


### PR DESCRIPTION
## Summary
- Trim and resolve inspect_scene MCP paths before reading
- Return a clear MCP error for blank inspect_scene paths
- Add coverage for the blank path case

## Tests
- pnpm --dir cli test -- inspectScene
- pnpm test