### PR TITLE
fix(cli): reject blank open scene paths

### DIFF
--- a/cli/src/commands/open.test.ts
+++ b/cli/src/commands/open.test.ts
@@ -97,6 +97,26 @@ test('open command trims padded scene paths before launching the app', async () 
   }
 })
 
+test('open command rejects blank scene paths before launching the app', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        openCommand({
+          locateApp: async () => {
+            throw new Error('should not locate app')
+          },
+          spawnApp: () => {
+            throw new Error('should not launch')
+          },
+        }).parseAsync(['   '], { from: 'user' }),
+        { exitCode: 2 },
+      )
+    })
+  })
+
+  assert.equal(stderr, '[open] scene path is required\n')
+})
+
 test('open command reports missing scene files before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-'))
   const scenePath = path.join(dir, 'missing.hype')

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -31,7 +31,13 @@ export function openCommand(deps: Partial<OpenCommandDeps> = {}): Command {
     .description('Open a .hype scene file in the hyper-motion desktop app.')
     .argument('<scene>', 'Path to a .hype scene file')
     .action(async (scene: string) => {
-      const scenePath = path.resolve(scene.trim())
+      const trimmedScenePath = scene.trim()
+      if (!trimmedScenePath) {
+        console.error('[open] scene path is required')
+        process.exit(2)
+      }
+
+      const scenePath = path.resolve(trimmedScenePath)
       if (!commandDeps.existsSync(scenePath)) {
         console.error(`[open] scene file not found: ${scenePath}`)
         process.exit(2)


### PR DESCRIPTION
## Summary
- reject blank scene paths in the CLI open command before resolving the current directory
- add a focused regression test for blank open scene paths

## Tests
- pnpm --dir cli test -- open.test.js