### PR TITLE
fix(cli): trim patch scene paths

### DIFF
--- a/cli/src/commands/patch.test.ts
+++ b/cli/src/commands/patch.test.ts
@@ -100,6 +100,59 @@ test('patch command overwrites the input scene by default', async () => {
   }
 })
 
+test('patch command trims padded scene paths before reading', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-patch-trimmed-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const patchPath = path.join(dir, 'patch.json')
+
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Before',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+    fs.writeFileSync(
+      patchPath,
+      JSON.stringify({ ops: [{ op: 'setMeta', patch: { name: 'Trimmed' } }] }),
+    )
+
+    await patchCommand()
+      .exitOverride()
+      .parseAsync([`  ${scenePath}\n`, '--from', patchPath], {
+        from: 'user',
+      })
+
+    assert.equal(readSceneSummary(fs.readFileSync(scenePath)).meta.name, 'Trimmed')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('patch command rejects blank scene paths before reading patch JSON', async () => {
+  const stderr = await withProcessExitThrow(() => captureStderr(() => {
+    return assert.rejects(
+      patchCommand().parseAsync(['   ', '--from', 'missing.json'], { from: 'user' }),
+      { exitCode: 2 },
+    )
+  }))
+
+  assert.equal(stderr, '[patch] scene path is required\n')
+})
+
 test('patch command reports directories before reading scene bytes', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-patch-dir-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/commands/patch.ts
+++ b/cli/src/commands/patch.ts
@@ -17,8 +17,14 @@ export function patchCommand(): Command {
     .requiredOption('-f, --from <json>', 'Patch JSON file. Use "-" to read from stdin.')
     .option('-o, --output <path>', 'Path to write. Defaults to overwriting <scene>.')
     .action(async (scenePath: string, options: PatchCommandOptions) => {
-      const resolvedScenePath = path.resolve(scenePath)
-      const output = path.resolve(options.output ?? scenePath)
+      const trimmedScenePath = scenePath.trim()
+      if (!trimmedScenePath) {
+        console.error('[patch] scene path is required')
+        process.exit(2)
+      }
+
+      const resolvedScenePath = path.resolve(trimmedScenePath)
+      const output = path.resolve(options.output ?? trimmedScenePath)
       let sceneBytes: Buffer
       let stats: fs.Stats
       try {


### PR DESCRIPTION
## Summary
- Trim patch command scene paths before resolving them
- Reject blank patch scene paths with a clear CLI error
- Add focused tests for padded and blank patch scene inputs

## Tests
- pnpm --dir cli test