### PR TITLE
docs(cli): punctuate info scene path schema

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -12,7 +12,7 @@ test('info_scene input schema exposes required scene path', () => {
   assert.deepEqual(infoSceneTool.inputSchema, {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to a .hype scene file' },
+      scene: { type: 'string', description: 'Path to a .hype scene file.' },
     },
     required: ['scene'],
   })

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -13,7 +13,7 @@ import fs from 'node:fs'
 import { readSceneSummary, type SceneSummary } from '../../scene/build.js'
 
 const InfoInput = z.object({
-  scene: z.string().describe('Path to a .hype scene file'),
+  scene: z.string().describe('Path to a .hype scene file.'),
 })
 type InfoInputData = z.infer<typeof InfoInput>
 
@@ -26,7 +26,7 @@ export const infoSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to a .hype scene file' },
+      scene: { type: 'string', description: 'Path to a .hype scene file.' },
     },
     required: ['scene'],
   },


### PR DESCRIPTION
## Summary\n- Add the missing trailing period to the info_scene path description in the MCP schema.\n- Update the matching schema assertion.\n\n## Tests\n- pnpm --dir cli test -- --test-name-pattern=info_scene\n- pnpm test