### PR TITLE
test: cover mixed render path suffixes

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -51,10 +51,12 @@ test('inferRenderFormatFromPath ignores URL-style suffixes', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.gif?download=1'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.webm#preview'), 'webm')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.mp4?download=1#preview'), 'mp4')
+  assert.equal(inferRenderFormatFromPath('/tmp/demo.webm#preview?download=1'), 'webm')
   assert.equal(inferRenderFormatFromPath(' /tmp/demo.webm?download=1 '), 'webm')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.GIF?download=1'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/demo?format=gif'), 'mp4')
   assert.equal(inferRenderFormatFromPath('/tmp/demo#preview.webm'), 'mp4')
+  assert.equal(inferRenderFormatFromPath('/tmp/demo#preview.webm?download=1'), 'mp4')
 })
 
 test('inferRenderFormatFromPath falls back to mp4 for unknown extensions', () => {


### PR DESCRIPTION
## Summary\n- Add CLI render format inference coverage for paths containing both fragment and query-like suffix text\n- Confirm suffix text after a fragment does not make a hidden extension look renderable\n\n## Tests\n- pnpm --dir cli run build && node --test cli/dist/renderOptions.test.js\n- pnpm test