### PR TITLE
test(cli): cover process exit restoration

### DIFF
--- a/cli/src/testUtils/processExit.test.ts
+++ b/cli/src/testUtils/processExit.test.ts
@@ -81,6 +81,19 @@ test('withProcessExitThrow converts process.exit into a thrown error', async () 
   )
 })
 
+test('withProcessExitThrow restores process.exit after process.exit throws', async () => {
+  const previousExit = process.exit
+
+  await assert.rejects(
+    withProcessExitThrow(() => {
+      process.exit(2)
+    }),
+    { exitCode: 2 },
+  )
+
+  assert.equal(process.exit, previousExit)
+})
+
 test('withProcessExitThrow preserves string exit codes', async () => {
   await assert.rejects(
     withProcessExitThrow(() => {


### PR DESCRIPTION
## Summary
- add focused coverage that withProcessExitThrow restores process.exit when process.exit is converted into a thrown error

## Verification
- pnpm --dir cli run build && node --test cli/dist/testUtils/processExit.test.js
- pnpm test
