### PR TITLE
test(cli): cover exact render option guards

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -15,6 +15,7 @@ test('render option guards accept supported values only', () => {
     assert.equal(isRenderFormat(format), true)
   }
   assert.equal(isRenderFormat('mov'), false)
+  assert.equal(isRenderFormat('MP4'), false)
   assert.equal(isRenderFormat(undefined), false)
   assert.equal(isRenderFormat(60), false)
 
@@ -22,6 +23,7 @@ test('render option guards accept supported values only', () => {
     assert.equal(isRenderQuality(quality), true)
   }
   assert.equal(isRenderQuality('1080p'), false)
+  assert.equal(isRenderQuality('4K'), false)
   assert.equal(isRenderQuality(undefined), false)
   assert.equal(isRenderQuality(60), false)
 })


### PR DESCRIPTION
## Summary\n- add assertions that render option type guards reject uppercase format and quality values\n- preserve normalization coverage in command/path-specific tests\n\n## Tests\n- pnpm --dir cli exec tsc && node --test cli/dist/renderOptions.test.js\n- pnpm test