### PR TITLE
Export patch operation type

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -502,6 +502,8 @@ export const PATCH_OPERATION_TYPES = [
   'deleteSection',
 ] as const satisfies readonly PatchOperation['op'][]
 
+export type PatchOperationType = (typeof PATCH_OPERATION_TYPES)[number]
+
 export type PatchOperation =
   | { op: 'setMeta'; patch: JsonObject }
   | { op: 'setRoot'; nodeId: string }


### PR DESCRIPTION
## Summary
- Export a PatchOperationType union from the existing PATCH_OPERATION_TYPES constant for CLI scene patch consumers.

## Verification
- pnpm --dir cli test