### PR TITLE
Validate blank render scene paths

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -67,6 +67,16 @@ test('render_scene rejects empty output paths as MCP errors', async () => {
   assert.equal(assertToolText(result), 'render_scene: output path is required')
 })
 
+test('render_scene rejects empty scene paths as MCP errors', async () => {
+  const result = await handleRenderScene({
+    output: 'demo.mp4',
+    scene: '   ',
+  })
+
+  assert.equal(result.isError, true)
+  assert.equal(assertToolText(result), 'render_scene: scene path is required')
+})
+
 test('render_scene rejects fractional fps values as MCP errors', async () => {
   const result = await handleRenderScene({
     output: 'demo.mp4',

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -133,6 +133,17 @@ export async function handleRenderScene(
   }
   const outputPath = path.resolve(outputInput)
   const sceneInput = input.scene?.trim()
+  if (input.scene !== undefined && !sceneInput) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: 'render_scene: scene path is required',
+        },
+      ],
+    }
+  }
   const scenePath = sceneInput ? path.resolve(sceneInput) : undefined
   const format = input.format ?? inferRenderFormatFromPath(outputPath)
   const quality = input.quality ?? 'comp'


### PR DESCRIPTION
## Summary\n- Reject whitespace-only scene paths in the render_scene MCP handler\n- Add coverage for the blank scene-path error\n\n## Tests\n- pnpm --dir cli test -- renderScene\n- pnpm test