### PR TITLE
test: cover query-like render output names

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -57,6 +57,7 @@ test('inferRenderFormatFromPath ignores URL-style suffixes', () => {
   assert.equal(inferRenderFormatFromPath(' /tmp/demo.webm?download=1 '), 'webm')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.GIF?download=1'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/demo?format=gif'), 'mp4')
+  assert.equal(inferRenderFormatFromPath('/tmp/demo?format=gif.mp4'), 'mp4')
   assert.equal(inferRenderFormatFromPath('/tmp/demo#preview.webm'), 'mp4')
   assert.equal(inferRenderFormatFromPath('/tmp/demo#preview.webm?download=1'), 'mp4')
 })


### PR DESCRIPTION
## Summary
- Add coverage for output paths where a query-like suffix contains a supported extension after `?`.
- Confirms render format inference keeps falling back to `mp4` for suffix-only extensions.

## Tests
- `pnpm --dir cli run build && node --test cli/dist/renderOptions.test.js`
- `pnpm test`