### PR TITLE
Validate blank create output paths

### DIFF
--- a/cli/src/commands/create.test.ts
+++ b/cli/src/commands/create.test.ts
@@ -154,6 +154,20 @@ test('create command trims padded output paths', async () => {
   }
 })
 
+test('create command rejects blank output paths before reading input', async () => {
+  const stderr = await withProcessExitThrow(async () => {
+    return captureStderr(async () => {
+      await assert.rejects(
+        createCommand()
+          .parseAsync(['   ', '--from', 'missing.json'], { from: 'user' }),
+        { exitCode: 2 },
+      )
+    })
+  })
+
+  assert.equal(stderr, '[create] output path is required\n')
+})
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -63,6 +63,12 @@ export function createCommand(): Command {
       'Path to a JSON file describing the scene. Use "-" to read from stdin.',
     )
     .action(async (output: string, options: CreateCommandOptions) => {
+      const trimmedOutput = output.trim()
+      if (!trimmedOutput) {
+        console.error('[create] output path is required')
+        process.exit(2)
+      }
+
       const source = options.from ?? '-'
       let raw: string
       try {
@@ -110,7 +116,7 @@ export function createCommand(): Command {
       // Make sure the output's parent directory exists. Tools and
       // agents tend to specify deeply-nested paths; we don't want a
       // simple ENOENT to obscure the real error.
-      const outputPath = path.resolve(output.trim())
+      const outputPath = path.resolve(trimmedOutput)
       const outDir = path.dirname(outputPath)
       try {
         fs.mkdirSync(outDir, { recursive: true })


### PR DESCRIPTION
## Summary
- Reject blank `hypermotion create` output paths before reading scene JSON
- Add CLI coverage for the blank-output error path

## Tests
- `pnpm --dir cli test -- cli/src/commands/create.test.ts`
- `pnpm test`