### PR TITLE
docs(cli): clarify platform locator scope

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -118,10 +118,9 @@ Locations checked, in order:
 
 - `$HYPERMOTION_APP_PATH` (env override, if set)
 - macOS: `/Applications/hyper-motion.app/...`, then `~/Applications/...`
-- Windows: `%ProgramFiles%\hyper-motion\hyper-motion.exe`, then
-  `%LOCALAPPDATA%\Programs\hyper-motion\...`
-- Linux: `/opt/hyper-motion/...`, `/usr/bin/hyper-motion`, AppImage in
-  `~/Applications`, then `~/.local/bin/hyper-motion`
+- Windows/Linux: best-effort lookup paths for future or development
+  builds. Public desktop releases are macOS-only today; see AGENTS.md
+  for the current install status.
 
 If the app isn't installed, the CLI exits with a clean message
 pointing you at the download page.

--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -7,10 +7,8 @@
  *
  *   macOS   — Check `/Applications/hyper-motion.app/Contents/MacOS/hyper-motion`
  *             then `~/Applications/...`. Future: query `mdfind`.
- *   Windows — Check expected Program Files and per-user installer locations.
- *   Linux   — Check common binary/AppImage install locations:
- *             `/opt/hyper-motion`, `/usr/bin`, `~/Applications`, and
- *             `~/.local/bin`.
+ *   Windows — Best-effort lookup for future or development builds.
+ *   Linux   — Best-effort lookup for future or development builds.
  *
  * Override path with `HYPERMOTION_APP_PATH` env var if installed somewhere
  * non-standard.


### PR DESCRIPTION
## Summary
- clarify that Windows/Linux locator entries are best-effort for future or development builds
- align the CLI README and locator header with the current macOS-only public desktop release status

## Tests
- pnpm --dir cli test