### PR TITLE
Ensure patched image nodes get defaults

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -754,6 +754,26 @@ test('applyScenePatch fills size defaults for created shape nodes', () => {
   assert.deepEqual(nodes.badge.size, { width: 100, height: 100 })
 })
 
+test('applyScenePatch fills image defaults for created nodes', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const patched = applyScenePatch(bytes, [
+    {
+      op: 'createNode',
+      node: {
+        id: 'thumbnail',
+        kind: 'image',
+        parent: 'root',
+      },
+    },
+  ])
+  const data = inspectScene(patched)
+  const nodes = data.nodes as PlainSceneMap
+
+  assert.deepEqual(nodes.thumbnail.size, { width: 100, height: 100 })
+  assert.equal(nodes.thumbnail.src, '')
+  assert.equal(nodes.thumbnail.fit, 'cover')
+})
+
 test('applyScenePatch fills layout defaults for created frame nodes', () => {
   const bytes = buildSceneBytes(sampleScene())
   const patched = applyScenePatch(bytes, [

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -1209,6 +1209,14 @@ function nodeToYMap(node: NodeJson): Y.Map<unknown> {
     handledKeys.add('size')
     y.set('size', mergeWithDefaults(DEFAULT_SIZE, node.size))
   }
+  if (node.kind === 'image') {
+    handledKeys.add('src')
+    handledKeys.add('fit')
+    handledKeys.add('importWarning')
+    y.set('src', node.src ?? '')
+    y.set('fit', node.fit ?? 'cover')
+    if (node.importWarning !== undefined) y.set('importWarning', node.importWarning)
+  }
   if (node.kind === 'frame' || node.kind === 'component') {
     for (const key of [
       'size',


### PR DESCRIPTION
## Summary
- apply image node src/fit defaults when patch_scene creates image nodes
- add focused CLI scene builder coverage for patch-created image defaults

## Verification
- pnpm --dir cli test

Note: pnpm typecheck currently fails on unrelated app TypeScript errors outside this CLI change.