### PR TITLE
test(cli): cover JSON keyframe values

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -857,6 +857,33 @@ test('buildSceneBytes defaults omitted track easing to ease-in-out', () => {
   assert.equal(tracks['fade-title'].defaultEasing, 'ease-in-out')
 })
 
+test('buildSceneBytes accepts JSON-compatible keyframe values', () => {
+  const scene = {
+    ...sampleScene(),
+    tracks: {
+      'toggle-visible': {
+        id: 'toggle-visible',
+        nodeId: 'title',
+        propertyId: 'appearance.opacity',
+        keyframes: [
+          { id: 'k1', time: 0, value: false },
+          { id: 'k2', time: 1, value: ['visible', true] },
+        ],
+      },
+    },
+  } satisfies SceneJson
+
+  const bytes = buildSceneBytes(scene)
+  const result = validateScene(bytes)
+  const data = inspectScene(bytes)
+  const tracks = data.tracks as PlainSceneMap
+  const keyframes = tracks['toggle-visible']?.keyframes as PlainSceneObject[]
+
+  assert.equal(result.ok, true)
+  assert.equal(keyframes[0]?.value, false)
+  assert.deepEqual(keyframes[1]?.value, ['visible', true])
+})
+
 test('validateScene accepts a valid authored scene', () => {
   const result = validateScene(buildSceneBytes(sampleScene()))
 

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -440,14 +440,6 @@ export interface KeyframeJson {
   presetOrigin?: 'in' | 'out'
 }
 
-export type KeyframeValueJson =
-  | number
-  | string
-  | null
-  | JsonObject
-  | 'row'
-  | 'column'
-
 export type JsonValue =
   | string
   | number
@@ -459,6 +451,8 @@ export type JsonValue =
 export interface JsonObject {
   [key: string]: JsonValue
 }
+
+export type KeyframeValueJson = JsonValue
 
 type DeepPartial<T> = {
   [K in keyof T]?: T[K] extends unknown[]


### PR DESCRIPTION
## Summary
- align KeyframeValueJson with JSON-compatible runtime validation
- add scene-builder coverage for boolean and array keyframe values

## Tests
- pnpm test