### PR TITLE
Keep open_scene test temp files out of repo

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -181,7 +181,7 @@ test('open_scene trims padded scene paths before opening', async () => {
 })
 
 test('open_scene resolves relative scene paths before opening', async () => {
-  const dir = fs.mkdtempSync(path.join(process.cwd(), 'hypermotion-open-relative-'))
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-relative-'))
   const scenePath = path.join(dir, 'scene.hype')
   const relativeScenePath = path.relative(process.cwd(), scenePath)
   const openedPaths: string[] = []


### PR DESCRIPTION
## Summary\n- Move the MCP open_scene relative-path test scratch directory from the repository cwd to the OS temp directory.\n- Keeps the relative path coverage while avoiding untracked repository folders if a test run is interrupted.\n\n## Tests\n- pnpm --dir cli run build && node --test cli/dist/mcp/openScene.test.js\n- pnpm test