### PR TITLE
test(cli): cover validate_scene stat failures

### DIFF
--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -63,6 +63,34 @@ test('validate_scene rejects directory inputs as MCP errors', async () => {
   }
 })
 
+test('validate_scene reports stat failures as read errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-stat-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const previousStatSync = fs.statSync
+
+  try {
+    Object.defineProperty(fs, 'statSync', {
+      configurable: true,
+      value: ((statPath: fs.PathLike) => {
+        if (statPath === scenePath) throw new Error('stat failed')
+        return previousStatSync(statPath)
+      }) as typeof fs.statSync,
+    })
+
+    const result = await handleValidateScene({ scene: scenePath })
+
+    assert.equal(result.isError, true)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    assert.equal(text, `validate_scene: failed to read ${scenePath}: stat failed`)
+  } finally {
+    Object.defineProperty(fs, 'statSync', {
+      configurable: true,
+      value: previousStatSync,
+    })
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('validate_scene reports read failures after stat succeeds', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-read-'))
   const scenePath = path.join(dir, 'scene.hype')


### PR DESCRIPTION
## Summary\n- add MCP validate_scene coverage for statSync failures\n- verify the tool returns the existing read-error message for that path\n\n## Tests\n- pnpm --dir cli test