### PR TITLE
Clarify unreleased platform locator paths

### DIFF
--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -7,8 +7,8 @@
  *
  *   macOS   — Check `/Applications/hyper-motion.app/Contents/MacOS/hyper-motion`
  *             then `~/Applications/...`. Future: query `mdfind`.
- *   Windows — Best-effort lookup for future or development builds.
- *   Linux   — Best-effort lookup for future or development builds.
+ *   Windows — Best-effort lookup for development builds; no public release yet.
+ *   Linux   — Best-effort lookup for development builds; no public release yet.
  *
  * Override path with `HYPERMOTION_APP_PATH` env var if installed somewhere
  * non-standard.


### PR DESCRIPTION
## Summary\n- Clarify that Windows/Linux desktop locator paths are for development builds because public releases are not available yet.\n\n## Verification\n- pnpm --dir cli test\n- pnpm --dir cli run build