### PR TITLE
Trim create command source paths

### DIFF
--- a/cli/src/commands/create.test.ts
+++ b/cli/src/commands/create.test.ts
@@ -154,6 +154,47 @@ test('create command trims padded output paths', async () => {
   }
 })
 
+test('create command trims padded JSON source paths', async () => {
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'hypermotion-create-trimmed-source-'),
+  )
+  const sourcePath = path.join(dir, 'scene.json')
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    fs.writeFileSync(
+      sourcePath,
+      JSON.stringify({
+        meta: {
+          name: 'Trimmed Source',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    await captureStdout(async () => {
+      await createCommand()
+        .exitOverride()
+        .parseAsync([scenePath, '--from', ` ${sourcePath} `], { from: 'user' })
+    })
+
+    const summary = readSceneSummary(fs.readFileSync(scenePath))
+
+    assert.equal(summary.meta.name, 'Trimmed Source')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('create command rejects blank output paths before reading input', async () => {
   const stderr = await withProcessExitThrow(async () => {
     return captureStderr(async () => {

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -69,7 +69,7 @@ export function createCommand(): Command {
         process.exit(2)
       }
 
-      const source = options.from ?? '-'
+      const source = options.from?.trim() || '-'
       let raw: string
       try {
         raw = source === '-' ? await readStdin() : fs.readFileSync(source, 'utf-8')


### PR DESCRIPTION
## Summary
- Trim padded --from values in the create command before reading JSON scene files
- Add a regression test for padded JSON source paths

## Tests
- pnpm test