### PR TITLE
test(cli): lock query scene required schemas

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -32,7 +32,9 @@ test('query scene MCP tool schemas describe their path and node id inputs', () =
   }
 
   assert.deepEqual(getLayerTool.inputSchema.required, ['scene', 'nodeId'])
+  assert.deepEqual(listLayersTool.inputSchema.required, ['scene'])
   assert.deepEqual(listTracksTool.inputSchema.required, ['scene'])
+  assert.deepEqual(listCamerasTool.inputSchema.required, ['scene'])
 
   const getNodeIdProperty = getLayerTool.inputSchema.properties?.nodeId as
     | Record<string, unknown>


### PR DESCRIPTION
## Summary
- assert list_layers and list_cameras keep scene as their required MCP schema input
- keep query-scene schema coverage aligned across all query tools

## Verification
- pnpm --dir cli run build && node --test cli/dist/mcp/queryScene.test.js
- pnpm --dir cli test