### PR TITLE
chore(cli): type MCP tool names

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -7,6 +7,7 @@ import {
   handleGetCapabilities,
   handleListKeyframeableProperties,
   MCP_TOOLS,
+  type McpToolName,
 } from './tools/capabilities.js'
 import { TOOLS } from './server.js'
 import {
@@ -28,7 +29,7 @@ import { assertToolText } from '../testUtils/mcp.js'
 type GetCapabilitiesToolPayload = {
   keyframeableProperties: readonly PropertyIdJson[]
   sceneExtension: string
-  mcpTools: typeof MCP_TOOLS
+  mcpTools: readonly McpToolName[]
   validation: {
     structuralSceneValidation: boolean
   }
@@ -148,7 +149,7 @@ function parseCapabilitiesJson(result: CallToolResult): GetCapabilitiesToolPaylo
   return {
     keyframeableProperties,
     sceneExtension,
-    mcpTools: requiredStringArray(parsedObject, 'mcpTools') as typeof MCP_TOOLS,
+    mcpTools: requiredStringArray(parsedObject, 'mcpTools') as readonly McpToolName[],
     validation,
     nodeKinds,
     patchOperations: requiredStringArray(parsedObject, 'patchOperations') as readonly PatchOperation['op'][],

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -32,7 +32,7 @@ const QUERY_TOOLS = [
 
 type CapabilitiesPayload = {
   sceneExtension: '.hype'
-  mcpTools: typeof MCP_TOOLS
+  mcpTools: readonly McpToolName[]
   nodeKinds: typeof NODE_KINDS
   patchOperations: typeof PATCH_OPERATION_TYPES
   validation: {


### PR DESCRIPTION
## Summary\n- Export a literal MCP tool-name union from the capabilities metadata\n- Use the narrower tool-name type in the capabilities payload and parser test\n\n## Tests\n- pnpm --dir cli run build && node --test cli/dist/mcp/capabilities.test.js\n- pnpm --dir cli test