### PR TITLE
chore(cli): mark render scene paths non-empty

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -12,6 +12,7 @@ import { handleRenderScene, renderSceneTool } from './tools/renderScene.js'
 type JsonSchemaProperty = {
   type?: string
   enum?: string[]
+  minLength?: number
   minimum?: number
   maximum?: number
   description?: string
@@ -30,6 +31,7 @@ test('render_scene input schema documents relative output paths', () => {
   const outputProperty = schemaProperty('output')
 
   assert.equal(outputProperty?.type, 'string')
+  assert.equal(outputProperty?.minLength, 1)
   assert.match(String(outputProperty?.description), /relative output file path/)
 })
 
@@ -45,6 +47,7 @@ test('render_scene input schema exposes the optional scene path', () => {
   const sceneProperty = schemaProperty('scene')
 
   assert.equal(sceneProperty?.type, 'string')
+  assert.equal(sceneProperty?.minLength, 1)
   assert.match(String(sceneProperty?.description), /\.hype scene file/)
 })
 

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -73,6 +73,7 @@ export const renderSceneTool: Tool = {
     properties: {
       output: {
         type: 'string',
+        minLength: 1,
         description: 'Absolute or relative output file path.',
       },
       format: {
@@ -93,6 +94,7 @@ export const renderSceneTool: Tool = {
       },
       scene: {
         type: 'string',
+        minLength: 1,
         description:
           'Path to a .hype scene file to render instead of the current desktop scene.',
       },


### PR DESCRIPTION
## Summary
- Add minLength metadata for render_scene output and scene string inputs
- Extend the MCP schema test to assert those non-empty path hints

## Tests
- pnpm --dir cli run build && node --test cli/dist/mcp/renderScene.test.js
- pnpm --dir cli test