### PR TITLE
test(cli): stabilize serialized test run

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "prepublishOnly": "pnpm run build",
-    "test": "pnpm run build && node --test dist/**/*.test.js"
+    "test": "pnpm run build && node --test --test-concurrency=1 dist/**/*.test.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",

--- a/cli/src/mcp/inspectScene.test.ts
+++ b/cli/src/mcp/inspectScene.test.ts
@@ -34,10 +34,17 @@ test('inspect_scene rejects blank scene paths as MCP errors', async () => {
 })
 
 test('inspect_scene reports missing files as MCP errors', async () => {
-  const result = await handleInspectScene({ scene: '/tmp/hypermotion-missing-inspect-scene.hype' })
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-missing-'))
+  const scenePath = path.join(dir, 'missing.hype')
 
-  assert.equal(result.isError, true)
-  assert.match(assertToolText(result), /^inspect_scene: failed to read /)
+  try {
+    const result = await handleInspectScene({ scene: scenePath })
+
+    assert.equal(result.isError, true)
+    assert.match(assertToolText(result), /^inspect_scene: failed to read /)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test('inspect_scene rejects directory inputs as MCP errors', async () => {


### PR DESCRIPTION
## Summary
- run CLI node test files serially to avoid cross-file process-global interference
- isolate the inspect_scene missing-file test under its own temp directory

## Verification
- pnpm test