### PR TITLE
Trim patch command output paths

### DIFF
--- a/cli/src/commands/patch.test.ts
+++ b/cli/src/commands/patch.test.ts
@@ -142,6 +142,50 @@ test('patch command trims padded scene paths before reading', async () => {
   }
 })
 
+test('patch command trims padded output paths before writing', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-patch-trimmed-output-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const patchPath = path.join(dir, 'patch.json')
+  const outputPath = path.join(dir, 'patched.hype')
+
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Before',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+    fs.writeFileSync(
+      patchPath,
+      JSON.stringify({ ops: [{ op: 'setMeta', patch: { name: 'Trimmed output' } }] }),
+    )
+
+    await patchCommand()
+      .exitOverride()
+      .parseAsync([scenePath, '--from', patchPath, '--output', `  ${outputPath}\n`], {
+        from: 'user',
+      })
+
+    assert.equal(readSceneSummary(fs.readFileSync(scenePath)).meta.name, 'Before')
+    assert.equal(readSceneSummary(fs.readFileSync(outputPath)).meta.name, 'Trimmed output')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('patch command rejects blank scene paths before reading patch JSON', async () => {
   const stderr = await withProcessExitThrow(() => captureStderr(() => {
     return assert.rejects(

--- a/cli/src/commands/patch.ts
+++ b/cli/src/commands/patch.ts
@@ -24,7 +24,8 @@ export function patchCommand(): Command {
       }
 
       const resolvedScenePath = path.resolve(trimmedScenePath)
-      const output = path.resolve(options.output ?? trimmedScenePath)
+      const trimmedOutputPath = options.output?.trim()
+      const output = path.resolve(trimmedOutputPath || trimmedScenePath)
       let sceneBytes: Buffer
       let stats: fs.Stats
       try {


### PR DESCRIPTION
## Summary
- trim padded `patch --output` values before resolving them
- add CLI regression coverage for padded patch output paths

## Verification
- `pnpm --dir cli test -- cli/src/commands/patch.test.ts` (365 tests passed)
- `pnpm typecheck` (fails on existing app-wide TypeScript errors unrelated to this CLI change)