### PR TITLE
Document query node id schema bounds

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -38,12 +38,14 @@ test('query scene MCP tool schemas describe their path and node id inputs', () =
     | Record<string, unknown>
     | undefined
   assert.equal(getNodeIdProperty?.type, 'string')
+  assert.equal(getNodeIdProperty?.minLength, 1)
   assert.equal(getNodeIdProperty?.description, 'Stable layer/node id to return.')
 
   const filterNodeIdProperty = listTracksTool.inputSchema.properties?.nodeId as
     | Record<string, unknown>
     | undefined
   assert.equal(filterNodeIdProperty?.type, 'string')
+  assert.equal(filterNodeIdProperty?.minLength, 1)
   assert.equal(filterNodeIdProperty?.description, 'Optional stable layer/node id to filter by.')
 })
 

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -53,7 +53,7 @@ export const getLayerTool: Tool = {
     type: 'object',
     properties: {
       scene: SCENE_PATH_PROPERTY,
-      nodeId: { type: 'string', description: 'Stable layer/node id to return.' },
+      nodeId: { type: 'string', minLength: 1, description: 'Stable layer/node id to return.' },
     },
     required: ['scene', 'nodeId'],
   },
@@ -66,7 +66,11 @@ export const listTracksTool: Tool = {
     type: 'object',
     properties: {
       scene: SCENE_PATH_PROPERTY,
-      nodeId: { type: 'string', description: 'Optional stable layer/node id to filter by.' },
+      nodeId: {
+        type: 'string',
+        minLength: 1,
+        description: 'Optional stable layer/node id to filter by.',
+      },
     },
     required: ['scene'],
   },


### PR DESCRIPTION
## Summary
- Add minLength metadata to query-scene MCP nodeId schema fields
- Assert the schema bounds in query scene MCP tests

## Tests
- pnpm --dir cli test