### PR TITLE
chore(cli): tighten render scene path schema

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -13,6 +13,7 @@ type JsonSchemaProperty = {
   type?: string
   enum?: string[]
   minLength?: number
+  pattern?: string
   minimum?: number
   maximum?: number
   description?: string
@@ -32,6 +33,7 @@ test('render_scene input schema documents relative output paths', () => {
 
   assert.equal(outputProperty?.type, 'string')
   assert.equal(outputProperty?.minLength, 1)
+  assert.equal(outputProperty?.pattern, '\\S')
   assert.match(String(outputProperty?.description), /relative output file path/)
 })
 
@@ -48,6 +50,7 @@ test('render_scene input schema exposes the optional scene path', () => {
 
   assert.equal(sceneProperty?.type, 'string')
   assert.equal(sceneProperty?.minLength, 1)
+  assert.equal(sceneProperty?.pattern, '\\S')
   assert.match(String(sceneProperty?.description), /\.hype scene file/)
 })
 

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -74,6 +74,7 @@ export const renderSceneTool: Tool = {
       output: {
         type: 'string',
         minLength: 1,
+        pattern: '\\S',
         description: 'Absolute or relative output file path.',
       },
       format: {
@@ -95,6 +96,7 @@ export const renderSceneTool: Tool = {
       scene: {
         type: 'string',
         minLength: 1,
+        pattern: '\\S',
         description:
           'Path to a .hype scene file to render instead of the current desktop scene.',
       },


### PR DESCRIPTION
## Summary
- add non-whitespace JSON schema patterns for render_scene output and scene paths
- assert the MCP schema matches the existing trim-based runtime validation

## Tests
- pnpm --dir cli run build && node --test cli/dist/mcp/renderScene.test.js
- pnpm --dir cli test