### PR TITLE
chore(cli): declare query scene path schema length

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -26,6 +26,7 @@ test('query scene MCP tool schemas describe their path and node id inputs', () =
       | undefined
 
     assert.equal(sceneProperty?.type, 'string')
+    assert.equal(sceneProperty?.minLength, 1)
     assert.equal(sceneProperty?.description, 'Path to a .hype scene file.')
     assert.ok(Array.isArray(tool.inputSchema.required))
     assert.ok(tool.inputSchema.required.includes('scene'))

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -15,6 +15,7 @@ type TrackInputData = z.infer<typeof TrackInput>
 type QuerySceneToolName = 'list_layers' | 'get_layer' | 'list_tracks' | 'list_cameras'
 type StringSchemaProperty = {
   readonly type: 'string'
+  readonly minLength?: number
   readonly description: string
 }
 type QuerySceneSnapshot = {
@@ -37,6 +38,7 @@ type LayerSummary = {
 
 const SCENE_PATH_PROPERTY: StringSchemaProperty = {
   type: 'string',
+  minLength: 1,
   description: 'Path to a .hype scene file.',
 }
 


### PR DESCRIPTION
## Summary
- declare `minLength: 1` on query scene MCP `scene` path schema metadata
- assert the schema bound in the query scene MCP tests

## Verification
- `PATH="/Users/siddharthponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm test`