### PR TITLE
Tighten export progress stub typing

### DIFF
--- a/src/ui/ExportProgressModal.tsx
+++ b/src/ui/ExportProgressModal.tsx
@@ -5,9 +5,9 @@
  * `ExportStatusPill` in the TopBar — see `./ExportStatusPill.tsx`.
  *
  * This module is kept as an empty stub so any stale imports during
- * the transition compile clean. Safe to delete once the worktree
+ * the transition compile clean. Safe to delete once the source tree
  * is confirmed free of `ExportProgressModal` references.
  */
-export function ExportProgressModal() {
+export function ExportProgressModal(): null {
   return null
 }


### PR DESCRIPTION
## Summary
- Clarify the deprecated `ExportProgressModal` stub comment to refer to the source tree.
- Add an explicit `null` return type to the placeholder component.

## Verification
- `PATH="/Users/siddharthponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm exec eslint src/ui/ExportProgressModal.tsx` passed.
- `pnpm typecheck` initially could not find `node` on PATH in the automation shell; rerun with the bundled Node runtime reached existing unrelated TypeScript errors elsewhere in the app.
- `pnpm lint` reached existing unrelated lint errors elsewhere in the app; the touched file passes focused ESLint.