### PR TITLE
chore(cli): declare info scene path schema length

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -13,7 +13,7 @@ test('info_scene input schema exposes required scene path', () => {
   assert.deepEqual(infoSceneTool.inputSchema, {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to a .hype scene file.' },
+      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
     },
     required: ['scene'],
   })

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -26,7 +26,7 @@ export const infoSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to a .hype scene file.' },
+      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
     },
     required: ['scene'],
   },


### PR DESCRIPTION
## Summary
- add minLength metadata to the info_scene MCP scene path JSON schema
- update the schema assertion in the info_scene MCP test

## Tests
- PATH="/Users/siddharthponnapalli/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm --dir cli run build
- PATH="/Users/siddharthponnapalli/.nvm/versions/node/v24.14.0/bin:$PATH" node --test --test-concurrency=1 cli/dist/mcp/infoScene.test.js