### PR TITLE
chore(cli): declare validate scene path schema length

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -16,7 +16,7 @@ export const validateSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to a .hype scene file.' },
+      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
     },
     required: ['scene'],
   },

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -12,7 +12,7 @@ test('validate_scene input schema exposes required scene path', () => {
   assert.deepEqual(validateSceneTool.inputSchema, {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to a .hype scene file.' },
+      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
     },
     required: ['scene'],
   })


### PR DESCRIPTION
## Summary
- add `minLength: 1` to the `validate_scene` MCP scene path schema
- update the schema assertion to match the runtime blank-path rejection

## Tests
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm --dir cli test`