### PR TITLE
Reject blank render scene paths

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -179,6 +179,23 @@ test('render command trims padded scene paths', async () => {
   }
 })
 
+test('render command rejects empty explicit scene paths before launching the app', async () => {
+  const stderr = await captureStderr(() => {
+    return withProcessExitThrow(async () => {
+      await assert.rejects(
+        renderCommand({
+          locateApp: async () => {
+            throw new Error('should not locate app')
+          },
+        }).parseAsync(['-o', 'out.mp4', '--scene', '   '], { from: 'user' }),
+        { exitCode: 2 },
+      )
+    })
+  })
+
+  assert.equal(stderr, '[render] scene path is required\n')
+})
+
 test('render command trims padded output paths', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-trimmed-output-'))
   const outputPath = path.join(dir, 'out.mp4')

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -141,6 +141,10 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
       }
 
       const sceneInput = opts.scene?.trim()
+      if (opts.scene !== undefined && !sceneInput) {
+        console.error('[render] scene path is required')
+        process.exit(2)
+      }
       const scenePath = sceneInput ? path.resolve(sceneInput) : undefined
       if (scenePath && !existsSync(scenePath)) {
         console.error(`[render] scene file not found: ${scenePath}`)


### PR DESCRIPTION
## Summary
- Reject an explicitly blank `--scene` value in `hypermotion render` instead of silently rendering the current desktop scene.
- Add CLI coverage for the validation path before app launch.

## Verification
- `PATH="/Users/siddharthponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm --dir cli test` (passes, 369 tests)

## Notes
- Broader `pnpm typecheck` and `pnpm lint` currently fail on pre-existing app-wide TypeScript/React lint issues outside this CLI change.
