### PR TITLE
chore(cli): declare inspect scene path schema length

### DIFF
--- a/cli/src/mcp/inspectScene.test.ts
+++ b/cli/src/mcp/inspectScene.test.ts
@@ -13,7 +13,7 @@ test('inspect_scene input schema exposes required scene path', () => {
   assert.deepEqual(inspectSceneTool.inputSchema, {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to a .hype scene file.' },
+      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
     },
     required: ['scene'],
   })

--- a/cli/src/mcp/tools/inspectScene.ts
+++ b/cli/src/mcp/tools/inspectScene.ts
@@ -17,7 +17,7 @@ export const inspectSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to a .hype scene file.' },
+      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
     },
     required: ['scene'],
   },


### PR DESCRIPTION
## Summary
- add minLength metadata to the inspect_scene MCP scene path schema
- update the schema assertion to keep the MCP tool contract covered

## Tests
- pnpm --dir cli test -- --test-name-pattern=inspect_scene