### PR TITLE
Tighten process exit test helper type

### DIFF
--- a/cli/src/testUtils/processExit.ts
+++ b/cli/src/testUtils/processExit.ts
@@ -2,9 +2,10 @@
 
 type ProcessExitCallback<T> = () => Promise<T> | T
 type ProcessExitCode = Parameters<typeof process.exit>[0]
+type NormalizedProcessExitCode = NonNullable<ProcessExitCode>
 
 export interface ProcessExitError extends Error {
-  exitCode: ProcessExitCode
+  exitCode: NormalizedProcessExitCode
 }
 
 export async function withProcessExitThrow<T>(


### PR DESCRIPTION
## Summary
- Narrow the CLI test helper's ProcessExitError.exitCode type to match runtime normalization.
- Keep process.exit(null/undefined) represented as the helper's normalized 0 value.

## Verification
- pnpm --dir cli test
- pnpm --dir cli exec tsc --noEmit

## Notes
- pnpm typecheck still fails on existing app-wide TypeScript errors outside this change.