### PR TITLE
chore(cli): declare open scene path schema length

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -12,7 +12,7 @@ test('open_scene input schema exposes required scene path', () => {
   assert.deepEqual(openSceneTool.inputSchema, {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to a .hype scene file.' },
+      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
     },
     required: ['scene'],
   })

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -28,7 +28,7 @@ export const openSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to a .hype scene file.' },
+      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
     },
     required: ['scene'],
   },


### PR DESCRIPTION
## Summary
- declare a non-empty string length in the open_scene MCP input schema
- update the existing schema assertion to match

## Verification
- pnpm --dir cli test