### PR TITLE
chore(cli): align info scene path validation

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -32,6 +32,13 @@ test('info_scene reports invalid arguments as MCP errors', async () => {
   assert.match(assertToolText(result), /^info_scene: invalid arguments/)
 })
 
+test('info_scene rejects blank schema scene paths as MCP errors', async () => {
+  const result = await handleInfoScene({ scene: '' })
+
+  assert.equal(result.isError, true)
+  assert.match(assertToolText(result), /^info_scene: invalid arguments/)
+})
+
 test('info_scene rejects empty scene paths as MCP errors', async () => {
   const result = await handleInfoScene({ scene: '   ' })
 

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -13,7 +13,7 @@ import fs from 'node:fs'
 import { readSceneSummary, type SceneSummary } from '../../scene/build.js'
 
 const InfoInput = z.object({
-  scene: z.string().describe('Path to a .hype scene file.'),
+  scene: z.string().min(1).describe('Path to a .hype scene file.'),
 })
 type InfoInputData = z.infer<typeof InfoInput>
 


### PR DESCRIPTION
## Summary
- align the info_scene Zod input parser with its advertised non-empty path schema
- add focused MCP coverage for empty scene path arguments

## Tests
- pnpm --dir cli test -- infoScene