### PR TITLE
chore(cli): declare patch scene path schema length

### DIFF
--- a/cli/src/mcp/patchScene.test.ts
+++ b/cli/src/mcp/patchScene.test.ts
@@ -12,7 +12,7 @@ test('patch_scene input schema exposes required scene and patch', () => {
   assert.deepEqual(patchSceneTool.inputSchema, {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to the input .hype scene file.' },
+      scene: { type: 'string', minLength: 1, description: 'Path to the input .hype scene file.' },
       output: { type: 'string', description: 'Path to write. Defaults to overwriting scene.' },
       patch: { description: 'Patch as { ops: [...] }, an operation array, or a JSON string.' },
       applyLive: {

--- a/cli/src/mcp/tools/patchScene.ts
+++ b/cli/src/mcp/tools/patchScene.ts
@@ -22,7 +22,7 @@ export const patchSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: { type: 'string', description: 'Path to the input .hype scene file.' },
+      scene: { type: 'string', minLength: 1, description: 'Path to the input .hype scene file.' },
       output: { type: 'string', description: 'Path to write. Defaults to overwriting scene.' },
       patch: { description: 'Patch as { ops: [...] }, an operation array, or a JSON string.' },
       applyLive: {


### PR DESCRIPTION
## Summary
- add minLength metadata to the patch_scene MCP scene path schema
- update the schema assertion for patch_scene

## Verification
- pnpm --dir cli test

Note: pnpm typecheck still fails on existing app TypeScript errors outside this CLI schema change.