### PR TITLE
chore(cli): reject blank patch scene paths

### DIFF
--- a/cli/src/mcp/patchScene.test.ts
+++ b/cli/src/mcp/patchScene.test.ts
@@ -32,6 +32,15 @@ test('patch_scene reports invalid arguments as MCP errors', async () => {
   assert.match(text, /^patch_scene: invalid arguments/)
 })
 
+test('patch_scene rejects blank scene paths as MCP errors', async () => {
+  const result = await handlePatchScene({ scene: '   ', patch: [] })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.match(text, /^patch_scene: invalid arguments/)
+  assert.match(text, /scene path is required/)
+})
+
 test('patch_scene reports malformed JSON patches as MCP errors', async () => {
   const result = await handlePatchScene({ scene: 'scene.hype', patch: '{bad json' })
 

--- a/cli/src/mcp/tools/patchScene.ts
+++ b/cli/src/mcp/tools/patchScene.ts
@@ -8,7 +8,7 @@ import { applyScenePatch, type PatchOperation, type ScenePatch } from '../../sce
 import { pushSceneToRunningApp } from '../../electron/live.js'
 
 const PatchInput = z.object({
-  scene: z.string().describe('Path to the input .hype scene file.'),
+  scene: z.string().trim().min(1, 'scene path is required').describe('Path to the input .hype scene file.'),
   output: z.string().optional().describe('Path to write. Defaults to overwriting scene.'),
   patch: z.union([z.string(), z.record(z.unknown()), z.array(z.record(z.unknown()))]),
   applyLive: z.boolean().optional().describe('Push the patched scene into the running desktop app. Defaults to true.'),


### PR DESCRIPTION
## Summary\n- Trim and reject blank patch_scene input paths before file I/O\n- Add MCP regression coverage for blank scene paths\n\n## Tests\n- pnpm test\n\nAutomation: hypermotion-maintainer