### PR TITLE
Add layer text animation target to CLI schema

### DIFF
--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -79,7 +79,7 @@ export const createSceneTool: Tool = {
     "Instances point at componentId and carry selection, overrides, and instance-local interaction additions. " +
     "Component timelines are local tracks triggered by interactions, e.g. onClick -> playTimeline, and are scoped per instance.\n" +
     "Tracks: { id, nodeId, propertyId, keyframes?: [{ id, time, value, easingOut? }], defaultEasing?, textAnimation? } — omitted keyframes default to [].\n" +
-    "Text animation tracks can include textAnimation with mode, applyTo, order, delay, smoothing, duration, startTime, acceleration, easingPresetId, easingStrength, direction, travelDistance, and blurRadius.\n" +
+    "Text animation tracks can include textAnimation with mode, applyTo ('layer'|'letters'|'words'|'lines'), order, delay, smoothing, duration, startTime, acceleration, easingPresetId, easingStrength, direction, travelDistance, and blurRadius.\n" +
     "Camera nodes can include focalLength, fieldOfView, pointOfInterestX/Y/Z, nearClip, farClip, " +
     "depthOfField, focusMode, focusWorldX/Y/Z, focusTargetNodeId, focusDistance, focusRadius, focusFalloff, aperture, iso, blurLevel, " +
     "blurQuality, and showFocusPlane. Hyper Motion currently supports only one camera node per scene; " +

--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -163,6 +163,35 @@ test('buildSceneBytes accepts soft text animation smoothing', () => {
   assert.equal(textAnimation.smoothing, 'soft')
 })
 
+test('buildSceneBytes accepts layer-wide text animation targeting', () => {
+  const scene = sampleScene()
+  const track = scene.tracks?.['fade-title']
+  if (!track) throw new Error('missing sample track')
+  track.propertyId = 'text.progress'
+  track.textAnimation = {
+    id: 'layer-fade',
+    mode: 'in',
+    applyTo: 'layer',
+    order: 'forward',
+    delay: 0,
+    smoothing: 'none',
+    duration: 0.4,
+    startTime: 0,
+    acceleration: 'linear',
+    easingPresetId: 'smooth',
+    easingStrength: 50,
+    direction: 'up',
+    travelDistance: 0,
+    blurRadius: 0,
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const tracks = data.tracks as PlainSceneMap
+  const textAnimation = tracks['fade-title']?.textAnimation as PlainSceneObject
+
+  assert.equal(textAnimation.applyTo, 'layer')
+})
+
 test('buildSceneBytes fills default metadata for minimal scenes', () => {
   const bytes = buildSceneBytes({
     nodes: {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -253,7 +253,7 @@ export interface TrackJson {
 export interface TextAnimationJson {
   id: string
   mode: 'in' | 'out'
-  applyTo: 'letters' | 'words' | 'lines'
+  applyTo: 'layer' | 'letters' | 'words' | 'lines'
   order: 'forward' | 'reverse' | 'random'
   delay: number
   smoothing: 'none' | 'soft' | 'smooth'


### PR DESCRIPTION
## Summary
- Add the app-supported `layer` text animation target to the CLI SceneJson type.
- Document the accepted `textAnimation.applyTo` values in the `create_scene` MCP tool description.
- Cover layer-wide text animation targeting in the CLI scene builder tests.

## Tests
- `pnpm --dir cli test`