### PR TITLE
chore(cli): align open scene schema validation

### DIFF
--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -7,7 +7,7 @@ import path from 'node:path'
 import { pushSceneToRunningApp } from '../../electron/live.js'
 
 const OpenInput = z.object({
-  scene: z.string().describe('Path to a .hype scene file.'),
+  scene: z.string().min(1).describe('Path to a .hype scene file.'),
 })
 type OpenInputData = z.infer<typeof OpenInput>
 type OpenSceneDeps = {


### PR DESCRIPTION
## Summary
- align the open_scene MCP runtime schema with its advertised non-empty scene path input

## Tests
- pnpm --dir cli test -- openScene