### PR TITLE
fix(cli): reject blank create_scene output paths

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -235,6 +235,17 @@ test('create_scene rejects relative output paths', async () => {
   assert.equal(text, 'create_scene: output must be an absolute path.')
 })
 
+test('create_scene rejects blank output paths', async () => {
+  const result = await handleCreateScene({
+    output: '   ',
+    scene: { nodes: {} },
+  })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.equal(text, 'create_scene: output path is required')
+})
+
 test('create_scene validates output paths before building scene bytes', async () => {
   const result = await handleCreateScene({
     output: 'relative-scene.hype',

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -166,6 +166,17 @@ export async function handleCreateScene(
   // specify deep paths and we don't want a simple ENOENT to obscure
   // the actual failure.
   const outputPath = input.output.trim()
+  if (!outputPath) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: 'create_scene: output path is required',
+        },
+      ],
+    }
+  }
   if (!path.isAbsolute(outputPath)) {
     return {
       isError: true,


### PR DESCRIPTION
## Summary
- return a clear MCP error when create_scene receives a whitespace-only output path
- add focused coverage for the blank output path case

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/createScene.test.js
- pnpm --dir cli test