### PR TITLE
chore(cli): mark create scene output non-empty

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -8,6 +8,14 @@ import test from 'node:test'
 import { PROPERTY_IDS, readSceneSummary } from '../scene/build.js'
 import { createSceneTool, handleCreateScene } from './tools/createScene.js'
 
+test('create_scene input schema marks output as non-empty', () => {
+  assert.deepEqual(createSceneTool.inputSchema.properties?.output, {
+    type: 'string',
+    minLength: 1,
+    description: 'Absolute path to write the .hype file to.',
+  })
+})
+
 test('create_scene description lists supported appearance property ids', () => {
   const description = createSceneTool.description
   if (typeof description !== 'string') {

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -93,6 +93,7 @@ export const createSceneTool: Tool = {
     properties: {
       output: {
         type: 'string',
+        minLength: 1,
         description: 'Absolute path to write the .hype file to.',
       },
       scene: {


### PR DESCRIPTION
## Summary
- add minLength metadata to the create_scene MCP output path schema
- cover the schema metadata with a focused unit test

## Tests
- pnpm --dir cli run build && node --test cli/dist/mcp/createScene.test.js
- pnpm test
