### PR TITLE
chore(cli): align scene path MCP schemas

### DIFF
--- a/cli/src/mcp/inspectScene.test.ts
+++ b/cli/src/mcp/inspectScene.test.ts
@@ -26,6 +26,13 @@ test('inspect_scene reports invalid arguments as MCP errors', async () => {
   assert.match(assertToolText(result), /^inspect_scene: invalid arguments/)
 })
 
+test('inspect_scene rejects blank schema scene paths as MCP errors', async () => {
+  const result = await handleInspectScene({ scene: '' })
+
+  assert.equal(result.isError, true)
+  assert.match(assertToolText(result), /^inspect_scene: invalid arguments/)
+})
+
 test('inspect_scene rejects blank scene paths as MCP errors', async () => {
   const result = await handleInspectScene({ scene: '   ' })
 

--- a/cli/src/mcp/tools/inspectScene.ts
+++ b/cli/src/mcp/tools/inspectScene.ts
@@ -7,7 +7,7 @@ import path from 'node:path'
 import { inspectScene } from '../../scene/build.js'
 
 const InspectInput = z.object({
-  scene: z.string().describe('Path to a .hype scene file.'),
+  scene: z.string().min(1).describe('Path to a .hype scene file.'),
 })
 type InspectInputData = z.infer<typeof InspectInput>
 

--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs'
 import { validateScene, type SceneValidationResult } from '../../scene/build.js'
 
 const ValidateInput = z.object({
-  scene: z.string().describe('Path to a .hype scene file.'),
+  scene: z.string().min(1).describe('Path to a .hype scene file.'),
 })
 type ValidateInputData = z.infer<typeof ValidateInput>
 

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -26,6 +26,14 @@ test('validate_scene reports invalid arguments as MCP errors', async () => {
   assert.match(text, /^validate_scene: invalid arguments/)
 })
 
+test('validate_scene rejects blank schema scene paths as MCP errors', async () => {
+  const result = await handleValidateScene({ scene: '' })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.match(text, /^validate_scene: invalid arguments/)
+})
+
 test('validate_scene rejects empty scene paths as MCP errors', async () => {
   const result = await handleValidateScene({ scene: '   ' })
 


### PR DESCRIPTION
## Summary
- enforce non-empty scene path inputs in inspect_scene and validate_scene runtime schemas
- add MCP handler coverage for empty-string scene paths

## Tests
- pnpm --dir cli exec tsc --noEmit
- pnpm --dir cli test