### PR TITLE
chore(cli): reject blank patch scene outputs

### DIFF
--- a/cli/src/mcp/patchScene.test.ts
+++ b/cli/src/mcp/patchScene.test.ts
@@ -12,8 +12,18 @@ test('patch_scene input schema exposes required scene and patch', () => {
   assert.deepEqual(patchSceneTool.inputSchema, {
     type: 'object',
     properties: {
-      scene: { type: 'string', minLength: 1, description: 'Path to the input .hype scene file.' },
-      output: { type: 'string', description: 'Path to write. Defaults to overwriting scene.' },
+      scene: {
+        type: 'string',
+        minLength: 1,
+        pattern: '\\S',
+        description: 'Path to the input .hype scene file.',
+      },
+      output: {
+        type: 'string',
+        minLength: 1,
+        pattern: '\\S',
+        description: 'Path to write. Defaults to overwriting scene.',
+      },
       patch: { description: 'Patch as { ops: [...] }, an operation array, or a JSON string.' },
       applyLive: {
         type: 'boolean',
@@ -39,6 +49,15 @@ test('patch_scene rejects blank scene paths as MCP errors', async () => {
   const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
   assert.match(text, /^patch_scene: invalid arguments/)
   assert.match(text, /scene path is required/)
+})
+
+test('patch_scene rejects blank output paths as MCP errors', async () => {
+  const result = await handlePatchScene({ scene: 'scene.hype', output: '   ', patch: [] })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.match(text, /^patch_scene: invalid arguments/)
+  assert.match(text, /output path is required/)
 })
 
 test('patch_scene reports malformed JSON patches as MCP errors', async () => {
@@ -134,7 +153,7 @@ test('patch_scene writes alternate output without applying live', async () => {
 
     const result = await handlePatchScene({
       scene: scenePath,
-      output: outputPath,
+      output: ` ${outputPath} `,
       applyLive: false,
       patch: {
         ops: [{ op: 'setMeta', patch: { name: 'Patched' } }],

--- a/cli/src/mcp/tools/patchScene.ts
+++ b/cli/src/mcp/tools/patchScene.ts
@@ -9,7 +9,7 @@ import { pushSceneToRunningApp } from '../../electron/live.js'
 
 const PatchInput = z.object({
   scene: z.string().trim().min(1, 'scene path is required').describe('Path to the input .hype scene file.'),
-  output: z.string().optional().describe('Path to write. Defaults to overwriting scene.'),
+  output: z.string().trim().min(1, 'output path is required').optional().describe('Path to write. Defaults to overwriting scene.'),
   patch: z.union([z.string(), z.record(z.unknown()), z.array(z.record(z.unknown()))]),
   applyLive: z.boolean().optional().describe('Push the patched scene into the running desktop app. Defaults to true.'),
 })
@@ -22,8 +22,18 @@ export const patchSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: { type: 'string', minLength: 1, description: 'Path to the input .hype scene file.' },
-      output: { type: 'string', description: 'Path to write. Defaults to overwriting scene.' },
+      scene: {
+        type: 'string',
+        minLength: 1,
+        pattern: '\\S',
+        description: 'Path to the input .hype scene file.',
+      },
+      output: {
+        type: 'string',
+        minLength: 1,
+        pattern: '\\S',
+        description: 'Path to write. Defaults to overwriting scene.',
+      },
       patch: { description: 'Patch as { ops: [...] }, an operation array, or a JSON string.' },
       applyLive: {
         type: 'boolean',


### PR DESCRIPTION
## Summary\n- trim and reject blank explicit `patch_scene.output` values\n- document non-blank `patch_scene` scene/output schema constraints\n- cover blank output rejection and padded output normalization in MCP tests\n\n## Tests\n- `pnpm --dir cli test`