### PR TITLE
chore(cli): validate render success sentinels

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -188,6 +188,44 @@ test('driveHeadlessRender clears stale error sentinels after successful renders'
   }
 })
 
+test('driveHeadlessRender waits for complete success sentinels', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(`${out}.done`, '');",
+      "setTimeout(() => {",
+      "  fs.writeFileSync(out, 'fresh output');",
+      "  fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: 12 }));",
+      '}, 100);',
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await driveHeadlessRender({
+      appPath,
+      outputPath,
+      format: 'mp4',
+      quality: 'comp',
+      fps: 30,
+    })
+
+    assert.equal(fs.readFileSync(outputPath, 'utf-8'), 'fresh output')
+    assert.equal(fs.existsSync(`${outputPath}.done`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('driveHeadlessRender enables Electron logging when verbose mode is set', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
   const appPath = path.join(dir, 'fake-app.mjs')

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -119,7 +119,7 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
     if (errorRef.current) {
       throw new Error(`Failed to spawn desktop app: ${errorRef.current.message}`)
     }
-    if (fs.existsSync(sentinelPath)) {
+    if (hasCompleteSuccessSentinel(sentinelPath)) {
       // Render complete. Remove the sentinel so subsequent runs start clean.
       cleanFile(sentinelPath)
       return
@@ -155,7 +155,7 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
 
   // If the event loop was suspended or starved past the timeout boundary,
   // a final sentinel may have landed after the last in-loop poll.
-  if (fs.existsSync(sentinelPath)) {
+  if (hasCompleteSuccessSentinel(sentinelPath)) {
     cleanFile(sentinelPath)
     return
   }
@@ -177,6 +177,23 @@ function cleanFile(p: string): void {
     fs.rmSync(p, { force: true })
   } catch {
     /* best-effort */
+  }
+}
+
+function hasCompleteSuccessSentinel(sentinelPath: string): boolean {
+  try {
+    const raw = fs.readFileSync(sentinelPath, 'utf-8')
+    const data = JSON.parse(raw)
+    return (
+      typeof data === 'object' &&
+      data !== null &&
+      'bytes' in data &&
+      typeof data.bytes === 'number' &&
+      Number.isFinite(data.bytes) &&
+      data.bytes >= 0
+    )
+  } catch {
+    return false
   }
 }
 


### PR DESCRIPTION
## Summary\n- require render success sentinels to contain complete JSON metadata before treating a render as done\n- add a CLI driver regression test for a premature blank .done file followed by a valid sentinel\n\n## Verification\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js\n- pnpm test\n\nNote: pnpm typecheck still fails on existing app-wide TypeScript errors outside this CLI driver change.