### PR TITLE
chore(cli): trim query scene paths in schemas

### DIFF
--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -5,10 +5,11 @@ import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
 import { inspectScene } from '../../scene/build.js'
 
-const SceneInput = z.object({ scene: z.string() })
+const ScenePathInput = z.string().trim()
+const SceneInput = z.object({ scene: ScenePathInput })
 const NodeIdInput = z.string().trim().min(1, 'nodeId is required')
-const LayerInput = z.object({ scene: z.string(), nodeId: NodeIdInput })
-const TrackInput = z.object({ scene: z.string(), nodeId: NodeIdInput.optional() })
+const LayerInput = z.object({ scene: ScenePathInput, nodeId: NodeIdInput })
+const TrackInput = z.object({ scene: ScenePathInput, nodeId: NodeIdInput.optional() })
 type SceneInputData = z.infer<typeof SceneInput>
 type LayerInputData = z.infer<typeof LayerInput>
 type TrackInputData = z.infer<typeof TrackInput>


### PR DESCRIPTION
## Summary
- share one trimmed scene-path Zod input across query-scene MCP handlers
- keep existing blank-path error behavior intact

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/queryScene.test.js
- pnpm test