### PR TITLE
fix(cli): reject blank create source paths

### DIFF
--- a/cli/src/commands/create.test.ts
+++ b/cli/src/commands/create.test.ts
@@ -209,6 +209,27 @@ test('create command rejects blank output paths before reading input', async () 
   assert.equal(stderr, '[create] output path is required\n')
 })
 
+test('create command rejects blank JSON source paths before reading stdin', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-create-blank-source-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    const stderr = await withProcessExitThrow(async () => {
+      return captureStderr(async () => {
+        await assert.rejects(
+          createCommand()
+            .parseAsync([scenePath, '--from', '   '], { from: 'user' }),
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.equal(stderr, '[create] scene JSON source path is required\n')
+    assert.equal(fs.existsSync(scenePath), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -69,7 +69,13 @@ export function createCommand(): Command {
         process.exit(2)
       }
 
-      const source = options.from?.trim() || '-'
+      const source =
+        options.from === undefined ? '-' : options.from.trim()
+      if (!source) {
+        console.error('[create] scene JSON source path is required')
+        process.exit(2)
+      }
+
       let raw: string
       try {
         raw = source === '-' ? await readStdin() : fs.readFileSync(source, 'utf-8')


### PR DESCRIPTION
## Summary\n- reject whitespace-only `hypermotion create --from` values before reading stdin\n- add regression coverage that no scene file is written for blank source paths\n\n## Tests\n- `pnpm --dir cli test`