### PR TITLE
chore(cli): clarify open scene path schema

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -12,7 +12,11 @@ test('open_scene input schema exposes required scene path', () => {
   assert.deepEqual(openSceneTool.inputSchema, {
     type: 'object',
     properties: {
-      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
+      scene: {
+        type: 'string',
+        minLength: 1,
+        description: 'Absolute or relative path to a .hype scene file.',
+      },
     },
     required: ['scene'],
   })

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -7,7 +7,7 @@ import path from 'node:path'
 import { pushSceneToRunningApp } from '../../electron/live.js'
 
 const OpenInput = z.object({
-  scene: z.string().min(1).describe('Path to a .hype scene file.'),
+  scene: z.string().min(1).describe('Absolute or relative path to a .hype scene file.'),
 })
 type OpenInputData = z.infer<typeof OpenInput>
 type OpenSceneDeps = {
@@ -28,7 +28,11 @@ export const openSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
+      scene: {
+        type: 'string',
+        minLength: 1,
+        description: 'Absolute or relative path to a .hype scene file.',
+      },
     },
     required: ['scene'],
   },


### PR DESCRIPTION
## Summary\n- clarify the open_scene MCP schema copy to say scene paths may be absolute or relative\n- keep the schema assertion in sync with the exported tool metadata\n\n## Verification\n- pnpm --dir cli test -- openScene.test.js\n- pnpm test