### PR TITLE
chore(cli): mark query scene paths nonblank

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -27,6 +27,7 @@ test('query scene MCP tool schemas describe their path and node id inputs', () =
 
     assert.equal(sceneProperty?.type, 'string')
     assert.equal(sceneProperty?.minLength, 1)
+    assert.equal(sceneProperty?.pattern, '\\S')
     assert.equal(sceneProperty?.description, 'Path to a .hype scene file.')
     assert.ok(Array.isArray(tool.inputSchema.required))
     assert.ok(tool.inputSchema.required.includes('scene'))

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -17,6 +17,7 @@ type QuerySceneToolName = 'list_layers' | 'get_layer' | 'list_tracks' | 'list_ca
 type StringSchemaProperty = {
   readonly type: 'string'
   readonly minLength?: number
+  readonly pattern?: string
   readonly description: string
 }
 type QuerySceneSnapshot = {
@@ -40,6 +41,7 @@ type LayerSummary = {
 const SCENE_PATH_PROPERTY: StringSchemaProperty = {
   type: 'string',
   minLength: 1,
+  pattern: '\\S',
   description: 'Path to a .hype scene file.',
 }
 


### PR DESCRIPTION
## Summary
- advertise the nonblank scene-path pattern on query-scene MCP tool schemas
- cover the schema metadata in the existing query-scene MCP test

## Verification
- pnpm --dir cli test -- --test-name-pattern="query scene MCP tool schemas" (runs CLI build and test suite; 380 passed)

Note: root pnpm typecheck currently fails on existing app TypeScript errors outside this CLI-only change.