### PR TITLE
Validate empty create_scene output paths

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -254,6 +254,17 @@ test('create_scene rejects blank output paths', async () => {
   assert.equal(text, 'create_scene: output path is required')
 })
 
+test('create_scene rejects empty output paths at schema validation', async () => {
+  const result = await handleCreateScene({
+    output: '',
+    scene: { nodes: {} },
+  })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.match(text, /^create_scene: invalid arguments/)
+})
+
 test('create_scene validates output paths before building scene bytes', async () => {
   const result = await handleCreateScene({
     output: 'relative-scene.hype',

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -38,6 +38,7 @@ import { pushSceneToRunningApp } from '../../electron/live.js'
 const CreateInput = z.object({
   output: z
     .string()
+    .min(1)
     .describe('Absolute path to write the .hype file to. Parent dirs are created if missing.'),
   scene: z
     .union([


### PR DESCRIPTION
## Summary
- align create_scene runtime validation with its public non-empty output schema
- add MCP coverage for an empty output path

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/createScene.test.js
- pnpm test