### PR TITLE
Handle Windows separators in render format inference

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -41,6 +41,7 @@ test('inferRenderFormatFromPath uses supported file extensions', () => {
 
 test('inferRenderFormatFromPath ignores extensions in parent directories', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/exports.webm/demo'), 'mp4')
+  assert.equal(inferRenderFormatFromPath('C:\\tmp\\exports.webm\\demo'), 'mp4')
 })
 
 test('inferRenderFormatFromPath normalizes extension casing', () => {
@@ -50,6 +51,7 @@ test('inferRenderFormatFromPath normalizes extension casing', () => {
 test('inferRenderFormatFromPath recognizes extension-only output filenames', () => {
   assert.equal(inferRenderFormatFromPath('.gif'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/.WEBM'), 'webm')
+  assert.equal(inferRenderFormatFromPath('C:\\tmp\\.WEBM'), 'webm')
   assert.equal(inferRenderFormatFromPath('.mov'), 'mp4')
 })
 

--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -21,9 +21,10 @@ export function isRenderQuality(value: unknown): value is RenderQuality {
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {
   const cleanPath = (filePath.split(/[?#]/, 1)[0] ?? filePath).trim()
-  const basename = path.basename(cleanPath)
+  const normalizedPath = cleanPath.replace(/\\/g, '/')
+  const basename = path.basename(normalizedPath)
   const ext = (
-    path.extname(cleanPath) || (basename.startsWith('.') ? basename : '')
+    path.extname(normalizedPath) || (basename.startsWith('.') ? basename : '')
   )
     .toLowerCase()
     .slice(1)


### PR DESCRIPTION
## Summary
- normalize backslashes before inferring render output extensions
- add coverage for Windows-style parent directories and hidden extension-only filenames

## Tests
- pnpm --dir cli test
- pnpm test