### PR TITLE
Tighten render option set types

### DIFF
--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -5,18 +5,18 @@ import path from 'node:path'
 export const RENDER_FORMATS = ['mp4', 'webm', 'gif'] as const
 export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
 
-const RENDER_FORMAT_SET: ReadonlySet<string> = new Set(RENDER_FORMATS)
-const RENDER_QUALITY_SET: ReadonlySet<string> = new Set(RENDER_QUALITIES)
-
 export type RenderFormat = (typeof RENDER_FORMATS)[number]
 export type RenderQuality = (typeof RENDER_QUALITIES)[number]
 
+const RENDER_FORMAT_SET: ReadonlySet<RenderFormat> = new Set(RENDER_FORMATS)
+const RENDER_QUALITY_SET: ReadonlySet<RenderQuality> = new Set(RENDER_QUALITIES)
+
 export function isRenderFormat(value: unknown): value is RenderFormat {
-  return typeof value === 'string' && RENDER_FORMAT_SET.has(value)
+  return typeof value === 'string' && RENDER_FORMAT_SET.has(value as RenderFormat)
 }
 
 export function isRenderQuality(value: unknown): value is RenderQuality {
-  return typeof value === 'string' && RENDER_QUALITY_SET.has(value)
+  return typeof value === 'string' && RENDER_QUALITY_SET.has(value as RenderQuality)
 }
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {


### PR DESCRIPTION
## Summary
- Keep render format and quality lookup sets typed to their literal union types.
- Preserve existing guard behavior while making the helper types narrower.

## Tests
- pnpm --dir cli test