### PR TITLE
test(cli): cover capture restore after failed writes

### DIFF
--- a/cli/src/testUtils/stdout.test.ts
+++ b/cli/src/testUtils/stdout.test.ts
@@ -203,6 +203,7 @@ test('captureStdout restores the writer when the callback throws', async () => {
 
   await assert.rejects(
     captureStdout(() => {
+      process.stdout.write('before failure')
       throw new Error('boom')
     }),
     /boom/,
@@ -230,6 +231,7 @@ test('captureStderr restores the writer when the callback throws', async () => {
 
   await assert.rejects(
     captureStderr(() => {
+      process.stderr.write('before failure')
       throw new Error('boom')
     }),
     /boom/,


### PR DESCRIPTION
## Summary\n- add coverage for stdout/stderr capture helpers restoring the original writer after a callback writes and then throws\n\n## Verification\n- pnpm --dir cli test