### PR TITLE
chore(cli): tighten render option guards

### DIFF
--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -8,15 +8,15 @@ export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
 export type RenderFormat = (typeof RENDER_FORMATS)[number]
 export type RenderQuality = (typeof RENDER_QUALITIES)[number]
 
-const RENDER_FORMAT_SET: ReadonlySet<RenderFormat> = new Set(RENDER_FORMATS)
-const RENDER_QUALITY_SET: ReadonlySet<RenderQuality> = new Set(RENDER_QUALITIES)
+const RENDER_FORMAT_SET: ReadonlySet<string> = new Set(RENDER_FORMATS)
+const RENDER_QUALITY_SET: ReadonlySet<string> = new Set(RENDER_QUALITIES)
 
 export function isRenderFormat(value: unknown): value is RenderFormat {
-  return typeof value === 'string' && RENDER_FORMAT_SET.has(value as RenderFormat)
+  return typeof value === 'string' && RENDER_FORMAT_SET.has(value)
 }
 
 export function isRenderQuality(value: unknown): value is RenderQuality {
-  return typeof value === 'string' && RENDER_QUALITY_SET.has(value as RenderQuality)
+  return typeof value === 'string' && RENDER_QUALITY_SET.has(value)
 }
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {


### PR DESCRIPTION
## Summary\n- type render option lookup sets as strings\n- remove guard-time assertions for untrusted render format and quality inputs\n\n## Verification\n- pnpm --dir cli test\n\nNote: root pnpm typecheck currently fails on existing app-wide TypeScript errors outside this CLI helper.