### PR TITLE
Trim validate_scene MCP input paths

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs'
 import { validateScene, type SceneValidationResult } from '../../scene/build.js'
 
 const ValidateInput = z.object({
-  scene: z.string().min(1).describe('Path to a .hype scene file.'),
+  scene: z.string().trim().min(1, 'scene path is required').describe('Path to a .hype scene file.'),
 })
 type ValidateInputData = z.infer<typeof ValidateInput>
 

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -34,12 +34,13 @@ test('validate_scene rejects blank schema scene paths as MCP errors', async () =
   assert.match(text, /^validate_scene: invalid arguments/)
 })
 
-test('validate_scene rejects empty scene paths as MCP errors', async () => {
+test('validate_scene rejects empty scene paths at schema validation', async () => {
   const result = await handleValidateScene({ scene: '   ' })
 
   assert.equal(result.isError, true)
   const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-  assert.equal(text, 'validate_scene: scene path is required')
+  assert.match(text, /^validate_scene: invalid arguments/)
+  assert.match(text, /scene path is required/)
 })
 
 test('validate_scene reports missing files as MCP errors', async () => {


### PR DESCRIPTION
## Summary
- Trim validate_scene MCP scene paths during schema validation
- Keep whitespace-only scene paths on the same invalid-arguments path as other schema failures
- Update the MCP test coverage for whitespace-only scene paths

## Verification
- pnpm --dir cli test
- pnpm --dir cli exec tsc --noEmit

Note: repo-wide pnpm typecheck and pnpm lint currently fail on unrelated pre-existing app issues outside this CLI change.