### PR TITLE
chore(cli): trim JSON render error messages

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -371,6 +371,41 @@ test('driveHeadlessRender surfaces JSON error sentinel messages', async () => {
   }
 })
 
+test('driveHeadlessRender trims JSON error sentinel messages', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(`${out}.error`, JSON.stringify({ message: '  encoder reported JSON failure  ' }));",
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await assert.rejects(
+      driveHeadlessRender({
+        appPath,
+        outputPath,
+        format: 'mp4',
+        quality: 'comp',
+        fps: 30,
+      }),
+      /^Error: encoder reported JSON failure$/,
+    )
+    assert.equal(fs.existsSync(`${outputPath}.error`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('driveHeadlessRender falls back when JSON error sentinels omit messages', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
   const appPath = path.join(dir, 'fake-app.mjs')

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -208,7 +208,7 @@ function readRenderErrorMessage(errorPath: string): string | null {
     if (raw.length === 0) return null
     try {
       const data = JSON.parse(raw)
-      if (hasErrorMessage(data)) message = data.message
+      if (hasErrorMessage(data)) message = data.message.trim()
     } catch {
       const text = raw.trim()
       if (text) message = text


### PR DESCRIPTION
## Summary
- trim JSON render error sentinel messages before surfacing them
- add focused driver coverage for padded JSON error messages

## Tests
- pnpm --dir cli test