### PR TITLE
Clarify render FPS limit test name

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -284,7 +284,7 @@ test('render command reports trimmed invalid fps values', async () => {
   assert.match(stderr, /^\[render\] invalid fps: 30\.5$/m)
 })
 
-test('render command rejects fps values above the MCP limit before launching the app', async () => {
+test('render command rejects fps values above the render limit before launching the app', async () => {
   const stderr = await captureStderr(() => {
     return withProcessExitThrow(async () => {
       await assert.rejects(


### PR DESCRIPTION
## Summary
- Clarify the render command FPS limit test name so it refers to the render limit instead of the MCP limit.

## Verification
- pnpm --dir cli test