### PR TITLE
Wait for complete JSON render error sentinels

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -441,6 +441,44 @@ test('driveHeadlessRender falls back when JSON error sentinels omit messages', a
   }
 })
 
+test('driveHeadlessRender waits for complete JSON error sentinels', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(`${out}.error`, '{');",
+      "setTimeout(() => {",
+      "  fs.writeFileSync(`${out}.error`, JSON.stringify({ message: 'encoder finished error details' }));",
+      '}, 100);',
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await assert.rejects(
+      driveHeadlessRender({
+        appPath,
+        outputPath,
+        format: 'mp4',
+        quality: 'comp',
+        fps: 30,
+      }),
+      /encoder finished error details/,
+    )
+    assert.equal(fs.existsSync(`${outputPath}.error`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('driveHeadlessRender falls back when JSON error sentinel messages are blank', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
   const appPath = path.join(dir, 'fake-app.mjs')

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -210,6 +210,7 @@ function readRenderErrorMessage(errorPath: string): string | null {
       const data = JSON.parse(raw)
       if (hasErrorMessage(data)) message = data.message.trim()
     } catch {
+      if (raw.trimStart().startsWith('{')) return null
       const text = raw.trim()
       if (text) message = text
     }


### PR DESCRIPTION
## Summary
- wait for JSON-looking render error sentinels to become parseable before consuming them
- add a driver regression test for partial JSON error sentinel writes

## Verification
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js
- pnpm test