### PR TITLE
Handle URL markers in render output basename parsing

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -44,6 +44,11 @@ test('inferRenderFormatFromPath ignores extensions in parent directories', () =>
   assert.equal(inferRenderFormatFromPath('C:\\tmp\\exports.webm\\demo'), 'mp4')
 })
 
+test('inferRenderFormatFromPath allows URL markers in parent directories', () => {
+  assert.equal(inferRenderFormatFromPath('/tmp/exports#draft/demo.gif'), 'gif')
+  assert.equal(inferRenderFormatFromPath('/tmp/exports?draft/demo.webm'), 'webm')
+})
+
 test('inferRenderFormatFromPath normalizes extension casing', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.WEBM'), 'webm')
 })

--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -20,11 +20,12 @@ export function isRenderQuality(value: unknown): value is RenderQuality {
 }
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {
-  const cleanPath = (filePath.split(/[?#]/, 1)[0] ?? filePath).trim()
-  const normalizedPath = cleanPath.replace(/\\/g, '/')
+  const normalizedPath = filePath.trim().replace(/\\/g, '/')
   const basename = path.basename(normalizedPath)
+  const cleanBasename = basename.split(/[?#]/, 1)[0] ?? basename
   const ext = (
-    path.extname(normalizedPath) || (basename.startsWith('.') ? basename : '')
+    path.extname(cleanBasename) ||
+    (cleanBasename.startsWith('.') ? cleanBasename : '')
   )
     .toLowerCase()
     .slice(1)


### PR DESCRIPTION
## Summary
- Strip URL-style query/hash markers from the output basename instead of the full path when inferring render format.
- Add regression coverage for parent directories containing `?` or `#`.

## Verification
- `pnpm --dir cli test -- --test-name-pattern='inferRenderFormatFromPath|render option guards'` (builds CLI and passed full CLI suite: 384 tests)
- `pnpm typecheck` (fails on existing app-side TypeScript errors unrelated to this change)