### PR TITLE
Validate scene metadata shape

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1064,6 +1064,17 @@ test('validateScene rejects non-string root ids', () => {
   assert.deepEqual(result.errors, ['scene.root must be a string'])
 })
 
+test('validateScene rejects non-object scene metadata', () => {
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(sampleScene()))
+  doc.getMap<unknown>('scene').set('meta', 'metadata')
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, ['scene.meta must be an object'])
+})
+
 test('validateScene rejects non-object scene collections', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -877,6 +877,9 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
   const root = typeof data.root === 'string' ? data.root : ''
   const activeCameraId = typeof data.activeCameraId === 'string' ? data.activeCameraId : ''
 
+  if (data.meta !== undefined && !isPlainObject(data.meta)) {
+    errors.push('scene.meta must be an object')
+  }
   if (data.nodes !== undefined && !isPlainObject(data.nodes)) {
     errors.push('scene.nodes must be an object')
   }


### PR DESCRIPTION
## Summary
- validate malformed non-object scene metadata in CLI scene validation
- add focused coverage for the new validation error

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/scene/build.test.js
- pnpm test