### PR TITLE
Tighten process exit test helper assertion

### DIFF
--- a/cli/src/testUtils/processExit.test.ts
+++ b/cli/src/testUtils/processExit.test.ts
@@ -125,9 +125,7 @@ function assertProcessExitError(err: unknown): asserts err is ProcessExitError {
   assert.ok(err instanceof Error)
   assert.ok('exitCode' in err)
   assert.ok(
-    err.exitCode === undefined ||
-      err.exitCode === null ||
-      typeof err.exitCode === 'number' ||
+    typeof err.exitCode === 'number' ||
       typeof err.exitCode === 'string',
   )
 }


### PR DESCRIPTION
## Summary
- Narrow the process exit test helper assertion to the normalized exit code types actually produced by withProcessExitThrow.

## Verification
- pnpm --dir cli test -- --test-name-pattern=withProcessExitThrow
- pnpm test

## Notes
- pnpm typecheck was also run and fails on existing app-wide TypeScript errors unrelated to this CLI test-only change.