### PR TITLE
Export render scene dependency type

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -8,6 +8,7 @@ import test from 'node:test'
 import { withEnvVar } from '../testUtils/env.js'
 import { assertToolText } from '../testUtils/mcp.js'
 import { handleRenderScene, renderSceneTool } from './tools/renderScene.js'
+import type { RenderSceneDeps } from './tools/renderScene.js'
 
 type JsonSchemaProperty = {
   type?: string
@@ -18,7 +19,6 @@ type JsonSchemaProperty = {
   maximum?: number
   description?: string
 }
-type RenderSceneDeps = NonNullable<Parameters<typeof handleRenderScene>[1]>
 
 test('render_scene input schema exposes fps bounds', () => {
   const fpsProperty = schemaProperty('fps')

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -42,7 +42,7 @@ const RenderInput = z.object({
     ),
 })
 type RenderInputData = z.infer<typeof RenderInput>
-type RenderSceneDeps = {
+export type RenderSceneDeps = {
   existsSync: typeof fs.existsSync
   statSync: (path: fs.PathLike) => fs.Stats
   mkdirSync: (path: fs.PathLike, options: { recursive: true }) => string | undefined


### PR DESCRIPTION
## Summary
- Export the MCP render_scene dependency type for direct type-only use in tests
- Replace parameter inference in the render_scene test with the explicit exported type

## Tests
- pnpm --dir cli test -- renderScene.test.js