### PR TITLE
chore(cli): align info scene path schema

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -43,7 +43,8 @@ test('info_scene rejects empty scene paths as MCP errors', async () => {
   const result = await handleInfoScene({ scene: '   ' })
 
   assert.equal(result.isError, true)
-  assert.equal(assertToolText(result), 'info_scene: scene path is required')
+  assert.match(assertToolText(result), /^info_scene: invalid arguments/)
+  assert.match(assertToolText(result), /scene path is required/)
 })
 
 test('info_scene returns a structured scene summary', async () => {

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -13,7 +13,7 @@ import fs from 'node:fs'
 import { readSceneSummary, type SceneSummary } from '../../scene/build.js'
 
 const InfoInput = z.object({
-  scene: z.string().min(1).describe('Path to a .hype scene file.'),
+  scene: z.string().trim().min(1, 'scene path is required').describe('Path to a .hype scene file.'),
 })
 type InfoInputData = z.infer<typeof InfoInput>
 


### PR DESCRIPTION
## Summary
- Trim info_scene path input during schema validation, matching adjacent MCP tools
- Update the whitespace-only path test to assert the schema-level error

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/infoScene.test.js
- pnpm test