### PR TITLE
Tighten render scene schema test typing

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -11,13 +11,13 @@ import { handleRenderScene, renderSceneTool } from './tools/renderScene.js'
 import type { RenderSceneDeps } from './tools/renderScene.js'
 
 type JsonSchemaProperty = {
-  type?: string
-  enum?: string[]
-  minLength?: number
-  pattern?: string
-  minimum?: number
-  maximum?: number
-  description?: string
+  readonly type?: string
+  readonly enum?: readonly string[]
+  readonly minLength?: number
+  readonly pattern?: string
+  readonly minimum?: number
+  readonly maximum?: number
+  readonly description?: string
 }
 
 test('render_scene input schema exposes fps bounds', () => {


### PR DESCRIPTION
## Summary
- Mark the render_scene schema test helper fields as readonly
- Keep enum typing readonly to match schema constants used by the assertions

## Tests
- pnpm --dir cli test