### PR TITLE
Type serve command options

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -20,13 +20,17 @@ interface ServeCommandDeps {
   startServer?: () => Promise<void>
 }
 
+type ServeCommandOptions = {
+  mcp?: boolean
+}
+
 export function serveCommand(deps: ServeCommandDeps = {}): Command {
   const startServer = deps.startServer ?? startMcpServer
 
   return new Command('serve')
     .description('Start a server (MCP over stdio, for AI agents).')
     .option('--mcp', 'Run as a Model Context Protocol server over stdio')
-    .action(async (opts: { mcp?: boolean }) => {
+    .action(async (opts: ServeCommandOptions) => {
       if (!opts.mcp) {
         console.error('[serve] no mode specified. Use --mcp to start the MCP server.')
         process.exit(1)


### PR DESCRIPTION
## Summary
- Replace the inline serve command action options shape with a named ServeCommandOptions type for consistency with other CLI commands.

## Tests
- pnpm --dir cli run build && node --test cli/dist/commands/serve.test.js
- pnpm --dir cli test