### PR TITLE
Remove unused CLI test type import

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -10,7 +10,6 @@ import {
   validateScene,
   type SceneJson,
   type TextAnimationJson,
-  type TrackJson,
 } from './build.js'
 
 type PlainSceneObject = Record<string, unknown>


### PR DESCRIPTION
## Summary\n- remove an unused type import from the CLI scene build tests\n\n## Verification\n- pnpm --dir cli test\n- pnpm exec eslint cli/src/scene/build.test.ts\n\nNote: full repo typecheck/lint currently fail on existing unrelated issues outside this small CLI test cleanup.