### PR TITLE
chore(cli): tighten capability payload test helper

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -215,6 +215,7 @@ function requiredBoolean(parsed: Record<string, unknown>, key: string): boolean 
 function assertRecord(value: unknown): asserts value is Record<string, unknown> {
   assert.equal(typeof value, 'object')
   assert.notEqual(value, null)
+  assert.equal(Array.isArray(value), false)
 }
 
 function assertStringArray(value: unknown): asserts value is readonly string[] {


### PR DESCRIPTION
## Summary\n- tighten the CLI capability test helper so arrays are not accepted as record-shaped payloads\n\n## Tests\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/capabilities.test.js\n- pnpm --dir cli test