### PR TITLE
chore(cli): tighten query node id schemas

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -41,11 +41,13 @@ test('query scene MCP tool schemas describe their path and node id inputs', () =
   const getNodeIdProperty = getLayerTool.inputSchema.properties?.nodeId as ToolSchemaProperty
   assert.equal(getNodeIdProperty?.type, 'string')
   assert.equal(getNodeIdProperty?.minLength, 1)
+  assert.equal(getNodeIdProperty?.pattern, '\\S')
   assert.equal(getNodeIdProperty?.description, 'Stable layer/node id to return.')
 
   const filterNodeIdProperty = listTracksTool.inputSchema.properties?.nodeId as ToolSchemaProperty
   assert.equal(filterNodeIdProperty?.type, 'string')
   assert.equal(filterNodeIdProperty?.minLength, 1)
+  assert.equal(filterNodeIdProperty?.pattern, '\\S')
   assert.equal(filterNodeIdProperty?.description, 'Optional stable layer/node id to filter by.')
 })
 

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -45,6 +45,13 @@ const SCENE_PATH_PROPERTY: StringSchemaProperty = {
   description: 'Path to a .hype scene file.',
 }
 
+const NODE_ID_PROPERTY: StringSchemaProperty = {
+  type: 'string',
+  minLength: 1,
+  pattern: '\\S',
+  description: 'Stable layer/node id to return.',
+}
+
 export const listLayersTool: Tool = {
   name: 'list_layers',
   description: 'List all scene layers with id, name, kind, parent, and children.',
@@ -58,7 +65,7 @@ export const getLayerTool: Tool = {
     type: 'object',
     properties: {
       scene: SCENE_PATH_PROPERTY,
-      nodeId: { type: 'string', minLength: 1, description: 'Stable layer/node id to return.' },
+      nodeId: NODE_ID_PROPERTY,
     },
     required: ['scene', 'nodeId'],
   },
@@ -72,8 +79,7 @@ export const listTracksTool: Tool = {
     properties: {
       scene: SCENE_PATH_PROPERTY,
       nodeId: {
-        type: 'string',
-        minLength: 1,
+        ...NODE_ID_PROPERTY,
         description: 'Optional stable layer/node id to filter by.',
       },
     },


### PR DESCRIPTION
## Summary
- Add a reusable MCP query node id schema with a non-whitespace pattern.
- Assert the advertised get_layer and list_tracks nodeId schemas match handler behavior.

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/queryScene.test.js
- pnpm --dir cli test