### PR TITLE
chore(cli): align info scene path schema

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -13,7 +13,12 @@ test('info_scene input schema exposes required scene path', () => {
   assert.deepEqual(infoSceneTool.inputSchema, {
     type: 'object',
     properties: {
-      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
+      scene: {
+        type: 'string',
+        minLength: 1,
+        pattern: '\\S',
+        description: 'Path to a .hype scene file.',
+      },
     },
     required: ['scene'],
   })

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -26,7 +26,12 @@ export const infoSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
+      scene: {
+        type: 'string',
+        minLength: 1,
+        pattern: '\\S',
+        description: 'Path to a .hype scene file.',
+      },
     },
     required: ['scene'],
   },


### PR DESCRIPTION
## Summary
- Add the non-whitespace path pattern to the info_scene MCP schema
- Update the schema assertion test to match the runtime's whitespace-only path rejection

## Tests
- pnpm --dir cli test