### PR TITLE
Test render format inference with URL suffixes

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -77,6 +77,25 @@ test('render command infers formats case-insensitively from output extensions', 
   }
 })
 
+test('render command ignores URL-style suffixes when inferring output formats', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-format-suffix-'))
+  const outputPath = path.join(dir, 'out.webm?download=1#preview')
+  const appPath = path.join(dir, 'hyper-motion')
+  const calls: HeadlessRenderRequest[] = []
+  try {
+    await renderCommand({
+      locateApp: async () => appPath,
+      driveRender: async (req) => {
+        calls.push(req)
+      },
+    }).parseAsync(['-o', outputPath], { from: 'user' })
+
+    assert.equal(calls[0]?.format, 'webm')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render command defaults to mp4 when output extension is unsupported', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-format-default-'))
   const outputPath = path.join(dir, 'out.mov')


### PR DESCRIPTION
## Summary
- add CLI render command coverage for output paths with URL-style query/hash suffixes
- verify the command still infers the actual file extension before invoking the driver

## Verification
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/commands/render.test.js cli/dist/renderOptions.test.js
- pnpm test

Note: pnpm typecheck was run and fails on existing app-level TypeScript errors unrelated to this test-only change.