### PR TITLE
Tighten capabilities scene extension test type

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -28,7 +28,7 @@ import { assertToolText } from '../testUtils/mcp.js'
 
 type GetCapabilitiesToolPayload = {
   keyframeableProperties: readonly PropertyIdJson[]
-  sceneExtension: string
+  sceneExtension: '.hype'
   mcpTools: readonly McpToolName[]
   validation: {
     structuralSceneValidation: boolean
@@ -124,7 +124,7 @@ function parseCapabilitiesJson(result: CallToolResult): GetCapabilitiesToolPaylo
   const parsedObject = parsed
 
   const rawSceneExtension = parsedObject.sceneExtension
-  assert.ok(typeof rawSceneExtension === 'string')
+  assert.equal(rawSceneExtension, '.hype')
   const sceneExtension = rawSceneExtension
 
   const rawValidation = parsedObject.validation


### PR DESCRIPTION
## Summary
- tighten the MCP capabilities test payload type so sceneExtension is asserted as the literal `.hype` contract
- keep runtime code unchanged

## Tests
- `pnpm --dir cli test -- --test-name-pattern capabilities` (builds CLI and passed all 386 CLI tests)