### PR TITLE
chore(cli): tighten open scene schema

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -15,6 +15,7 @@ test('open_scene input schema exposes required scene path', () => {
       scene: {
         type: 'string',
         minLength: 1,
+        pattern: '\\S',
         description: 'Absolute or relative path to a .hype scene file.',
       },
     },

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -31,6 +31,7 @@ export const openSceneTool: Tool = {
       scene: {
         type: 'string',
         minLength: 1,
+        pattern: '\\S',
         description: 'Absolute or relative path to a .hype scene file.',
       },
     },


### PR DESCRIPTION
## Summary\n- Require non-whitespace scene paths in the open_scene MCP input schema\n- Update the schema assertion test to match\n\n## Verification\n- pnpm --dir cli test -- openScene.test.ts\n\nNote: repository-wide pnpm typecheck and pnpm lint still fail on pre-existing app-level issues unrelated to this CLI schema change.