### PR TITLE
docs(cli): format PATH reference

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -20,7 +20,7 @@ pnpm add -g @psiddharthdesign/hypermotion
 npm install -g @psiddharthdesign/hypermotion
 ```
 
-This installs two binaries on your PATH:
+This installs two binaries on your `$PATH`:
 
 - `hypermotion` — interactive CLI for humans.
 - `hypermotion-mcp` — Model Context Protocol server for AI agents.


### PR DESCRIPTION
## Summary
- format the CLI README PATH reference as `$PATH` for consistency with the rest of the docs

## Tests
- pnpm --dir cli test