### PR TITLE
chore(cli): align validate scene schema

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -16,7 +16,12 @@ export const validateSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
+      scene: {
+        type: 'string',
+        minLength: 1,
+        pattern: '\\S',
+        description: 'Path to a .hype scene file.',
+      },
     },
     required: ['scene'],
   },

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -12,7 +12,12 @@ test('validate_scene input schema exposes required scene path', () => {
   assert.deepEqual(validateSceneTool.inputSchema, {
     type: 'object',
     properties: {
-      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
+      scene: {
+        type: 'string',
+        minLength: 1,
+        pattern: '\\S',
+        description: 'Path to a .hype scene file.',
+      },
     },
     required: ['scene'],
   })


### PR DESCRIPTION
## Summary
- add the non-whitespace scene path pattern to the validate_scene MCP input schema
- update the schema assertion to cover the pattern

## Tests
- pnpm --dir cli test -- --test-name-pattern validate_scene