### PR TITLE
test(cli): cover Windows render suffix inference

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -72,6 +72,7 @@ test('inferRenderFormatFromPath trims surrounding whitespace', () => {
 test('inferRenderFormatFromPath ignores URL-style suffixes', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.gif?download=1'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.webm#preview'), 'webm')
+  assert.equal(inferRenderFormatFromPath('C:\\tmp\\demo.WEBM?download=1'), 'webm')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.mp4?download=1#preview'), 'mp4')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.webm#preview?download=1'), 'webm')
   assert.equal(inferRenderFormatFromPath(' /tmp/demo.webm?download=1 '), 'webm')


### PR DESCRIPTION
## Summary\n- Add a focused render option test for Windows-style output paths with URL-style suffixes.\n\n## Tests\n- pnpm --dir cli test