### PR TITLE
Validate complete render success sentinels

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -226,6 +226,44 @@ test('driveHeadlessRender waits for complete success sentinels', async () => {
   }
 })
 
+test('driveHeadlessRender waits for success sentinels with timestamps', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(`${out}.done`, JSON.stringify({ bytes: 12 }));",
+      "setTimeout(() => {",
+      "  fs.writeFileSync(out, 'fresh output');",
+      "  fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: 12 }));",
+      '}, 100);',
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await driveHeadlessRender({
+      appPath,
+      outputPath,
+      format: 'mp4',
+      quality: 'comp',
+      fps: 30,
+    })
+
+    assert.equal(fs.readFileSync(outputPath, 'utf-8'), 'fresh output')
+    assert.equal(fs.existsSync(`${outputPath}.done`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('driveHeadlessRender enables Electron logging when verbose mode is set', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
   const appPath = path.join(dir, 'fake-app.mjs')

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -40,6 +40,7 @@ export interface HeadlessRenderRequest {
 }
 
 type SuccessSentinel = {
+  readonly ts: number
   readonly bytes: number
 }
 
@@ -202,9 +203,13 @@ function hasSuccessSentinelBytes(value: unknown): value is SuccessSentinel {
   return (
     typeof value === 'object' &&
     value !== null &&
+    'ts' in value &&
     'bytes' in value &&
+    typeof value.ts === 'number' &&
     typeof value.bytes === 'number' &&
+    Number.isFinite(value.ts) &&
     Number.isFinite(value.bytes) &&
+    value.ts >= 0 &&
     value.bytes >= 0
   )
 }


### PR DESCRIPTION
## Summary
- Require render success sentinels to include the documented `ts` field as well as `bytes`
- Add driver coverage proving incomplete success sentinel JSON is ignored until the full sentinel arrives

## Tests
- `pnpm test` from `cli/`

Automation: hypermotion-maintainer