### PR TITLE
test: cover blank render option guards

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -16,6 +16,7 @@ test('render option guards accept supported values only', () => {
   }
   assert.equal(isRenderFormat('mov'), false)
   assert.equal(isRenderFormat('MP4'), false)
+  assert.equal(isRenderFormat(''), false)
   assert.equal(isRenderFormat(undefined), false)
   assert.equal(isRenderFormat(null), false)
   assert.equal(isRenderFormat(60), false)
@@ -26,6 +27,7 @@ test('render option guards accept supported values only', () => {
   }
   assert.equal(isRenderQuality('1080p'), false)
   assert.equal(isRenderQuality('4K'), false)
+  assert.equal(isRenderQuality(''), false)
   assert.equal(isRenderQuality(undefined), false)
   assert.equal(isRenderQuality(null), false)
   assert.equal(isRenderQuality(60), false)


### PR DESCRIPTION
## Summary
- Add explicit render option guard coverage for blank format and quality values.

## Verification
- `pnpm --dir cli test`

Note: a full repo `pnpm typecheck` was attempted before narrowing the change and currently fails on existing app-level TypeScript errors unrelated to this PR.