### PR TITLE
docs(cli): mention uiState in scene builder layout

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -6,8 +6,8 @@
  * The CLI is standalone — it doesn't import the desktop app's
  * SceneAPI. To produce a `.hype` we mirror the SceneAPI's Y.Doc
  * layout directly: a top-level `scene` Y.Map carrying `nodes`,
- * `tracks`, `meta`, `sections`, plus the scalar `root` and
- * `activeCameraId`. The encoded update bytes are byte-identical
+ * `tracks`, `meta`, `sections`, and `uiState`, plus the scalar
+ * `root` and `activeCameraId`. The encoded update bytes are byte-identical
  * (mod CRDT history details) to what the desktop app's
  * `sceneToBytes` produces, so the desktop app reads our output
  * back without any special handling.


### PR DESCRIPTION
## Summary
- Update the CLI scene builder layout comment to include the seeded `uiState` map.
- Keep the comment aligned with the existing editor compatibility behavior.

## Tests
- `pnpm --dir cli test`