### PR TITLE
docs(cli): include active camera in create example

### DIFF
--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -13,6 +13,7 @@
  *
  *   {
  *     "meta": { "name": "My scene", "canvas": { "width": 1080, "height": 1920 } },
+ *     "activeCameraId": "camera",
  *     "nodes": {
  *       "root":   {
  *         "id": "root",


### PR DESCRIPTION
## Summary
- Add the missing activeCameraId field to the CLI create command's scene JSON example so it matches the current camera authoring guidance.

## Verification
- pnpm --dir cli test