### PR TITLE
fix(cli): accept macOS app bundle override

### DIFF
--- a/cli/src/electron/locator.test.ts
+++ b/cli/src/electron/locator.test.ts
@@ -56,6 +56,23 @@ test('locator accepts a HYPERMOTION_APP_PATH symlink to the app binary', async (
   }
 })
 
+test('locator accepts a HYPERMOTION_APP_PATH macOS app bundle', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-bundle-'))
+  const bundlePath = path.join(dir, 'hyper-motion.app')
+  const binaryPath = path.join(bundlePath, 'Contents', 'MacOS', 'hyper-motion')
+
+  try {
+    fs.mkdirSync(path.dirname(binaryPath), { recursive: true })
+    fs.writeFileSync(binaryPath, '')
+
+    await withEnvVar('HYPERMOTION_APP_PATH', bundlePath, async () => {
+      assert.equal(await locateDesktopApp(), binaryPath)
+    })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('locator rejects a missing HYPERMOTION_APP_PATH override', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-missing-'))
   const missingPath = path.join(dir, 'hyper-motion')

--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -23,8 +23,9 @@ import fs from 'node:fs'
 export async function locateDesktopApp(): Promise<string | null> {
   const override = process.env.HYPERMOTION_APP_PATH?.trim()
   if (override) {
-    if (isFile(override)) {
-      return override
+    const overrideBinary = resolveOverrideBinary(override)
+    if (overrideBinary) {
+      return overrideBinary
     }
     // Loud failure — silently falling through when the user set an
     // explicit override usually means a typo or a build that hasn't
@@ -47,6 +48,17 @@ export async function locateDesktopApp(): Promise<string | null> {
     default:
       return null
   }
+}
+
+function resolveOverrideBinary(override: string): string | null {
+  if (isFile(override)) return override
+
+  if (path.basename(override).toLowerCase().endsWith('.app')) {
+    const bundleBinary = path.join(override, 'Contents', 'MacOS', 'hyper-motion')
+    if (isFile(bundleBinary)) return bundleBinary
+  }
+
+  return null
 }
 
 function locateMac(): string | null {


### PR DESCRIPTION
## Summary
- allow HYPERMOTION_APP_PATH to point at a macOS hyper-motion.app bundle
- keep existing strict handling for missing files and ordinary directories
- add locator regression coverage for bundle overrides

## Tests
- pnpm --dir cli run build && cd cli && node --test --test-concurrency=1 dist/electron/locator.test.js
- pnpm --dir cli test