### PR TITLE
chore(cli): tighten inspect scene schema

### DIFF
--- a/cli/src/mcp/inspectScene.test.ts
+++ b/cli/src/mcp/inspectScene.test.ts
@@ -13,7 +13,12 @@ test('inspect_scene input schema exposes required scene path', () => {
   assert.deepEqual(inspectSceneTool.inputSchema, {
     type: 'object',
     properties: {
-      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
+      scene: {
+        type: 'string',
+        minLength: 1,
+        pattern: '\\S',
+        description: 'Path to a .hype scene file.',
+      },
     },
     required: ['scene'],
   })
@@ -37,7 +42,7 @@ test('inspect_scene rejects blank scene paths as MCP errors', async () => {
   const result = await handleInspectScene({ scene: '   ' })
 
   assert.equal(result.isError, true)
-  assert.equal(assertToolText(result), 'inspect_scene: scene path is required')
+  assert.match(assertToolText(result), /^inspect_scene: invalid arguments/)
 })
 
 test('inspect_scene reports missing files as MCP errors', async () => {

--- a/cli/src/mcp/tools/inspectScene.ts
+++ b/cli/src/mcp/tools/inspectScene.ts
@@ -7,7 +7,7 @@ import path from 'node:path'
 import { inspectScene } from '../../scene/build.js'
 
 const InspectInput = z.object({
-  scene: z.string().min(1).describe('Path to a .hype scene file.'),
+  scene: z.string().trim().min(1, 'scene path is required').describe('Path to a .hype scene file.'),
 })
 type InspectInputData = z.infer<typeof InspectInput>
 
@@ -17,7 +17,12 @@ export const inspectSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: { type: 'string', minLength: 1, description: 'Path to a .hype scene file.' },
+      scene: {
+        type: 'string',
+        minLength: 1,
+        pattern: '\\S',
+        description: 'Path to a .hype scene file.',
+      },
     },
     required: ['scene'],
   },


### PR DESCRIPTION
## Summary
- trim and validate inspect_scene MCP scene paths in the Zod input schema
- advertise the non-whitespace path requirement in the MCP input schema
- update inspect_scene tests for the stricter schema behavior

## Tests
- pnpm --dir cli run build && node --test cli/dist/mcp/inspectScene.test.js
- pnpm --dir cli test