### PR TITLE
chore(cli): share empty MCP input schema

### DIFF
--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -3,6 +3,7 @@
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import { NODE_KINDS, PATCH_OPERATION_TYPES, PROPERTY_IDS } from '../../scene/build.js'
 import { RENDER_FORMATS, RENDER_QUALITIES } from '../../renderOptions.js'
+import { EMPTY_OBJECT_INPUT_SCHEMA } from './schema.js'
 
 export const MCP_TOOLS = [
   'doctor',
@@ -56,13 +57,13 @@ export const getCapabilitiesTool: Tool = {
   name: 'get_capabilities',
   description:
     'Return supported scene node kinds, patch operations, render formats/qualities, saved-scene render support, validation/query tools, and keyframeable properties.',
-  inputSchema: { type: 'object', properties: {}, required: [] },
+  inputSchema: EMPTY_OBJECT_INPUT_SCHEMA,
 }
 
 export const listKeyframeablePropertiesTool: Tool = {
   name: 'list_keyframeable_properties',
   description: 'Return property ids that can be animated with tracks/keyframes.',
-  inputSchema: { type: 'object', properties: {}, required: [] },
+  inputSchema: EMPTY_OBJECT_INPUT_SCHEMA,
 }
 
 export async function handleGetCapabilities(): Promise<CallToolResult> {

--- a/cli/src/mcp/tools/doctor.ts
+++ b/cli/src/mcp/tools/doctor.ts
@@ -2,11 +2,12 @@
 
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import { getDoctorReport } from '../../commands/doctor.js'
+import { EMPTY_OBJECT_INPUT_SCHEMA } from './schema.js'
 
 export const doctorTool: Tool = {
   name: 'doctor',
   description: 'Check hyper-motion CLI, desktop app, scene format, render, and MCP capabilities.',
-  inputSchema: { type: 'object', properties: {}, required: [] },
+  inputSchema: EMPTY_OBJECT_INPUT_SCHEMA,
 }
 
 export async function handleDoctor(): Promise<CallToolResult> {

--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool } from '@modelcontextprotocol/sdk/types.js'
+
+export const EMPTY_OBJECT_INPUT_SCHEMA = {
+  type: 'object',
+  properties: {},
+  required: [],
+} as const satisfies Tool['inputSchema']


### PR DESCRIPTION
## Summary\n- add a shared typed empty-object MCP input schema helper\n- reuse it for the doctor and capability tools\n\n## Tests\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/capabilities.test.js cli/dist/mcp/doctor.test.js\n- pnpm --dir cli test