### PR TITLE
Add explicit types for render sentinel JSON

### DIFF
--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -192,7 +192,7 @@ function cleanFile(p: string): void {
 function hasCompleteSuccessSentinel(sentinelPath: string): boolean {
   try {
     const raw = fs.readFileSync(sentinelPath, 'utf-8')
-    const data = JSON.parse(raw)
+    const data: unknown = JSON.parse(raw)
     return hasSuccessSentinelBytes(data)
   } catch {
     return false
@@ -220,7 +220,7 @@ function readRenderErrorMessage(errorPath: string): string | null {
     const raw = fs.readFileSync(errorPath, 'utf-8')
     if (raw.length === 0) return null
     try {
-      const data = JSON.parse(raw)
+      const data: unknown = JSON.parse(raw)
       if (hasErrorMessage(data)) message = data.message.trim()
     } catch {
       if (raw.trimStart().startsWith('{')) return null


### PR DESCRIPTION
## Summary\n- Annotate parsed render sentinel JSON payloads as unknown before guard validation\n\n## Tests\n- pnpm --dir cli exec tsc && node --test cli/dist/electron/driver.test.js\n- pnpm --dir cli test