### PR TITLE
Update render install guidance

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -556,3 +556,33 @@ test('render command reports scene stat failures before launching the app', asyn
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('render command reports the releases page when the desktop app is missing', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-missing-app-'))
+  const outPath = path.join(dir, 'out.mp4')
+  try {
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          renderCommand({
+            locateApp: async () => null,
+            driveRender: async () => {
+              throw new Error('should not render')
+            },
+          }).parseAsync(['-o', outPath], {
+            from: 'user',
+          }),
+          { exitCode: 1 },
+        )
+      })
+    })
+
+    assert.match(stderr, /^\[render\] hyper-motion desktop app not found\.$/m)
+    assert.match(
+      stderr,
+      /https:\/\/github\.com\/psiddharthdesign\/hypermotion\/releases/,
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -174,7 +174,7 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
       if (!appPath) {
         console.error(
           '[render] hyper-motion desktop app not found.\n' +
-            '         Install from https://hypermotion.app, then retry.',
+            '         Install from https://github.com/psiddharthdesign/hypermotion/releases, then retry.',
         )
         process.exit(1)
       }

--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -382,6 +382,31 @@ test('render_scene reports desktop driver failures as MCP errors', async () => {
   }
 })
 
+test('render_scene reports the releases page when the desktop app is missing', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-missing-app-'))
+
+  try {
+    const result = await handleRenderScene(
+      {
+        output: path.join(dir, 'out.mp4'),
+      },
+      testDeps({ locateApp: async () => null }),
+    )
+
+    assert.equal(result.isError, true)
+    assert.match(
+      assertToolText(result),
+      /^hyper-motion desktop app not found\. Install it from /,
+    )
+    assert.match(
+      assertToolText(result),
+      /https:\/\/github\.com\/psiddharthdesign\/hypermotion\/releases/,
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 function schemaProperty(name: string): JsonSchemaProperty | undefined {
   return renderSceneTool.inputSchema.properties?.[name] as
     | JsonSchemaProperty

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -252,7 +252,7 @@ export async function handleRenderScene(
           type: 'text' as const,
           text:
             'hyper-motion desktop app not found. Install it from ' +
-            'https://hypermotion.app and try again.',
+            'https://github.com/psiddharthdesign/hypermotion/releases and try again.',
         },
       ],
     }


### PR DESCRIPTION
## Summary
- point render missing-app guidance at the GitHub releases page
- cover the CLI and MCP render missing-app messages with focused tests

## Tests
- pnpm --dir cli test -- --test-name-pattern "render command|render_scene"