### PR TITLE
test: cover Windows hash render suffixes

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -75,6 +75,7 @@ test('inferRenderFormatFromPath ignores URL-style suffixes', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.gif?download=1'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.webm#preview'), 'webm')
   assert.equal(inferRenderFormatFromPath('C:\\tmp\\demo.WEBM?download=1'), 'webm')
+  assert.equal(inferRenderFormatFromPath('C:\\tmp\\demo.GIF#preview'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.mp4?download=1#preview'), 'mp4')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.webm#preview?download=1'), 'webm')
   assert.equal(inferRenderFormatFromPath(' /tmp/demo.webm?download=1 '), 'webm')


### PR DESCRIPTION
## Summary\n- add a focused render format inference assertion for Windows-style output paths with hash suffixes\n\n## Tests\n- pnpm --dir cli test