### PR TITLE
Clarify create_scene output path schema

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -12,7 +12,7 @@ test('create_scene input schema marks output as non-empty', () => {
   assert.deepEqual(createSceneTool.inputSchema.properties?.output, {
     type: 'string',
     minLength: 1,
-    description: 'Absolute path to write the .hype file to.',
+    description: 'Absolute, non-blank path to write the .hype file to.',
   })
 })
 

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -95,7 +95,7 @@ export const createSceneTool: Tool = {
       output: {
         type: 'string',
         minLength: 1,
-        description: 'Absolute path to write the .hype file to.',
+        description: 'Absolute, non-blank path to write the .hype file to.',
       },
       scene: {
         anyOf: [{ type: 'string' }, { type: 'object' }],


### PR DESCRIPTION
## Summary\n- Clarify that the MCP create_scene output path schema expects an absolute, non-blank path\n- Update the schema assertion test to match the tool metadata\n\n## Tests\n- pnpm test