### PR TITLE
Reject blank patch output paths

### DIFF
--- a/cli/src/commands/patch.test.ts
+++ b/cli/src/commands/patch.test.ts
@@ -186,6 +186,19 @@ test('patch command trims padded output paths before writing', async () => {
   }
 })
 
+test('patch command rejects blank output paths', async () => {
+  const stderr = await withProcessExitThrow(() => captureStderr(() => {
+    return assert.rejects(
+      patchCommand().parseAsync(['scene.hype', '--from', 'patch.json', '--output', '   '], {
+        from: 'user',
+      }),
+      { exitCode: 2 },
+    )
+  }))
+
+  assert.equal(stderr, '[patch] output path is required\n')
+})
+
 test('patch command rejects blank scene paths before reading patch JSON', async () => {
   const stderr = await withProcessExitThrow(() => captureStderr(() => {
     return assert.rejects(

--- a/cli/src/commands/patch.ts
+++ b/cli/src/commands/patch.ts
@@ -25,6 +25,10 @@ export function patchCommand(): Command {
 
       const resolvedScenePath = path.resolve(trimmedScenePath)
       const trimmedOutputPath = options.output?.trim()
+      if (options.output !== undefined && !trimmedOutputPath) {
+        console.error('[patch] output path is required')
+        process.exit(2)
+      }
       const output = path.resolve(trimmedOutputPath || trimmedScenePath)
       let sceneBytes: Buffer
       let stats: fs.Stats


### PR DESCRIPTION
## Summary
- Reject whitespace-only `hypermotion patch --output` values with a clear usage error
- Add a regression test for blank patch output paths

## Verification
- `pnpm test`