### PR TITLE
Clarify render sentinel polling comment

### DIFF
--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -118,7 +118,8 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
     exitedAt = Date.now()
   })
 
-  // Poll for the sentinel. The render is complete when it appears.
+  // Poll until the success sentinel is fully written. Empty, partial, or
+  // malformed sentinel files are ignored and retried.
   const start = Date.now()
   while (Date.now() - start < RENDER_TIMEOUT_MS) {
     if (errorRef.current) {


### PR DESCRIPTION
## Summary
- clarify that the CLI render driver waits for a complete success sentinel, not just any .done file

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js
- pnpm --dir cli test