### PR TITLE
fix(cli): reject blank patch input paths

### DIFF
--- a/cli/src/commands/patch.test.ts
+++ b/cli/src/commands/patch.test.ts
@@ -199,6 +199,17 @@ test('patch command rejects blank output paths', async () => {
   assert.equal(stderr, '[patch] output path is required\n')
 })
 
+test('patch command rejects blank patch paths before reading scene bytes', async () => {
+  const stderr = await withProcessExitThrow(() => captureStderr(() => {
+    return assert.rejects(
+      patchCommand().parseAsync(['scene.hype', '--from', '   '], { from: 'user' }),
+      { exitCode: 2 },
+    )
+  }))
+
+  assert.equal(stderr, '[patch] patch path is required\n')
+})
+
 test('patch command rejects blank scene paths before reading patch JSON', async () => {
   const stderr = await withProcessExitThrow(() => captureStderr(() => {
     return assert.rejects(

--- a/cli/src/commands/patch.ts
+++ b/cli/src/commands/patch.ts
@@ -30,6 +30,11 @@ export function patchCommand(): Command {
         process.exit(2)
       }
       const output = path.resolve(trimmedOutputPath || trimmedScenePath)
+      const trimmedPatchPath = options.from.trim()
+      if (!trimmedPatchPath) {
+        console.error('[patch] patch path is required')
+        process.exit(2)
+      }
       let sceneBytes: Buffer
       let stats: fs.Stats
       try {
@@ -51,7 +56,7 @@ export function patchCommand(): Command {
 
       let patch: unknown
       try {
-        const raw = options.from === '-' ? await readStdin() : fs.readFileSync(options.from, 'utf-8')
+        const raw = trimmedPatchPath === '-' ? await readStdin() : fs.readFileSync(trimmedPatchPath, 'utf-8')
         patch = JSON.parse(raw)
       } catch (err) {
         console.error(`[patch] failed to read patch: ${err instanceof Error ? err.message : err}`)


### PR DESCRIPTION
## Summary
- Reject whitespace-only patch JSON paths in the CLI patch command
- Trim the patch path before reading it, matching scene/output path handling
- Add coverage for the blank --from path case

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/commands/patch.test.js
- pnpm test