### PR TITLE
Normalize query layer child ids

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -245,7 +245,7 @@ test('query scene MCP handlers return layers, tracks, and cameras', async () => 
             name: 'Root frame',
             kind: 'frame',
             parent: null,
-            children: ['title', 'title.*'],
+            children: ['title', 'title.*', 42] as unknown as string[],
             size: { width: 320, height: 180 },
             layout: { mode: 'none' },
           },

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -35,7 +35,7 @@ type LayerSummary = {
   name: unknown
   kind: unknown
   parent: unknown
-  children: unknown[]
+  children: string[]
 }
 
 const SCENE_PATH_PROPERTY: StringSchemaProperty = {
@@ -114,7 +114,7 @@ export async function handleListLayers(
         name: n.name,
         kind: n.kind,
         parent: n.parent,
-        children: Array.isArray(n.children) ? n.children : [],
+        children: stringArray(n.children),
       }
     }),
   })
@@ -215,6 +215,12 @@ function record(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {}
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : []
 }
 
 function text(value: unknown): CallToolResult {


### PR DESCRIPTION
## Summary
- normalize `list_layers` child ids to strings in the CLI MCP query response
- add coverage for malformed child entries being filtered from the public payload

## Tests
- pnpm test