### PR TITLE
Handle missing parent validation safely

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1039,6 +1039,21 @@ test('validateScene rejects tracks targeting missing nodes', () => {
   ])
 })
 
+test('validateScene rejects missing parents without throwing', () => {
+  const scene = sampleScene()
+  const title = scene.nodes?.title
+  if (!title) throw new Error('missing sample title')
+  title.parent = 'missing-parent'
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    "node root lists child title, but child's parent is missing-parent",
+    'node title has missing parent: missing-parent',
+  ])
+})
+
 test('validateScene rejects non-frame root nodes', () => {
   const scene = sampleScene()
   scene.root = 'title'

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -957,6 +957,7 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
         break
       }
       seenParents.add(current)
+      if (!nodes[current]) break
       current = asRecord(nodes[current]).parent
     }
   }


### PR DESCRIPTION
## Summary
- stop scene validation parent-cycle traversal when it reaches an already-missing parent
- add a regression test for malformed scenes with missing parent ids

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/scene/build.test.js
- pnpm test