### PR TITLE
fix(cli): validate query scene paths in schema

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -128,7 +128,8 @@ test('query scene MCP handlers reject empty scene paths clearly', async () => {
   for (const entry of cases) {
     const result = await entry.run()
     assert.equal(result.isError, true)
-    assert.equal(assertToolText(result), `${entry.name}: scene path is required`)
+    assert.match(assertToolText(result), new RegExp(`^${entry.name}: invalid arguments`))
+    assert.match(assertToolText(result), /scene path is required/)
   }
 })
 

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -5,7 +5,7 @@ import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
 import { inspectScene } from '../../scene/build.js'
 
-const ScenePathInput = z.string().trim()
+const ScenePathInput = z.string().trim().min(1, 'scene path is required')
 const SceneInput = z.object({ scene: ScenePathInput })
 const NodeIdInput = z.string().trim().min(1, 'nodeId is required')
 const LayerInput = z.object({ scene: ScenePathInput, nodeId: NodeIdInput })


### PR DESCRIPTION
## Summary
- align query scene MCP path parsing with its advertised non-empty schema
- update blank scene path assertions to expect schema validation errors

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/queryScene.test.js
- pnpm --dir cli test