### PR TITLE
Tighten render scene mkdir dependency type

### DIFF
--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -45,7 +45,10 @@ type RenderInputData = z.infer<typeof RenderInput>
 export type RenderSceneDeps = {
   existsSync: typeof fs.existsSync
   statSync: (path: fs.PathLike) => fs.Stats
-  mkdirSync: (path: fs.PathLike, options: { recursive: true }) => string | undefined
+  mkdirSync: (
+    path: fs.PathLike,
+    options?: fs.MakeDirectoryOptions,
+  ) => string | undefined | void
   locateApp: typeof locateDesktopApp
   render: typeof driveHeadlessRender
 }


### PR DESCRIPTION
## Summary
- Align the render_scene MCP dependency type for mkdirSync with the MakeDirectoryOptions shape used by the handler and test doubles.

## Tests
- pnpm --dir cli test