### PR TITLE
test(cli): reuse MCP text assertion in create scene tests

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -6,6 +6,7 @@ import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { PROPERTY_IDS, readSceneSummary } from '../scene/build.js'
+import { assertToolText } from '../testUtils/mcp.js'
 import { createSceneTool, handleCreateScene } from './tools/createScene.js'
 
 test('create_scene input schema marks output as non-empty', () => {
@@ -177,8 +178,7 @@ test('create_scene reports invalid arguments as MCP errors', async () => {
   })
 
   assert.equal(result.isError, true)
-  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-  assert.match(text, /^create_scene: invalid arguments/)
+  assert.match(assertToolText(result), /^create_scene: invalid arguments/)
 })
 
 test('create_scene rejects array scene JSON', async () => {
@@ -191,8 +191,10 @@ test('create_scene rejects array scene JSON', async () => {
     })
 
     assert.equal(result.isError, true)
-    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-    assert.equal(text, 'create_scene: scene must be an object (or a JSON-encoded object).')
+    assert.equal(
+      assertToolText(result),
+      'create_scene: scene must be an object (or a JSON-encoded object).',
+    )
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }
@@ -208,8 +210,10 @@ test('create_scene rejects null scene JSON', async () => {
     })
 
     assert.equal(result.isError, true)
-    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-    assert.equal(text, 'create_scene: scene must be an object (or a JSON-encoded object).')
+    assert.equal(
+      assertToolText(result),
+      'create_scene: scene must be an object (or a JSON-encoded object).',
+    )
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }
@@ -225,8 +229,10 @@ test('create_scene reports malformed scene JSON strings as MCP errors', async ()
     })
 
     assert.equal(result.isError, true)
-    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-    assert.match(text, /^create_scene: 'scene' was a string but not valid JSON:/)
+    assert.match(
+      assertToolText(result),
+      /^create_scene: 'scene' was a string but not valid JSON:/,
+    )
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }
@@ -239,8 +245,7 @@ test('create_scene rejects relative output paths', async () => {
   })
 
   assert.equal(result.isError, true)
-  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-  assert.equal(text, 'create_scene: output must be an absolute path.')
+  assert.equal(assertToolText(result), 'create_scene: output must be an absolute path.')
 })
 
 test('create_scene rejects blank output paths', async () => {
@@ -250,8 +255,7 @@ test('create_scene rejects blank output paths', async () => {
   })
 
   assert.equal(result.isError, true)
-  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-  assert.equal(text, 'create_scene: output path is required')
+  assert.equal(assertToolText(result), 'create_scene: output path is required')
 })
 
 test('create_scene rejects empty output paths at schema validation', async () => {
@@ -261,8 +265,7 @@ test('create_scene rejects empty output paths at schema validation', async () =>
   })
 
   assert.equal(result.isError, true)
-  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-  assert.match(text, /^create_scene: invalid arguments/)
+  assert.match(assertToolText(result), /^create_scene: invalid arguments/)
 })
 
 test('create_scene validates output paths before building scene bytes', async () => {
@@ -272,8 +275,7 @@ test('create_scene validates output paths before building scene bytes', async ()
   })
 
   assert.equal(result.isError, true)
-  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-  assert.equal(text, 'create_scene: output must be an absolute path.')
+  assert.equal(assertToolText(result), 'create_scene: output must be an absolute path.')
 })
 
 test('create_scene trims output paths before writing', async () => {
@@ -340,11 +342,10 @@ test('create_scene reports persisted layer and track counts', async () => {
       },
     })
 
-    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
     const summary = readSceneSummary(fs.readFileSync(scenePath))
 
     assert.equal(result.isError, undefined)
-    assert.match(text, /1 layer, 1 track/)
+    assert.match(assertToolText(result), /1 layer, 1 track/)
     assert.equal(summary.layerCount, 1)
     assert.equal(summary.trackCount, 1)
   } finally {


### PR DESCRIPTION
## Summary
- Reuse the existing MCP text assertion helper in create_scene tests
- Remove duplicated inline MCP text-content extraction

## Tests
- pnpm test