### PR TITLE
Tighten render_scene MCP schema

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -40,6 +40,7 @@ test('render_scene input schema documents relative output paths', () => {
 
 test('render_scene input schema requires only the output path', () => {
   assert.deepEqual(renderSceneTool.inputSchema.required, ['output'])
+  assert.equal(renderSceneTool.inputSchema.additionalProperties, false)
 })
 
 test('render_scene input schema exposes render preset enums', () => {

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -105,6 +105,7 @@ export const renderSceneTool: Tool = {
       },
     },
     required: ['output'],
+    additionalProperties: false,
   },
 }
 


### PR DESCRIPTION
## Summary
- Mark the render_scene MCP input schema as rejecting additional properties.
- Add a schema assertion covering that contract.

## Verification
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/renderScene.test.js
- pnpm --dir cli test

Note: repo-wide pnpm typecheck currently fails on existing editor-side type errors on main; this change is verified through the CLI build and test suite.