### PR TITLE
test(cli): cover Windows render extension inference

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -36,6 +36,7 @@ test('render option guards accept supported values only', () => {
 
 test('inferRenderFormatFromPath uses supported file extensions', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/demo.mp4'), 'mp4')
+  assert.equal(inferRenderFormatFromPath('C:\\tmp\\demo.mp4'), 'mp4')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.webm'), 'webm')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.gif'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/demo.final.mp4'), 'mp4')


### PR DESCRIPTION
## Summary
- add coverage for Windows-style output paths when inferring render formats

## Tests
- pnpm --dir cli test