### PR TITLE
test(cli): cover create scene required schema

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -17,6 +17,10 @@ test('create_scene input schema marks output as non-empty', () => {
   })
 })
 
+test('create_scene input schema requires output and scene', () => {
+  assert.deepEqual(createSceneTool.inputSchema.required, ['output', 'scene'])
+})
+
 test('create_scene description lists supported appearance property ids', () => {
   const description = createSceneTool.description
   if (typeof description !== 'string') {


### PR DESCRIPTION
## Summary
- add coverage that the create_scene MCP schema keeps output and scene required

## Tests
- pnpm --dir cli test