### PR TITLE
chore(cli): name MCP query tool type

### DIFF
--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -30,6 +30,7 @@ const QUERY_TOOLS = [
   'list_tracks',
   'list_cameras',
 ] as const satisfies readonly McpToolName[]
+export type QueryToolName = (typeof QUERY_TOOLS)[number]
 
 type CapabilitiesPayload = {
   sceneExtension: '.hype'


### PR DESCRIPTION
## Summary
- export a named QueryToolName union from the MCP capabilities module
- keep the existing query tool tuple and runtime payload unchanged

## Tests
- pnpm --dir cli test