### PR TITLE
chore(cli): tighten empty MCP input schemas

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -100,11 +100,13 @@ test('capability tool schemas accept no arguments', () => {
     type: 'object',
     properties: {},
     required: [],
+    additionalProperties: false,
   })
   assert.deepEqual(listKeyframeableProperties?.inputSchema, {
     type: 'object',
     properties: {},
     required: [],
+    additionalProperties: false,
   })
 })
 

--- a/cli/src/mcp/doctor.test.ts
+++ b/cli/src/mcp/doctor.test.ts
@@ -16,6 +16,7 @@ test('doctor input schema accepts no arguments', () => {
     type: 'object',
     properties: {},
     required: [],
+    additionalProperties: false,
   })
 })
 

--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -6,4 +6,5 @@ export const EMPTY_OBJECT_INPUT_SCHEMA = {
   type: 'object',
   properties: {},
   required: [],
+  additionalProperties: false,
 } as const satisfies Tool['inputSchema']


### PR DESCRIPTION
## Summary
- mark shared empty-object MCP input schemas with additionalProperties: false
- update exact schema assertions for capabilities and doctor tools

## Tests
- pnpm test