### PR TITLE
chore(cli): close query scene MCP schemas

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -31,6 +31,7 @@ test('query scene MCP tool schemas describe their path and node id inputs', () =
     assert.equal(sceneProperty?.description, 'Path to a .hype scene file.')
     assert.ok(Array.isArray(tool.inputSchema.required))
     assert.ok(tool.inputSchema.required.includes('scene'))
+    assert.equal(tool.inputSchema.additionalProperties, false)
   }
 
   assert.deepEqual(getLayerTool.inputSchema.required, ['scene', 'nodeId'])

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -55,7 +55,12 @@ const NODE_ID_PROPERTY: StringSchemaProperty = {
 export const listLayersTool: Tool = {
   name: 'list_layers',
   description: 'List all scene layers with id, name, kind, parent, and children.',
-  inputSchema: { type: 'object', properties: { scene: SCENE_PATH_PROPERTY }, required: ['scene'] },
+  inputSchema: {
+    type: 'object',
+    properties: { scene: SCENE_PATH_PROPERTY },
+    required: ['scene'],
+    additionalProperties: false,
+  },
 }
 
 export const getLayerTool: Tool = {
@@ -68,6 +73,7 @@ export const getLayerTool: Tool = {
       nodeId: NODE_ID_PROPERTY,
     },
     required: ['scene', 'nodeId'],
+    additionalProperties: false,
   },
 }
 
@@ -84,13 +90,19 @@ export const listTracksTool: Tool = {
       },
     },
     required: ['scene'],
+    additionalProperties: false,
   },
 }
 
 export const listCamerasTool: Tool = {
   name: 'list_cameras',
   description: 'List camera nodes and the active camera id.',
-  inputSchema: { type: 'object', properties: { scene: SCENE_PATH_PROPERTY }, required: ['scene'] },
+  inputSchema: {
+    type: 'object',
+    properties: { scene: SCENE_PATH_PROPERTY },
+    required: ['scene'],
+    additionalProperties: false,
+  },
 }
 
 export async function handleListLayers(


### PR DESCRIPTION
## Summary
- mark query scene MCP tool schemas as closed to extra input properties
- cover that metadata in the existing schema test

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/queryScene.test.js
- pnpm test