### PR TITLE
chore(cli): reject extra info and validate args

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -21,6 +21,7 @@ test('info_scene input schema exposes required scene path', () => {
       },
     },
     required: ['scene'],
+    additionalProperties: false,
   })
 })
 
@@ -32,6 +33,13 @@ test('info_scene description does not require absolute paths', () => {
 
 test('info_scene reports invalid arguments as MCP errors', async () => {
   const result = await handleInfoScene({ scene: 42 })
+
+  assert.equal(result.isError, true)
+  assert.match(assertToolText(result), /^info_scene: invalid arguments/)
+})
+
+test('info_scene rejects unknown arguments as MCP errors', async () => {
+  const result = await handleInfoScene({ scene: 'demo.hype', output: 'demo.json' })
 
   assert.equal(result.isError, true)
   assert.match(assertToolText(result), /^info_scene: invalid arguments/)

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -14,7 +14,7 @@ import { readSceneSummary, type SceneSummary } from '../../scene/build.js'
 
 const InfoInput = z.object({
   scene: z.string().trim().min(1, 'scene path is required').describe('Path to a .hype scene file.'),
-})
+}).strict()
 type InfoInputData = z.infer<typeof InfoInput>
 
 export const infoSceneTool: Tool = {
@@ -34,6 +34,7 @@ export const infoSceneTool: Tool = {
       },
     },
     required: ['scene'],
+    additionalProperties: false,
   },
 }
 

--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -7,7 +7,7 @@ import { validateScene, type SceneValidationResult } from '../../scene/build.js'
 
 const ValidateInput = z.object({
   scene: z.string().trim().min(1, 'scene path is required').describe('Path to a .hype scene file.'),
-})
+}).strict()
 type ValidateInputData = z.infer<typeof ValidateInput>
 
 export const validateSceneTool: Tool = {
@@ -24,6 +24,7 @@ export const validateSceneTool: Tool = {
       },
     },
     required: ['scene'],
+    additionalProperties: false,
   },
 }
 

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -20,11 +20,20 @@ test('validate_scene input schema exposes required scene path', () => {
       },
     },
     required: ['scene'],
+    additionalProperties: false,
   })
 })
 
 test('validate_scene reports invalid arguments as MCP errors', async () => {
   const result = await handleValidateScene({ scene: 42 })
+
+  assert.equal(result.isError, true)
+  const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+  assert.match(text, /^validate_scene: invalid arguments/)
+})
+
+test('validate_scene rejects unknown arguments as MCP errors', async () => {
+  const result = await handleValidateScene({ scene: 'demo.hype', output: 'demo.json' })
 
   assert.equal(result.isError, true)
   const text = result.content[0]?.type === 'text' ? result.content[0].text : ''


### PR DESCRIPTION
## Summary
- mark info_scene and validate_scene MCP schemas as closed objects
- make their Zod parsers reject unknown arguments
- add focused MCP tests for unknown argument rejection

## Tests
- pnpm --dir cli test -- --test-name-pattern='info_scene|validate_scene'