### PR TITLE
chore(cli): reject extra open scene args

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -20,6 +20,7 @@ test('open_scene input schema exposes required scene path', () => {
       },
     },
     required: ['scene'],
+    additionalProperties: false,
   })
 })
 
@@ -32,6 +33,13 @@ test('open_scene reports invalid arguments as MCP errors', async () => {
 
 test('open_scene rejects empty schema scene paths as MCP errors', async () => {
   const result = await handleOpenScene({ scene: '' })
+
+  assert.equal(result.isError, true)
+  assert.match(assertToolText(result), /^open_scene: invalid arguments/)
+})
+
+test('open_scene rejects unknown arguments as MCP errors', async () => {
+  const result = await handleOpenScene({ scene: 'demo.hype', output: 'demo.mp4' })
 
   assert.equal(result.isError, true)
   assert.match(assertToolText(result), /^open_scene: invalid arguments/)

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -8,7 +8,7 @@ import { pushSceneToRunningApp } from '../../electron/live.js'
 
 const OpenInput = z.object({
   scene: z.string().min(1).describe('Absolute or relative path to a .hype scene file.'),
-})
+}).strict()
 type OpenInputData = z.infer<typeof OpenInput>
 type OpenSceneDeps = {
   existsSync: typeof fs.existsSync
@@ -36,6 +36,7 @@ export const openSceneTool: Tool = {
       },
     },
     required: ['scene'],
+    additionalProperties: false,
   },
 }
 


### PR DESCRIPTION
## Summary\n- make the MCP open_scene runtime input parser reject unknown arguments\n- expose additionalProperties: false in the open_scene tool schema\n- add coverage for accidental extra arguments\n\n## Tests\n- pnpm --dir cli test -- --test-name-pattern=open_scene