### PR TITLE
Validate render sentinel integer metadata

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -302,6 +302,44 @@ test('driveHeadlessRender ignores malformed success sentinels', async () => {
   }
 })
 
+test('driveHeadlessRender ignores success sentinels with fractional metadata', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now() + 0.5, bytes: 12.5 }));",
+      "setTimeout(() => {",
+      "  fs.writeFileSync(out, 'fresh output');",
+      "  fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: 12 }));",
+      '}, 100);',
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await driveHeadlessRender({
+      appPath,
+      outputPath,
+      format: 'mp4',
+      quality: 'comp',
+      fps: 30,
+    })
+
+    assert.equal(fs.readFileSync(outputPath, 'utf-8'), 'fresh output')
+    assert.equal(fs.existsSync(`${outputPath}.done`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('driveHeadlessRender enables Electron logging when verbose mode is set', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
   const appPath = path.join(dir, 'fake-app.mjs')

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -210,6 +210,8 @@ function hasSuccessSentinelBytes(value: unknown): value is SuccessSentinel {
     typeof value.bytes === 'number' &&
     Number.isFinite(value.ts) &&
     Number.isFinite(value.bytes) &&
+    Number.isInteger(value.ts) &&
+    Number.isInteger(value.bytes) &&
     value.ts >= 0 &&
     value.bytes >= 0
   )


### PR DESCRIPTION
## Summary
- Require render success sentinel timestamp and byte metadata to be integers before accepting completion.
- Add a focused driver test covering fractional sentinel metadata followed by a valid sentinel.

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js
- pnpm --dir cli test