### PR TITLE
Tighten env test cleanup

### DIFF
--- a/cli/src/testUtils/env.test.ts
+++ b/cli/src/testUtils/env.test.ts
@@ -99,23 +99,31 @@ test('withEnvVar returns sync callback values', async () => {
   const name = 'HYPERMOTION_TEST_ENV_SYNC_RETURN'
   delete process.env[name]
 
-  const value = await withEnvVar(name, 'during', () => process.env[name])
+  try {
+    const value = await withEnvVar(name, 'during', () => process.env[name])
 
-  assert.equal(value, 'during')
-  assert.equal(process.env[name], undefined)
+    assert.equal(value, 'during')
+    assert.equal(process.env[name], undefined)
+  } finally {
+    delete process.env[name]
+  }
 })
 
 test('withEnvVar returns async callback values', async () => {
   const name = 'HYPERMOTION_TEST_ENV_ASYNC_RETURN'
   delete process.env[name]
 
-  const value = await withEnvVar(name, 'during', async () => {
-    await Promise.resolve()
-    return process.env[name]
-  })
+  try {
+    const value = await withEnvVar(name, 'during', async () => {
+      await Promise.resolve()
+      return process.env[name]
+    })
 
-  assert.equal(value, 'during')
-  assert.equal(process.env[name], undefined)
+    assert.equal(value, 'during')
+    assert.equal(process.env[name], undefined)
+  } finally {
+    delete process.env[name]
+  }
 })
 
 test('withEnvVar restores values after async callback failures', async () => {


### PR DESCRIPTION
## Summary
- wrap the `withEnvVar` return-value tests in cleanup guards
- ensure temporary test env vars are removed even if assertions fail

## Tests
- `pnpm --dir cli test`