### PR TITLE
chore(cli): narrow render command test deps

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -528,10 +528,10 @@ test('render command reports output directory stat failures before launching the
             driveRender: async () => {
               throw new Error('should not render')
             },
-            statSync: ((targetPath: fs.PathLike) => {
+            statSync: (targetPath: fs.PathLike) => {
               if (targetPath === dir) throw new Error('stat failed')
               return fs.statSync(targetPath)
-            }) as typeof fs.statSync,
+            },
           }).parseAsync(['-o', outPath], {
             from: 'user',
           }),
@@ -560,10 +560,10 @@ test('render command reports scene stat failures before launching the app', asyn
             driveRender: async () => {
               throw new Error('should not render')
             },
-            statSync: ((targetPath: fs.PathLike) => {
+            statSync: (targetPath: fs.PathLike) => {
               if (targetPath === scenePath) throw new Error('stat failed')
               return fs.statSync(targetPath)
-            }) as typeof fs.statSync,
+            },
           }).parseAsync(['--scene', scenePath, '-o', outPath], {
             from: 'user',
           }),

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -45,8 +45,8 @@ export interface RenderCommandDeps {
   locateApp?: () => Promise<string | null>
   driveRender?: (req: HeadlessRenderRequest) => Promise<void>
   existsSync?: typeof fs.existsSync
-  mkdirSync?: typeof fs.mkdirSync
-  statSync?: typeof fs.statSync
+  mkdirSync?: (path: fs.PathLike, options?: fs.MakeDirectoryOptions) => string | undefined | void
+  statSync?: (path: fs.PathLike) => fs.Stats
 }
 
 export function renderCommand(deps: RenderCommandDeps = {}): Command {


### PR DESCRIPTION
## Summary
- narrow render command dependency hook types for injected fs helpers
- remove now-unnecessary casts in render command tests

## Tests
- pnpm --dir cli test