### PR TITLE
chore(cli): tighten inspect scene MCP args

### DIFF
--- a/cli/src/mcp/inspectScene.test.ts
+++ b/cli/src/mcp/inspectScene.test.ts
@@ -21,11 +21,19 @@ test('inspect_scene input schema exposes required scene path', () => {
       },
     },
     required: ['scene'],
+    additionalProperties: false,
   })
 })
 
 test('inspect_scene reports invalid arguments as MCP errors', async () => {
   const result = await handleInspectScene({ scene: 42 })
+
+  assert.equal(result.isError, true)
+  assert.match(assertToolText(result), /^inspect_scene: invalid arguments/)
+})
+
+test('inspect_scene rejects unknown arguments as MCP errors', async () => {
+  const result = await handleInspectScene({ scene: '/tmp/scene.hype', extra: true })
 
   assert.equal(result.isError, true)
   assert.match(assertToolText(result), /^inspect_scene: invalid arguments/)

--- a/cli/src/mcp/tools/inspectScene.ts
+++ b/cli/src/mcp/tools/inspectScene.ts
@@ -8,7 +8,7 @@ import { inspectScene } from '../../scene/build.js'
 
 const InspectInput = z.object({
   scene: z.string().trim().min(1, 'scene path is required').describe('Path to a .hype scene file.'),
-})
+}).strict()
 type InspectInputData = z.infer<typeof InspectInput>
 
 export const inspectSceneTool: Tool = {
@@ -25,6 +25,7 @@ export const inspectSceneTool: Tool = {
       },
     },
     required: ['scene'],
+    additionalProperties: false,
   },
 }
 


### PR DESCRIPTION
## Summary
- reject unknown arguments in the inspect_scene MCP handler
- declare additionalProperties: false in the inspect_scene MCP input schema
- add coverage for unknown inspect_scene arguments

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/inspectScene.test.js
- pnpm --dir cli test