### PR TITLE
chore(cli): simplify inspect scene path handling

### DIFF
--- a/cli/src/mcp/tools/inspectScene.ts
+++ b/cli/src/mcp/tools/inspectScene.ts
@@ -46,15 +46,7 @@ export async function handleInspectScene(
   }
 
   const input: InspectInputData = parsed.data
-  const trimmedScene = input.scene.trim()
-  if (!trimmedScene) {
-    return {
-      isError: true,
-      content: [{ type: 'text' as const, text: 'inspect_scene: scene path is required' }],
-    }
-  }
-
-  const scenePath = path.resolve(trimmedScene)
+  const scenePath = path.resolve(input.scene)
   let bytes: Buffer
   let stat: fs.Stats
   try {


### PR DESCRIPTION
## Summary\n- remove a redundant blank-path branch from the inspect_scene MCP handler\n- rely on the existing Zod trim/min validation before resolving the scene path\n\n## Tests\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/inspectScene.test.js\n- pnpm --dir cli test