### PR TITLE
Handle directory-like render output paths

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -47,6 +47,11 @@ test('inferRenderFormatFromPath ignores extensions in parent directories', () =>
   assert.equal(inferRenderFormatFromPath('C:\\tmp\\exports.webm\\demo'), 'mp4')
 })
 
+test('inferRenderFormatFromPath ignores directory-like output paths', () => {
+  assert.equal(inferRenderFormatFromPath('/tmp/exports.gif/'), 'mp4')
+  assert.equal(inferRenderFormatFromPath('C:\\tmp\\exports.webm\\'), 'mp4')
+})
+
 test('inferRenderFormatFromPath allows URL markers in parent directories', () => {
   assert.equal(inferRenderFormatFromPath('/tmp/exports#draft/demo.gif'), 'gif')
   assert.equal(inferRenderFormatFromPath('/tmp/exports?draft/demo.webm'), 'webm')

--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -21,6 +21,7 @@ export function isRenderQuality(value: unknown): value is RenderQuality {
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {
   const normalizedPath = filePath.trim().replace(/\\/g, '/')
+  if (normalizedPath.endsWith('/')) return 'mp4'
   const basename = path.basename(normalizedPath)
   const cleanBasename = basename.split(/[?#]/, 1)[0] ?? basename
   const ext = (


### PR DESCRIPTION
## Summary
- default render format inference to mp4 when the output path ends with a path separator
- add coverage for Unix and Windows-style directory-like output paths

## Tests
- pnpm --dir cli run build && node --test cli/dist/renderOptions.test.js
- pnpm test