### PR TITLE
chore(cli): tighten create scene MCP schema

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -19,6 +19,7 @@ test('create_scene input schema marks output as non-empty', () => {
 
 test('create_scene input schema requires output and scene', () => {
   assert.deepEqual(createSceneTool.inputSchema.required, ['output', 'scene'])
+  assert.equal(createSceneTool.inputSchema.additionalProperties, false)
 })
 
 test('create_scene description lists supported appearance property ids', () => {

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -109,6 +109,7 @@ export const createSceneTool: Tool = {
       },
     },
     required: ['output', 'scene'],
+    additionalProperties: false,
   },
 }
 


### PR DESCRIPTION
## Summary
- mark the create_scene MCP input schema as rejecting unknown top-level arguments
- cover that schema contract in the existing create_scene MCP test

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/createScene.test.js
- pnpm --dir cli test