### PR TITLE
chore(cli): reject directory create outputs

### DIFF
--- a/cli/src/commands/create.test.ts
+++ b/cli/src/commands/create.test.ts
@@ -195,6 +195,44 @@ test('create command trims padded JSON source paths', async () => {
   }
 })
 
+test('create command rejects directory output paths', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-create-dir-output-'))
+  const sourcePath = path.join(dir, 'scene.json')
+  const outputPath = path.join(dir, 'existing-output')
+  try {
+    fs.mkdirSync(outputPath)
+    fs.writeFileSync(
+      sourcePath,
+      JSON.stringify({
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const stderr = await withProcessExitThrow(async () => {
+      return captureStderr(async () => {
+        await assert.rejects(
+          createCommand()
+            .parseAsync([outputPath, '--from', sourcePath], { from: 'user' }),
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.equal(stderr, `[create] output path is a directory: ${outputPath}\n`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('create command rejects blank output paths before reading input', async () => {
   const stderr = await withProcessExitThrow(async () => {
     return captureStderr(async () => {

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -136,6 +136,24 @@ export function createCommand(): Command {
         process.exit(1)
       }
 
+      let outputStats: fs.Stats | undefined
+      try {
+        outputStats = fs.statSync(outputPath)
+      } catch (err) {
+        if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          console.error(
+            `[create] failed to inspect output path ${outputPath}: ${
+              err instanceof Error ? err.message : err
+            }`,
+          )
+          process.exit(1)
+        }
+      }
+      if (outputStats?.isDirectory()) {
+        console.error(`[create] output path is a directory: ${outputPath}`)
+        process.exit(2)
+      }
+
       try {
         fs.writeFileSync(outputPath, Buffer.from(bytes))
       } catch (err) {


### PR DESCRIPTION
## Summary
- reject existing directories as invalid hypermotion create output paths before writing
- add a regression test for directory output paths

## Verification
- pnpm --dir cli test -- create.test.js
- pnpm test

Note: pnpm typecheck still fails on existing app-wide TypeScript errors outside this CLI change.