### PR TITLE
Handle directory outputs in create_scene

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -301,6 +301,29 @@ test('create_scene trims output paths before writing', async () => {
   }
 })
 
+test('create_scene rejects directory output paths', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-create-dir-'))
+  const outputPath = path.join(dir, 'existing-output')
+
+  try {
+    fs.mkdirSync(outputPath)
+
+    const result = await handleCreateScene({
+      output: outputPath,
+      open: false,
+      scene: { nodes: {} },
+    })
+
+    assert.equal(result.isError, true)
+    assert.equal(
+      assertToolText(result),
+      `create_scene: output path is a directory: ${outputPath}`,
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('create_scene reports persisted layer and track counts', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-create-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -226,6 +226,36 @@ export async function handleCreateScene(
     }
   }
 
+  let outputStats: fs.Stats | undefined
+  try {
+    outputStats = fs.statSync(outputPath)
+  } catch (err) {
+    if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: `create_scene: failed to inspect output path ${outputPath}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          },
+        ],
+      }
+    }
+  }
+  if (outputStats?.isDirectory()) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `create_scene: output path is a directory: ${outputPath}`,
+        },
+      ],
+    }
+  }
+
   try {
     fs.writeFileSync(outputPath, Buffer.from(bytes))
   } catch (err) {


### PR DESCRIPTION
## Summary
- reject directory output paths in the MCP create_scene handler before attempting to write
- add a regression test matching the CLI create command behavior

## Tests
- pnpm --dir cli test
- pnpm test