### PR TITLE
Reject extra query scene MCP args

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -70,6 +70,40 @@ test('query scene MCP handlers report invalid arguments as MCP errors', async ()
   }
 })
 
+test('query scene MCP handlers reject unknown arguments as MCP errors', async () => {
+  const cases: Array<{
+    name: string
+    run: () => Promise<CallToolResult>
+  }> = [
+    {
+      name: 'list_layers',
+      run: () => handleListLayers({ scene: '/tmp/scene.hype', output: 'out.json' }),
+    },
+    {
+      name: 'get_layer',
+      run: () => handleGetLayer({
+        scene: '/tmp/scene.hype',
+        nodeId: 'title',
+        output: 'out.json',
+      }),
+    },
+    {
+      name: 'list_tracks',
+      run: () => handleListTracks({ scene: '/tmp/scene.hype', output: 'out.json' }),
+    },
+    {
+      name: 'list_cameras',
+      run: () => handleListCameras({ scene: '/tmp/scene.hype', output: 'out.json' }),
+    },
+  ]
+
+  for (const entry of cases) {
+    const result = await entry.run()
+    assert.equal(result.isError, true)
+    assert.match(assertToolText(result), new RegExp(`^${entry.name}: invalid arguments`))
+  }
+})
+
 test('query scene MCP handlers reject blank node ids clearly', async () => {
   const cases: Array<{
     name: string

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -6,10 +6,10 @@ import fs from 'node:fs'
 import { inspectScene } from '../../scene/build.js'
 
 const ScenePathInput = z.string().trim().min(1, 'scene path is required')
-const SceneInput = z.object({ scene: ScenePathInput })
+const SceneInput = z.object({ scene: ScenePathInput }).strict()
 const NodeIdInput = z.string().trim().min(1, 'nodeId is required')
-const LayerInput = z.object({ scene: ScenePathInput, nodeId: NodeIdInput })
-const TrackInput = z.object({ scene: ScenePathInput, nodeId: NodeIdInput.optional() })
+const LayerInput = z.object({ scene: ScenePathInput, nodeId: NodeIdInput }).strict()
+const TrackInput = z.object({ scene: ScenePathInput, nodeId: NodeIdInput.optional() }).strict()
 type SceneInputData = z.infer<typeof SceneInput>
 type LayerInputData = z.infer<typeof LayerInput>
 type TrackInputData = z.infer<typeof TrackInput>


### PR DESCRIPTION
## Summary
- make query scene MCP runtime schemas reject unknown arguments to match their published schemas
- add coverage for extra args on list_layers, get_layer, list_tracks, and list_cameras

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/queryScene.test.js
- pnpm --dir cli test