### PR TITLE
fix(cli): reject extra render_scene args

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -70,6 +70,17 @@ test('render_scene reports invalid arguments as MCP errors', async () => {
   assert.match(assertToolText(result), /^render_scene: invalid arguments/)
 })
 
+test('render_scene rejects unknown arguments as MCP errors', async () => {
+  const result = await handleRenderScene({
+    output: 'demo.mp4',
+    chapter: 1,
+  })
+
+  assert.equal(result.isError, true)
+  assert.match(assertToolText(result), /^render_scene: invalid arguments/)
+  assert.match(assertToolText(result), /Unrecognized key/)
+})
+
 test('render_scene rejects empty output paths as MCP errors', async () => {
   const result = await handleRenderScene({
     output: '   ',

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -40,7 +40,7 @@ const RenderInput = z.object({
     .describe(
       'Path to a .hype scene file to render instead of the current desktop scene.',
     ),
-})
+}).strict()
 type RenderInputData = z.infer<typeof RenderInput>
 export type RenderSceneDeps = {
   existsSync: typeof fs.existsSync


### PR DESCRIPTION
## Summary\n- make the render_scene MCP input parser strict so it matches its additionalProperties: false schema\n- add regression coverage for unknown render_scene arguments\n\n## Tests\n- pnpm --dir cli test