### PR TITLE
fix(cli): trim open scene MCP path input

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -45,11 +45,12 @@ test('open_scene rejects unknown arguments as MCP errors', async () => {
   assert.match(assertToolText(result), /^open_scene: invalid arguments/)
 })
 
-test('open_scene rejects empty scene paths as MCP errors', async () => {
+test('open_scene rejects whitespace-only scene paths as MCP argument errors', async () => {
   const result = await handleOpenScene({ scene: '   ' })
 
   assert.equal(result.isError, true)
-  assert.equal(assertToolText(result), 'open_scene: scene path is required')
+  assert.match(assertToolText(result), /^open_scene: invalid arguments/)
+  assert.match(assertToolText(result), /scene path is required/)
 })
 
 test('open_scene reports missing files as MCP errors', async () => {

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -7,7 +7,11 @@ import path from 'node:path'
 import { pushSceneToRunningApp } from '../../electron/live.js'
 
 const OpenInput = z.object({
-  scene: z.string().min(1).describe('Absolute or relative path to a .hype scene file.'),
+  scene: z
+    .string()
+    .trim()
+    .min(1, 'scene path is required')
+    .describe('Absolute or relative path to a .hype scene file.'),
 }).strict()
 type OpenInputData = z.infer<typeof OpenInput>
 type OpenSceneDeps = {
@@ -58,15 +62,7 @@ export async function handleOpenScene(
   }
 
   const input: OpenInputData = parsed.data
-  const trimmedScene = input.scene.trim()
-  if (!trimmedScene) {
-    return {
-      isError: true,
-      content: [{ type: 'text' as const, text: 'open_scene: scene path is required' }],
-    }
-  }
-
-  const scenePath = path.resolve(trimmedScene)
+  const scenePath = path.resolve(input.scene)
   if (!deps.existsSync(scenePath)) {
     return {
       isError: true,


### PR DESCRIPTION
## Summary
- Trim and validate open_scene MCP scene paths in the Zod input schema
- Keep whitespace-only paths reported as argument validation errors

## Tests
- pnpm test