### PR TITLE
fix(cli): resolve query scene paths

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -263,6 +263,48 @@ test('query scene MCP handlers trim padded scene paths before reading', async ()
   }
 })
 
+test('query scene MCP handlers resolve padded relative scene paths before reading', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-relative-query-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const previousCwd = process.cwd()
+
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: { name: 'Relative Query', canvas: { width: 320, height: 180 } },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+    process.chdir(dir)
+
+    const result = await handleListLayers({ scene: ' ./scene.hype ' })
+    const payload = JSON.parse(assertToolText(result)) as {
+      root: string
+      layers: Array<{ id: string }>
+    }
+
+    assert.equal(result.isError, undefined)
+    assert.equal(payload.root, 'root')
+    assert.deepEqual(
+      payload.layers.map((layer) => layer.id),
+      ['root'],
+    )
+  } finally {
+    process.chdir(previousCwd)
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('query scene MCP handlers return layers, tracks, and cameras', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-query-mcp-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -3,6 +3,7 @@
 import { z } from 'zod'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
+import path from 'node:path'
 import { inspectScene } from '../../scene/build.js'
 
 const ScenePathInput = z.string().trim().min(1, 'scene path is required')
@@ -180,13 +181,14 @@ export async function handleListCameras(
 }
 
 function read(toolName: QuerySceneToolName, scenePath: string): ReadSceneResult {
-  const normalizedScenePath = scenePath.trim()
-  if (!normalizedScenePath) {
+  const trimmedScenePath = scenePath.trim()
+  if (!trimmedScenePath) {
     return {
       ok: false,
       result: errorText(`${toolName}: scene path is required`),
     }
   }
+  const normalizedScenePath = path.resolve(trimmedScenePath)
 
   let bytes: Buffer
   try {


### PR DESCRIPTION
## Summary
- Resolve trimmed query-scene MCP paths before stat/read/error reporting
- Add coverage for padded relative scene paths

## Tests
- pnpm --dir cli test