### PR TITLE
docs(cli): fix driver path references

### DIFF
--- a/SHIPPING.md
+++ b/SHIPPING.md
@@ -347,7 +347,7 @@ When you're ready to declare v0.1.0 done:
 - `src/commands/serve.ts` — starts MCP server
 - `src/mcp/server.ts` — MCP stdio server with `render_scene` + `info_scene` tools
 - `src/electron/locator.ts` — finds installed desktop app cross-platform
-- `src/electron/driver.ts` — spawns it with headless flags
+- `cli/src/electron/driver.ts` — spawns it with headless flags
 - README, LICENSE, NOTICE
 
 **Landing site (`hyper-motion-landing-site/`):**

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -15,7 +15,7 @@
  * The renderer itself lives in the Electron desktop app. The CLI's `render`
  * command shells out to the installed hyper-motion app with the `--render`
  * flag, which the desktop app handles in `electron/main.ts`. See
- * `electron/driver.ts` for the spawn glue.
+ * `cli/src/electron/driver.ts` for the spawn glue.
  */
 
 import { Command } from 'commander'


### PR DESCRIPTION
## Summary\n- update stale CLI driver source references to the current cli/src/electron/driver.ts path\n\n## Tests\n- pnpm --dir cli test