### PR TITLE
Clarify render_scene scene path schema

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -58,6 +58,7 @@ test('render_scene input schema exposes the optional scene path', () => {
   assert.equal(sceneProperty?.minLength, 1)
   assert.equal(sceneProperty?.pattern, '\\S')
   assert.match(String(sceneProperty?.description), /\.hype scene file/)
+  assert.match(String(sceneProperty?.description), /relative path/)
 })
 
 test('render_scene reports invalid arguments as MCP errors', async () => {

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -101,7 +101,7 @@ export const renderSceneTool: Tool = {
         minLength: 1,
         pattern: '\\S',
         description:
-          'Path to a .hype scene file to render instead of the current desktop scene.',
+          'Absolute or relative path to a .hype scene file to render instead of the current desktop scene.',
       },
     },
     required: ['output'],


### PR DESCRIPTION
## Summary
- clarify that the render_scene MCP schema accepts absolute or relative saved scene paths
- add a schema assertion so the wording stays documented

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/renderScene.test.js
- pnpm --dir cli test

Note: pnpm typecheck was also checked before this change and currently fails on unrelated pre-existing app TypeScript errors.