### PR TITLE
Clarify validate_scene path guidance

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -12,7 +12,8 @@ type ValidateInputData = z.infer<typeof ValidateInput>
 
 export const validateSceneTool: Tool = {
   name: 'validate_scene',
-  description: 'Validate a .hype scene for structural consistency after agent edits.',
+  description:
+    'Validate a .hype scene for structural consistency after agent edits. Pass the path to the .hype file.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -24,6 +24,12 @@ test('validate_scene input schema exposes required scene path', () => {
   })
 })
 
+test('validate_scene description does not require absolute paths', () => {
+  const description = validateSceneTool.description ?? ''
+  assert.match(description, /Pass the path to the \.hype file\./)
+  assert.doesNotMatch(description, /absolute path/i)
+})
+
 test('validate_scene reports invalid arguments as MCP errors', async () => {
   const result = await handleValidateScene({ scene: 42 })
 


### PR DESCRIPTION
## Summary\n- clarify the validate_scene MCP tool description to say callers can pass the .hype path\n- add a regression test that the description does not require absolute paths\n\n## Tests\n- pnpm test