### PR TITLE
Clarify inspect_scene path schema

### DIFF
--- a/cli/src/mcp/inspectScene.test.ts
+++ b/cli/src/mcp/inspectScene.test.ts
@@ -17,7 +17,7 @@ test('inspect_scene input schema exposes required scene path', () => {
         type: 'string',
         minLength: 1,
         pattern: '\\S',
-        description: 'Path to a .hype scene file.',
+        description: 'Absolute or relative path to a .hype scene file.',
       },
     },
     required: ['scene'],

--- a/cli/src/mcp/tools/inspectScene.ts
+++ b/cli/src/mcp/tools/inspectScene.ts
@@ -7,7 +7,11 @@ import path from 'node:path'
 import { inspectScene } from '../../scene/build.js'
 
 const InspectInput = z.object({
-  scene: z.string().trim().min(1, 'scene path is required').describe('Path to a .hype scene file.'),
+  scene: z
+    .string()
+    .trim()
+    .min(1, 'scene path is required')
+    .describe('Absolute or relative path to a .hype scene file.'),
 }).strict()
 type InspectInputData = z.infer<typeof InspectInput>
 
@@ -21,7 +25,7 @@ export const inspectSceneTool: Tool = {
         type: 'string',
         minLength: 1,
         pattern: '\\S',
-        description: 'Path to a .hype scene file.',
+        description: 'Absolute or relative path to a .hype scene file.',
       },
     },
     required: ['scene'],


### PR DESCRIPTION
## Summary
- clarify that the inspect_scene MCP schema accepts absolute or relative .hype paths
- update the schema expectation test to match

## Tests
- pnpm test