### PR TITLE
Test env helper mutation restore

### DIFF
--- a/cli/src/testUtils/env.test.ts
+++ b/cli/src/testUtils/env.test.ts
@@ -19,6 +19,22 @@ test('withEnvVar restores values after sync callbacks', async () => {
   }
 })
 
+test('withEnvVar restores values after callback mutations', async () => {
+  const name = 'HYPERMOTION_TEST_ENV_MUTATED'
+  process.env[name] = 'before'
+
+  try {
+    await withEnvVar(name, 'during', () => {
+      process.env[name] = 'mutated'
+      assert.equal(process.env[name], 'mutated')
+    })
+
+    assert.equal(process.env[name], 'before')
+  } finally {
+    delete process.env[name]
+  }
+})
+
 test('withEnvVar restores existing empty string values', async () => {
   const name = 'HYPERMOTION_TEST_ENV_EMPTY'
   process.env[name] = ''


### PR DESCRIPTION
## Summary
- Add coverage that withEnvVar restores the original environment value even if the callback mutates it.

## Verification
- pnpm run build && node --test --test-concurrency=1 dist/testUtils/env.test.js
- pnpm test