### PR TITLE
Clarify CLI render sentinel behavior

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -113,8 +113,9 @@ hyper-motion desktop app and spawns it with command-line flags that put
 it into a headless render mode. The desktop app boots a hidden render
 window, the renderer waits for the scene to hydrate, the export pipeline
 captures frames and encodes them for the requested format, and the
-desktop app writes the output file directly. The CLI waits for the
-matching completion sentinel before reporting success.
+desktop app writes the output file directly. The CLI waits for a
+complete success sentinel before reporting success, or surfaces the
+renderer's error sentinel if the desktop app reports a failure.
 
 Locations checked, in order:
 


### PR DESCRIPTION
## Summary
- Update the CLI README render workflow description to mention complete success sentinels and renderer error sentinels.

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js
- pnpm --dir cli test
