### PR TITLE
Test explicit success process exits

### DIFF
--- a/cli/src/testUtils/processExit.test.ts
+++ b/cli/src/testUtils/processExit.test.ts
@@ -112,6 +112,15 @@ test('withProcessExitThrow treats process.exit without a code as success', async
   )
 })
 
+test('withProcessExitThrow preserves explicit success exit codes', async () => {
+  await assert.rejects(
+    withProcessExitThrow(() => {
+      process.exit(0)
+    }),
+    { exitCode: 0 },
+  )
+})
+
 test('withProcessExitThrow treats null process.exit codes as success', async () => {
   await assert.rejects(
     withProcessExitThrow(() => {


### PR DESCRIPTION
## Summary
- add coverage that `withProcessExitThrow` preserves an explicit `process.exit(0)` code

## Tests
- `pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/testUtils/processExit.test.js`
- `pnpm --dir cli test`