### PR TITLE
Test stdout capture mutation restore

### DIFF
--- a/cli/src/testUtils/stdout.test.ts
+++ b/cli/src/testUtils/stdout.test.ts
@@ -142,6 +142,26 @@ test('captureStderr restores the writer after sync callbacks', async () => {
   assert.equal(process.stderr.write, originalWrite)
 })
 
+test('captureStdout restores the writer after callback mutations', async () => {
+  const originalWrite = process.stdout.write
+
+  await captureStdout(() => {
+    process.stdout.write = (() => true) as typeof process.stdout.write
+  })
+
+  assert.equal(process.stdout.write, originalWrite)
+})
+
+test('captureStderr restores the writer after callback mutations', async () => {
+  const originalWrite = process.stderr.write
+
+  await captureStderr(() => {
+    process.stderr.write = (() => true) as typeof process.stderr.write
+  })
+
+  assert.equal(process.stderr.write, originalWrite)
+})
+
 test('captureStdout restores the writer after async callbacks', async () => {
   const originalWrite = process.stdout.write
 


### PR DESCRIPTION
## Summary
- add stdout/stderr capture helper coverage for callback-side writer mutations

## Verification
- pnpm run build && node --test --test-concurrency=1 dist/testUtils/stdout.test.js
- pnpm test