### PR TITLE
chore(cli): type MCP capability groups

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -7,6 +7,8 @@ import {
   handleGetCapabilities,
   handleListKeyframeableProperties,
   MCP_TOOLS,
+  QUERY_TOOLS,
+  VALIDATION_TOOLS,
   type McpToolName,
 } from './tools/capabilities.js'
 import { TOOLS } from './server.js'
@@ -157,11 +159,11 @@ function parseCapabilitiesJson(result: CallToolResult): GetCapabilitiesToolPaylo
       'patchOperations',
       PATCH_OPERATION_TYPES,
     ),
-    queryTools: requiredKnownStringArray(parsedObject, 'queryTools', MCP_TOOLS),
+    queryTools: requiredKnownStringArray(parsedObject, 'queryTools', QUERY_TOOLS),
     validationTools: requiredKnownStringArray(
       parsedObject,
       'validationTools',
-      MCP_TOOLS,
+      VALIDATION_TOOLS,
     ),
     renderFormats: requiredKnownStringArray(parsedObject, 'renderFormats', RENDER_FORMATS),
     renderQualities: requiredKnownStringArray(

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -23,8 +23,8 @@ export const MCP_TOOLS = [
 ] as const
 export type McpToolName = (typeof MCP_TOOLS)[number]
 
-const VALIDATION_TOOLS = ['validate_scene'] as const satisfies readonly McpToolName[]
-const QUERY_TOOLS = [
+export const VALIDATION_TOOLS = ['validate_scene'] as const satisfies readonly McpToolName[]
+export const QUERY_TOOLS = [
   'list_layers',
   'get_layer',
   'list_tracks',


### PR DESCRIPTION
## Summary
- export the MCP validation/query capability group constants
- use those narrower groups when parsing capability test payloads

## Tests
- pnpm --dir cli test