### PR TITLE
Cover hidden output suffix format inference

### DIFF
--- a/cli/src/renderOptions.test.ts
+++ b/cli/src/renderOptions.test.ts
@@ -73,6 +73,11 @@ test('inferRenderFormatFromPath recognizes supported suffixes on hidden files', 
   assert.equal(inferRenderFormatFromPath('/tmp/.draft.WEBM'), 'webm')
 })
 
+test('inferRenderFormatFromPath ignores URL-style suffixes on hidden files', () => {
+  assert.equal(inferRenderFormatFromPath('/tmp/.preview.gif?download=1'), 'gif')
+  assert.equal(inferRenderFormatFromPath('/tmp/.draft.WEBM#preview'), 'webm')
+})
+
 test('inferRenderFormatFromPath trims surrounding whitespace', () => {
   assert.equal(inferRenderFormatFromPath(' /tmp/demo.gif '), 'gif')
 })


### PR DESCRIPTION
## Summary
- add CLI render format inference coverage for hidden filenames with URL-style suffixes

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/renderOptions.test.js
- pnpm --dir cli test

Ready for review.