### PR TITLE
Tighten render command dependency typing

### DIFF
--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -42,11 +42,14 @@ interface RenderOptions {
 }
 
 export interface RenderCommandDeps {
-  locateApp?: () => Promise<string | null>
-  driveRender?: (req: HeadlessRenderRequest) => Promise<void>
-  existsSync?: typeof fs.existsSync
-  mkdirSync?: (path: fs.PathLike, options?: fs.MakeDirectoryOptions) => string | undefined | void
-  statSync?: (path: fs.PathLike) => fs.Stats
+  readonly locateApp?: () => Promise<string | null>
+  readonly driveRender?: (req: HeadlessRenderRequest) => Promise<void>
+  readonly existsSync?: typeof fs.existsSync
+  readonly mkdirSync?: (
+    path: fs.PathLike,
+    options?: fs.MakeDirectoryOptions,
+  ) => string | undefined | void
+  readonly statSync?: (path: fs.PathLike) => fs.Stats
 }
 
 export function renderCommand(deps: RenderCommandDeps = {}): Command {


### PR DESCRIPTION
## Summary
- Mark render command dependency injection hooks as readonly
- Wrap the mkdirSync dependency type for readability

## Verification
- pnpm --dir cli test -- render.test.ts

Note: root `pnpm typecheck` currently fails on existing app-wide TypeScript errors outside this CLI type-only change.