### PR TITLE
Tighten create_scene MCP argument validation

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -186,6 +186,17 @@ test('create_scene reports invalid arguments as MCP errors', async () => {
   assert.match(assertToolText(result), /^create_scene: invalid arguments/)
 })
 
+test('create_scene rejects unknown arguments as MCP errors', async () => {
+  const result = await handleCreateScene({
+    output: '/tmp/scene.hype',
+    scene: {},
+    unexpected: true,
+  })
+
+  assert.equal(result.isError, true)
+  assert.match(assertToolText(result), /^create_scene: invalid arguments/)
+})
+
 test('create_scene rejects array scene JSON', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-array-scene-'))
 

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -52,7 +52,7 @@ const CreateInput = z.object({
     .boolean()
     .default(true)
     .describe('Open the newly-created scene in the desktop app. Defaults to true.'),
-})
+}).strict()
 type CreateInputData = z.infer<typeof CreateInput>
 
 const KEYFRAMEABLE_PROPERTY_DESCRIPTION = PROPERTY_IDS.join(', ')


### PR DESCRIPTION
## Summary
- make the create_scene MCP runtime parser reject unknown arguments like its published schema
- add a focused regression test for unknown create_scene arguments

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/createScene.test.js
- pnpm --dir cli test