### PR TITLE
Clarify MCP scene path schema descriptions

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -17,7 +17,7 @@ test('info_scene input schema exposes required scene path', () => {
         type: 'string',
         minLength: 1,
         pattern: '\\S',
-        description: 'Path to a .hype scene file.',
+        description: 'Absolute or relative path to a .hype scene file.',
       },
     },
     required: ['scene'],
@@ -28,7 +28,7 @@ test('info_scene input schema exposes required scene path', () => {
 test('info_scene description does not require absolute paths', () => {
   const description = infoSceneTool.description ?? ''
   assert.match(description, /Pass the path to the \.hype file\./)
-  assert.doesNotMatch(description, /absolute path/i)
+  assert.doesNotMatch(description, /absolute path only/i)
 })
 
 test('info_scene reports invalid arguments as MCP errors', async () => {

--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -28,7 +28,7 @@ test('query scene MCP tool schemas describe their path and node id inputs', () =
     assert.equal(sceneProperty?.type, 'string')
     assert.equal(sceneProperty?.minLength, 1)
     assert.equal(sceneProperty?.pattern, '\\S')
-    assert.equal(sceneProperty?.description, 'Path to a .hype scene file.')
+    assert.equal(sceneProperty?.description, 'Absolute or relative path to a .hype scene file.')
     assert.ok(Array.isArray(tool.inputSchema.required))
     assert.ok(tool.inputSchema.required.includes('scene'))
     assert.equal(tool.inputSchema.additionalProperties, false)

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -13,7 +13,7 @@ import fs from 'node:fs'
 import { readSceneSummary, type SceneSummary } from '../../scene/build.js'
 
 const InfoInput = z.object({
-  scene: z.string().trim().min(1, 'scene path is required').describe('Path to a .hype scene file.'),
+  scene: z.string().trim().min(1, 'scene path is required').describe('Absolute or relative path to a .hype scene file.'),
 }).strict()
 type InfoInputData = z.infer<typeof InfoInput>
 
@@ -30,7 +30,7 @@ export const infoSceneTool: Tool = {
         type: 'string',
         minLength: 1,
         pattern: '\\S',
-        description: 'Path to a .hype scene file.',
+        description: 'Absolute or relative path to a .hype scene file.',
       },
     },
     required: ['scene'],

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -44,7 +44,7 @@ const SCENE_PATH_PROPERTY: StringSchemaProperty = {
   type: 'string',
   minLength: 1,
   pattern: '\\S',
-  description: 'Path to a .hype scene file.',
+  description: 'Absolute or relative path to a .hype scene file.',
 }
 
 const NODE_ID_PROPERTY: StringSchemaProperty = {

--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs'
 import { validateScene, type SceneValidationResult } from '../../scene/build.js'
 
 const ValidateInput = z.object({
-  scene: z.string().trim().min(1, 'scene path is required').describe('Path to a .hype scene file.'),
+  scene: z.string().trim().min(1, 'scene path is required').describe('Absolute or relative path to a .hype scene file.'),
 }).strict()
 type ValidateInputData = z.infer<typeof ValidateInput>
 
@@ -21,7 +21,7 @@ export const validateSceneTool: Tool = {
         type: 'string',
         minLength: 1,
         pattern: '\\S',
-        description: 'Path to a .hype scene file.',
+        description: 'Absolute or relative path to a .hype scene file.',
       },
     },
     required: ['scene'],

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -16,7 +16,7 @@ test('validate_scene input schema exposes required scene path', () => {
         type: 'string',
         minLength: 1,
         pattern: '\\S',
-        description: 'Path to a .hype scene file.',
+        description: 'Absolute or relative path to a .hype scene file.',
       },
     },
     required: ['scene'],
@@ -27,7 +27,7 @@ test('validate_scene input schema exposes required scene path', () => {
 test('validate_scene description does not require absolute paths', () => {
   const description = validateSceneTool.description ?? ''
   assert.match(description, /Pass the path to the \.hype file\./)
-  assert.doesNotMatch(description, /absolute path/i)
+  assert.doesNotMatch(description, /absolute path only/i)
 })
 
 test('validate_scene reports invalid arguments as MCP errors', async () => {


### PR DESCRIPTION
## Summary
- Clarify MCP scene path schema descriptions for info, validate, and query tools to say paths may be absolute or relative
- Update the schema assertions that pin those agent-facing descriptions

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/infoScene.test.js cli/dist/mcp/validateScene.test.js cli/dist/mcp/queryScene.test.js
- pnpm --dir cli test