### PR TITLE
test: cover uppercase macOS app bundle overrides

### DIFF
--- a/cli/src/electron/locator.test.ts
+++ b/cli/src/electron/locator.test.ts
@@ -73,6 +73,23 @@ test('locator accepts a HYPERMOTION_APP_PATH macOS app bundle', async () => {
   }
 })
 
+test('locator accepts a HYPERMOTION_APP_PATH macOS app bundle case-insensitively', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-bundle-case-'))
+  const bundlePath = path.join(dir, 'hyper-motion.APP')
+  const binaryPath = path.join(bundlePath, 'Contents', 'MacOS', 'hyper-motion')
+
+  try {
+    fs.mkdirSync(path.dirname(binaryPath), { recursive: true })
+    fs.writeFileSync(binaryPath, '')
+
+    await withEnvVar('HYPERMOTION_APP_PATH', bundlePath, async () => {
+      assert.equal(await locateDesktopApp(), binaryPath)
+    })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('locator rejects a missing HYPERMOTION_APP_PATH override', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-missing-'))
   const missingPath = path.join(dir, 'hyper-motion')


### PR DESCRIPTION
## Summary
- add locator coverage for uppercase macOS .APP bundle override paths

## Tests
- pnpm --dir cli run build && node --test cli/dist/electron/locator.test.js
- pnpm test