### PR TITLE
chore(cli): mark create output schema non-blank

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -13,6 +13,7 @@ test('create_scene input schema marks output as non-empty', () => {
   assert.deepEqual(createSceneTool.inputSchema.properties?.output, {
     type: 'string',
     minLength: 1,
+    pattern: '\\S',
     description: 'Absolute, non-blank path to write the .hype file to.',
   })
 })

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -95,6 +95,7 @@ export const createSceneTool: Tool = {
       output: {
         type: 'string',
         minLength: 1,
+        pattern: '\\S',
         description: 'Absolute, non-blank path to write the .hype file to.',
       },
       scene: {


### PR DESCRIPTION
## Summary
- Advertise a non-whitespace pattern for the create_scene MCP output path schema.
- Update the schema assertion to keep the test in sync.

## Tests
- pnpm test