### PR TITLE
Stabilize driver error sentinel test

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -67,7 +67,8 @@ test('driveHeadlessRender surfaces plain-text error sentinels', async () => {
       "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
       "const out = outArg?.slice('--out='.length);",
       "if (!out) process.exit(2);",
-      "await import('node:fs').then((fs) => fs.writeFileSync(`${out}.error`, 'encoder failed before JSON'))",
+      "const fs = await import('node:fs');",
+      "fs.writeFileSync(`${out}.error`, 'encoder failed before JSON');",
     ].join('\n'),
   )
   fs.chmodSync(appPath, 0o755)


### PR DESCRIPTION
## Summary
- simplify the plain-text error sentinel fake app fixture to import fs the same way as the other driver fixtures
- avoids the fixture occasionally failing to write its sentinel before the render timeout

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js
- pnpm --dir cli test