### PR TITLE
Tighten MCP capabilities test types

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -10,6 +10,7 @@ import {
   QUERY_TOOLS,
   VALIDATION_TOOLS,
   type McpToolName,
+  type QueryToolName,
 } from './tools/capabilities.js'
 import { TOOLS } from './server.js'
 import {
@@ -37,8 +38,8 @@ type GetCapabilitiesToolPayload = {
   }
   nodeKinds: readonly NodeKindJson[]
   patchOperations: readonly PatchOperation['op'][]
-  queryTools: readonly McpToolName[]
-  validationTools: readonly McpToolName[]
+  queryTools: readonly QueryToolName[]
+  validationTools: readonly (typeof VALIDATION_TOOLS)[number][]
   renderFormats: readonly RenderFormat[]
   renderQualities: readonly RenderQuality[]
   renderFileSceneInput: boolean


### PR DESCRIPTION
## Summary
- Narrow MCP capabilities test payload types for query and validation tool arrays
- Keep assertions aligned with the exported tool-name constants

## Verification
- pnpm --dir cli test

Note: root `pnpm typecheck` was also attempted and fails on pre-existing app-wide TypeScript errors unrelated to this change.