### PR TITLE
test(cli): cover render scene schema types

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -47,6 +47,8 @@ test('render_scene input schema exposes render preset enums', () => {
   const formatProperty = schemaProperty('format')
   const qualityProperty = schemaProperty('quality')
 
+  assert.equal(formatProperty?.type, 'string')
+  assert.equal(qualityProperty?.type, 'string')
   assert.deepEqual(formatProperty?.enum, [...RENDER_FORMATS])
   assert.deepEqual(qualityProperty?.enum, [...RENDER_QUALITIES])
 })


### PR DESCRIPTION
## Summary
- Assert render_scene format and quality schema entries are declared as string properties.

## Verification
- pnpm --dir cli test -- --test-name-pattern='render_scene input schema exposes render preset enums'