### PR TITLE
Make spawn failure driver test deterministic

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -92,9 +92,10 @@ test('driveHeadlessRender surfaces plain-text error sentinels', async () => {
 
 test('driveHeadlessRender removes stale files before spawn failures', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
-  const appPath = path.join(dir, 'missing-app')
+  const appPath = path.join(dir, 'not-executable-app')
   const outputPath = path.join(dir, 'out.mp4')
 
+  fs.writeFileSync(appPath, 'not executable')
   fs.writeFileSync(outputPath, 'stale output')
   fs.writeFileSync(`${outputPath}.done`, 'stale sentinel')
   fs.writeFileSync(`${outputPath}.error`, 'stale failure')


### PR DESCRIPTION
## Summary\n- use a non-executable fake app fixture for the driver spawn-failure cleanup test\n- avoids the slow missing-binary spawn path while preserving stale output/sentinel cleanup coverage\n\n## Tests\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js\n- pnpm test