### PR TITLE
Validate no-argument MCP tool inputs

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -113,6 +113,18 @@ test('capability tool schemas accept no arguments', () => {
   })
 })
 
+test('capability tools reject unknown arguments as MCP errors', async () => {
+  const capabilities = await handleGetCapabilities({ output: 'capabilities.json' })
+  const keyframeable = await handleListKeyframeableProperties({ property: 'opacity' })
+
+  assert.equal(capabilities.isError, true)
+  assert.match(assertToolText(capabilities), /^get_capabilities: invalid arguments/)
+  assert.match(assertToolText(capabilities), /Unrecognized key/)
+  assert.equal(keyframeable.isError, true)
+  assert.match(assertToolText(keyframeable), /^list_keyframeable_properties: invalid arguments/)
+  assert.match(assertToolText(keyframeable), /Unrecognized key/)
+})
+
 test('get_capabilities description mentions agent-facing capability groups', () => {
   const getCapabilities = TOOLS.find((tool) => tool.name === 'get_capabilities')
   const description = getCapabilities?.description ?? ''

--- a/cli/src/mcp/doctor.test.ts
+++ b/cli/src/mcp/doctor.test.ts
@@ -20,6 +20,14 @@ test('doctor input schema accepts no arguments', () => {
   })
 })
 
+test('doctor rejects unknown arguments as MCP errors', async () => {
+  const result = await handleDoctor({ verbose: true })
+
+  assert.equal(result.isError, true)
+  assert.match(assertToolText(result), /^doctor: invalid arguments/)
+  assert.match(assertToolText(result), /Unrecognized key/)
+})
+
 test('doctor returns the report as MCP JSON content', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-mcp-doctor-missing-'))
   try {

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -95,9 +95,9 @@ export async function startMcpServer(): Promise<void> {
     try {
       switch (name) {
         case 'doctor':
-          return await handleDoctor()
+          return await handleDoctor(args ?? {})
         case 'get_capabilities':
-          return await handleGetCapabilities()
+          return await handleGetCapabilities(args ?? {})
         case 'render_scene':
           return await handleRenderScene(args ?? {})
         case 'info_scene':
@@ -121,7 +121,7 @@ export async function startMcpServer(): Promise<void> {
         case 'open_scene':
           return await handleOpenScene(args ?? {})
         case 'list_keyframeable_properties':
-          return await handleListKeyframeableProperties()
+          return await handleListKeyframeableProperties(args ?? {})
         default:
           return textToolResult(`Unknown tool: ${name}`, true)
       }

--- a/cli/src/mcp/tools/capabilities.ts
+++ b/cli/src/mcp/tools/capabilities.ts
@@ -3,7 +3,11 @@
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import { NODE_KINDS, PATCH_OPERATION_TYPES, PROPERTY_IDS } from '../../scene/build.js'
 import { RENDER_FORMATS, RENDER_QUALITIES } from '../../renderOptions.js'
-import { EMPTY_OBJECT_INPUT_SCHEMA } from './schema.js'
+import {
+  EMPTY_OBJECT_INPUT_SCHEMA,
+  rejectUnexpectedEmptyArgs,
+  type McpToolArgs,
+} from './schema.js'
 
 export const MCP_TOOLS = [
   'doctor',
@@ -67,7 +71,10 @@ export const listKeyframeablePropertiesTool: Tool = {
   inputSchema: EMPTY_OBJECT_INPUT_SCHEMA,
 }
 
-export async function handleGetCapabilities(): Promise<CallToolResult> {
+export async function handleGetCapabilities(args: McpToolArgs = {}): Promise<CallToolResult> {
+  const invalidArgsMessage = rejectUnexpectedEmptyArgs('get_capabilities', args)
+  if (invalidArgsMessage !== null) return text(invalidArgsMessage, true)
+
   const payload: CapabilitiesPayload = {
     sceneExtension: '.hype',
     mcpTools: MCP_TOOLS,
@@ -87,7 +94,12 @@ export async function handleGetCapabilities(): Promise<CallToolResult> {
   return text(payload)
 }
 
-export async function handleListKeyframeableProperties(): Promise<CallToolResult> {
+export async function handleListKeyframeableProperties(
+  args: McpToolArgs = {},
+): Promise<CallToolResult> {
+  const invalidArgsMessage = rejectUnexpectedEmptyArgs('list_keyframeable_properties', args)
+  if (invalidArgsMessage !== null) return text(invalidArgsMessage, true)
+
   const payload: KeyframeablePropertiesPayload = {
     keyframeableProperties: PROPERTY_IDS,
   }
@@ -95,8 +107,14 @@ export async function handleListKeyframeableProperties(): Promise<CallToolResult
   return text(payload)
 }
 
-function text(value: CapabilityToolPayload): CallToolResult {
+function text(value: CapabilityToolPayload | string, isError?: boolean): CallToolResult {
   return {
-    content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }],
+    isError,
+    content: [
+      {
+        type: 'text' as const,
+        text: typeof value === 'string' ? value : JSON.stringify(value, null, 2),
+      },
+    ],
   }
 }

--- a/cli/src/mcp/tools/doctor.ts
+++ b/cli/src/mcp/tools/doctor.ts
@@ -2,7 +2,11 @@
 
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import { getDoctorReport } from '../../commands/doctor.js'
-import { EMPTY_OBJECT_INPUT_SCHEMA } from './schema.js'
+import {
+  EMPTY_OBJECT_INPUT_SCHEMA,
+  rejectUnexpectedEmptyArgs,
+  type McpToolArgs,
+} from './schema.js'
 
 export const doctorTool: Tool = {
   name: 'doctor',
@@ -10,7 +14,15 @@ export const doctorTool: Tool = {
   inputSchema: EMPTY_OBJECT_INPUT_SCHEMA,
 }
 
-export async function handleDoctor(): Promise<CallToolResult> {
+export async function handleDoctor(args: McpToolArgs = {}): Promise<CallToolResult> {
+  const invalidArgsMessage = rejectUnexpectedEmptyArgs('doctor', args)
+  if (invalidArgsMessage !== null) {
+    return {
+      isError: true,
+      content: [{ type: 'text' as const, text: invalidArgsMessage }],
+    }
+  }
+
   return {
     content: [
       {

--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -10,3 +10,12 @@ export const EMPTY_OBJECT_INPUT_SCHEMA = {
   required: [],
   additionalProperties: false,
 } as const satisfies Tool['inputSchema']
+
+export function rejectUnexpectedEmptyArgs(
+  toolName: string,
+  args: McpToolArgs,
+): string | null {
+  const keys = Object.keys(args)
+  if (keys.length === 0) return null
+  return `${toolName}: invalid arguments — Unrecognized key(s): ${keys.join(', ')}`
+}


### PR DESCRIPTION
## Summary
- reject unexpected arguments for no-argument MCP handlers
- route MCP request args to doctor and capability handlers
- add focused tests for unknown argument rejection

## Tests
- pnpm --dir cli test