### PR TITLE
test(cli): cover app bundle override slash

### DIFF
--- a/cli/src/electron/locator.test.ts
+++ b/cli/src/electron/locator.test.ts
@@ -73,6 +73,23 @@ test('locator accepts a HYPERMOTION_APP_PATH macOS app bundle', async () => {
   }
 })
 
+test('locator accepts a HYPERMOTION_APP_PATH macOS app bundle with trailing slash', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-bundle-slash-'))
+  const bundlePath = path.join(dir, 'hyper-motion.app')
+  const binaryPath = path.join(bundlePath, 'Contents', 'MacOS', 'hyper-motion')
+
+  try {
+    fs.mkdirSync(path.dirname(binaryPath), { recursive: true })
+    fs.writeFileSync(binaryPath, '')
+
+    await withEnvVar('HYPERMOTION_APP_PATH', `${bundlePath}${path.sep}`, async () => {
+      assert.equal(await locateDesktopApp(), binaryPath)
+    })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('locator accepts a HYPERMOTION_APP_PATH macOS app bundle case-insensitively', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-bundle-case-'))
   const bundlePath = path.join(dir, 'hyper-motion.APP')


### PR DESCRIPTION
## Summary
- add CLI locator coverage for macOS .app bundle overrides with a trailing slash

## Verification
- pnpm --dir cli test