### PR TITLE
Use shared MCP tool args type

### DIFF
--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -34,6 +34,7 @@ import {
   type SceneJson,
 } from '../../scene/build.js'
 import { pushSceneToRunningApp } from '../../electron/live.js'
+import type { McpToolArgs } from './schema.js'
 
 const CreateInput = z.object({
   output: z
@@ -115,7 +116,7 @@ export const createSceneTool: Tool = {
 }
 
 export async function handleCreateScene(
-  args: Record<string, unknown>,
+  args: McpToolArgs,
 ): Promise<CallToolResult> {
   const parsed = CreateInput.safeParse(args)
   if (!parsed.success) {

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -11,6 +11,7 @@ import { z } from 'zod'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
 import { readSceneSummary, type SceneSummary } from '../../scene/build.js'
+import type { McpToolArgs } from './schema.js'
 
 const InfoInput = z.object({
   scene: z.string().trim().min(1, 'scene path is required').describe('Absolute or relative path to a .hype scene file.'),
@@ -39,7 +40,7 @@ export const infoSceneTool: Tool = {
 }
 
 export async function handleInfoScene(
-  args: Record<string, unknown>,
+  args: McpToolArgs,
 ): Promise<CallToolResult> {
   const parsed = InfoInput.safeParse(args)
   if (!parsed.success) {

--- a/cli/src/mcp/tools/inspectScene.ts
+++ b/cli/src/mcp/tools/inspectScene.ts
@@ -5,6 +5,7 @@ import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
 import path from 'node:path'
 import { inspectScene } from '../../scene/build.js'
+import type { McpToolArgs } from './schema.js'
 
 const InspectInput = z.object({
   scene: z
@@ -34,7 +35,7 @@ export const inspectSceneTool: Tool = {
 }
 
 export async function handleInspectScene(
-  args: Record<string, unknown>,
+  args: McpToolArgs,
 ): Promise<CallToolResult> {
   const parsed = InspectInput.safeParse(args)
   if (!parsed.success) {

--- a/cli/src/mcp/tools/patchScene.ts
+++ b/cli/src/mcp/tools/patchScene.ts
@@ -6,6 +6,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { applyScenePatch, type PatchOperation, type ScenePatch } from '../../scene/build.js'
 import { pushSceneToRunningApp } from '../../electron/live.js'
+import type { McpToolArgs } from './schema.js'
 
 const PatchInput = z.object({
   scene: z.string().trim().min(1, 'scene path is required').describe('Path to the input .hype scene file.'),
@@ -45,7 +46,7 @@ export const patchSceneTool: Tool = {
 }
 
 export async function handlePatchScene(
-  args: Record<string, unknown>,
+  args: McpToolArgs,
 ): Promise<CallToolResult> {
   const parsed = PatchInput.safeParse(args)
   if (!parsed.success) {

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -23,6 +23,7 @@ import {
   inferRenderFormatFromPath,
 } from '../../renderOptions.js'
 import type { RenderFormat, RenderQuality } from '../../renderOptions.js'
+import type { McpToolArgs } from './schema.js'
 
 const RenderInput = z.object({
   output: z
@@ -142,7 +143,7 @@ export const renderSceneTool: Tool = {
 }
 
 export async function handleRenderScene(
-  args: Record<string, unknown>,
+  args: McpToolArgs,
   deps: RenderSceneDeps = defaultDeps,
 ): Promise<CallToolResult> {
   const parsed = RenderInput.safeParse(args)

--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
 import { validateScene, type SceneValidationResult } from '../../scene/build.js'
+import type { McpToolArgs } from './schema.js'
 
 const ValidateInput = z.object({
   scene: z.string().trim().min(1, 'scene path is required').describe('Absolute or relative path to a .hype scene file.'),
@@ -30,7 +31,7 @@ export const validateSceneTool: Tool = {
 }
 
 export async function handleValidateScene(
-  args: Record<string, unknown>,
+  args: McpToolArgs,
 ): Promise<CallToolResult> {
   const parsed = ValidateInput.safeParse(args)
   if (!parsed.success) {


### PR DESCRIPTION
## Summary
- Reuse the shared `McpToolArgs` alias across MCP scene tool handlers
- Keep handler argument typing consistent with `open_scene`

## Tests
- `pnpm --dir cli test`