### PR TITLE
test(cli): cover parented camera validation

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1093,6 +1093,22 @@ test('validateScene rejects non-frame root nodes', () => {
   assert.deepEqual(result.errors, ['scene.root is not a frame node: title'])
 })
 
+test('validateScene rejects cameras parented inside frames', () => {
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  const camera = scene.nodes?.camera
+  if (!root || !camera) throw new Error('missing sample nodes')
+  root.children = [...(root.children ?? []), 'camera']
+  camera.parent = 'root'
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'camera node camera must be scene-level with parent: null',
+  ])
+})
+
 test('validateScene rejects non-string root ids', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))


### PR DESCRIPTION
## Summary
- add CLI scene validation coverage for cameras parented inside frames
- documents the existing single scene-level camera constraint through a regression test

## Tests
- pnpm --dir cli test