### PR TITLE
test(cli): tighten info canvas fixture typing

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -12,7 +12,11 @@ import { captureStderr, captureStdout } from '../testUtils/stdout.js'
 
 type PersistedSceneInput = Parameters<typeof buildSceneBytes>[0]
 type PersistedSceneMeta = NonNullable<PersistedSceneInput['meta']>
-type MalformedPersistedCanvas = Record<string, unknown> & {
+type PersistedSceneCanvas = PersistedSceneMeta['canvas']
+type MalformedPersistedCanvas = Omit<
+  NonNullable<PersistedSceneCanvas>,
+  'width' | 'height'
+> & {
   width: string
   height: string
 }
@@ -402,11 +406,11 @@ test('info command replaces string canvas dimensions with placeholders', async (
   }
 })
 
-function stringCanvas(width: string, height: string): PersistedSceneMeta['canvas'] {
+function stringCanvas(width: string, height: string): PersistedSceneCanvas {
   const canvas: MalformedPersistedCanvas = { width, height }
   // Exercise the read path for malformed persisted scenes whose canvas
   // dimensions are not valid authoring input.
-  return canvas as unknown as PersistedSceneMeta['canvas']
+  return canvas as unknown as PersistedSceneCanvas
 }
 
 test('info command reports missing scene files', async () => {


### PR DESCRIPTION
## Summary
- add a named persisted canvas alias in the info command tests
- constrain the malformed canvas fixture type to the persisted canvas shape while keeping the intentional malformed dimensions isolated

## Verification
- pnpm --dir cli test -- info.test.ts