### PR TITLE
Remove unused inspect command options type

### DIFF
--- a/cli/src/commands/inspect.ts
+++ b/cli/src/commands/inspect.ts
@@ -5,16 +5,12 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { inspectScene } from '../scene/build.js'
 
-type InspectCommandOptions = {
-  json?: boolean
-}
-
 export function inspectCommand(): Command {
   return new Command('inspect')
     .description('Print the full editable scene graph for a .hype file.')
     .argument('<scene>', 'Path to a .hype scene file')
     .option('--json', 'Output JSON (default)', true)
-    .action((scenePath: string, _options: InspectCommandOptions) => {
+    .action((scenePath: string) => {
       const trimmedScenePath = scenePath.trim()
       if (!trimmedScenePath) {
         console.error('[inspect] scene path is required')


### PR DESCRIPTION
## Summary
- remove the unused inspect command options type and ignored action parameter

## Verification
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/commands/inspect.test.js
- pnpm --dir cli test