### PR TITLE
Tighten render option type guards

### DIFF
--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -8,15 +8,15 @@ export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
 export type RenderFormat = (typeof RENDER_FORMATS)[number]
 export type RenderQuality = (typeof RENDER_QUALITIES)[number]
 
-const RENDER_FORMAT_SET: ReadonlySet<RenderFormat> = new Set(RENDER_FORMATS)
-const RENDER_QUALITY_SET: ReadonlySet<RenderQuality> = new Set(RENDER_QUALITIES)
+const RENDER_FORMAT_SET: ReadonlySet<string> = new Set(RENDER_FORMATS)
+const RENDER_QUALITY_SET: ReadonlySet<string> = new Set(RENDER_QUALITIES)
 
 export function isRenderFormat(value: unknown): value is RenderFormat {
-  return typeof value === 'string' && RENDER_FORMAT_SET.has(value as RenderFormat)
+  return typeof value === 'string' && RENDER_FORMAT_SET.has(value)
 }
 
 export function isRenderQuality(value: unknown): value is RenderQuality {
-  return typeof value === 'string' && RENDER_QUALITY_SET.has(value as RenderQuality)
+  return typeof value === 'string' && RENDER_QUALITY_SET.has(value)
 }
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {


### PR DESCRIPTION
## Summary
- widen internal render option lookup sets to string sets
- remove assertions from render format and quality type guards

## Tests
- pnpm --dir cli test