### PR TITLE
Clarify patch_scene path schema descriptions

### DIFF
--- a/cli/src/mcp/patchScene.test.ts
+++ b/cli/src/mcp/patchScene.test.ts
@@ -17,13 +17,13 @@ test('patch_scene input schema exposes required scene and patch', () => {
         type: 'string',
         minLength: 1,
         pattern: '\\S',
-        description: 'Path to the input .hype scene file.',
+        description: 'Absolute or relative path to the input .hype scene file.',
       },
       output: {
         type: 'string',
         minLength: 1,
         pattern: '\\S',
-        description: 'Path to write. Defaults to overwriting scene.',
+        description: 'Absolute or relative path to write. Defaults to overwriting scene.',
       },
       patch: { description: 'Patch as { ops: [...] }, an operation array, or a JSON string.' },
       applyLive: {

--- a/cli/src/mcp/tools/patchScene.ts
+++ b/cli/src/mcp/tools/patchScene.ts
@@ -8,8 +8,8 @@ import { applyScenePatch, type PatchOperation, type ScenePatch } from '../../sce
 import { pushSceneToRunningApp } from '../../electron/live.js'
 
 const PatchInput = z.object({
-  scene: z.string().trim().min(1, 'scene path is required').describe('Path to the input .hype scene file.'),
-  output: z.string().trim().min(1, 'output path is required').optional().describe('Path to write. Defaults to overwriting scene.'),
+  scene: z.string().trim().min(1, 'scene path is required').describe('Absolute or relative path to the input .hype scene file.'),
+  output: z.string().trim().min(1, 'output path is required').optional().describe('Absolute or relative path to write. Defaults to overwriting scene.'),
   patch: z.union([z.string(), z.record(z.unknown()), z.array(z.record(z.unknown()))]),
   applyLive: z.boolean().optional().describe('Push the patched scene into the running desktop app. Defaults to true.'),
 })
@@ -26,13 +26,13 @@ export const patchSceneTool: Tool = {
         type: 'string',
         minLength: 1,
         pattern: '\\S',
-        description: 'Path to the input .hype scene file.',
+        description: 'Absolute or relative path to the input .hype scene file.',
       },
       output: {
         type: 'string',
         minLength: 1,
         pattern: '\\S',
-        description: 'Path to write. Defaults to overwriting scene.',
+        description: 'Absolute or relative path to write. Defaults to overwriting scene.',
       },
       patch: { description: 'Patch as { ops: [...] }, an operation array, or a JSON string.' },
       applyLive: {


### PR DESCRIPTION
## Summary
- clarify patch_scene MCP schema descriptions for scene and output paths
- keep the schema test in sync with the documented absolute-or-relative behavior

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/patchScene.test.js
- pnpm test