### PR TITLE
Validate blank create_scene output paths in schema

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -265,14 +265,15 @@ test('create_scene rejects relative output paths', async () => {
   assert.equal(assertToolText(result), 'create_scene: output must be an absolute path.')
 })
 
-test('create_scene rejects blank output paths', async () => {
+test('create_scene rejects blank output paths at schema validation', async () => {
   const result = await handleCreateScene({
     output: '   ',
     scene: { nodes: {} },
   })
 
   assert.equal(result.isError, true)
-  assert.equal(assertToolText(result), 'create_scene: output path is required')
+  assert.match(assertToolText(result), /^create_scene: invalid arguments/)
+  assert.match(assertToolText(result), /output path is required/)
 })
 
 test('create_scene rejects empty output paths at schema validation', async () => {

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -38,7 +38,8 @@ import { pushSceneToRunningApp } from '../../electron/live.js'
 const CreateInput = z.object({
   output: z
     .string()
-    .min(1)
+    .trim()
+    .min(1, 'output path is required')
     .describe('Absolute path to write the .hype file to. Parent dirs are created if missing.'),
   scene: z
     .union([
@@ -169,18 +170,7 @@ export async function handleCreateScene(
   // Make sure the output's parent directory exists. Agents tend to
   // specify deep paths and we don't want a simple ENOENT to obscure
   // the actual failure.
-  const outputPath = input.output.trim()
-  if (!outputPath) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text' as const,
-          text: 'create_scene: output path is required',
-        },
-      ],
-    }
-  }
+  const outputPath = input.output
   if (!path.isAbsolute(outputPath)) {
     return {
       isError: true,


### PR DESCRIPTION
## Summary
- Trim create_scene output paths in the Zod input schema
- Return the standard invalid-arguments MCP error for whitespace-only output paths
- Update the create_scene MCP test expectation

## Tests
- pnpm --dir cli test