### PR TITLE
test(cli): cover malformed MCP text content

### DIFF
--- a/cli/src/testUtils/mcp.test.ts
+++ b/cli/src/testUtils/mcp.test.ts
@@ -36,6 +36,17 @@ test('assertToolText reports missing text content clearly', () => {
   )
 })
 
+test('assertToolText rejects undefined content items', () => {
+  const result = {
+    content: [undefined],
+  } as unknown as CallToolResult
+
+  assert.throws(
+    () => assertToolText(result),
+    /expected first MCP content item to be text/,
+  )
+})
+
 test('assertToolText rejects non-text first content items', () => {
   const result: CallToolResult = {
     content: [{ type: 'image', data: 'base64-png', mimeType: 'image/png' }],


### PR DESCRIPTION
## Summary\n- Add test coverage for malformed MCP content where the sole content item is undefined.\n- Keeps the change scoped to the CLI MCP test helper.\n\n## Verification\n- pnpm --dir cli run build && node --test cli/dist/testUtils/mcp.test.js\n- pnpm --dir cli test