### PR TITLE
chore(cli): name scene metadata json type

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -6,13 +6,15 @@ import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { infoCommand } from './info.js'
-import { buildSceneBytes, type SceneSummary } from '../scene/build.js'
+import {
+  buildSceneBytes,
+  type SceneMetaJson,
+  type SceneSummary,
+} from '../scene/build.js'
 import { withProcessExitThrow } from '../testUtils/processExit.js'
 import { captureStderr, captureStdout } from '../testUtils/stdout.js'
 
-type PersistedSceneInput = Parameters<typeof buildSceneBytes>[0]
-type PersistedSceneMeta = NonNullable<PersistedSceneInput['meta']>
-type PersistedSceneCanvas = PersistedSceneMeta['canvas']
+type PersistedSceneCanvas = SceneMetaJson['canvas']
 type MalformedPersistedCanvas = Omit<
   NonNullable<PersistedSceneCanvas>,
   'width' | 'height'
@@ -23,7 +25,7 @@ type MalformedPersistedCanvas = Omit<
 
 function writeMinimalScene(
   scenePath: string,
-  meta: Pick<PersistedSceneMeta, 'name' | 'canvas'>,
+  meta: Pick<SceneMetaJson, 'name' | 'canvas'>,
 ): void {
   fs.writeFileSync(
     scenePath,

--- a/cli/src/commands/validate.test.ts
+++ b/cli/src/commands/validate.test.ts
@@ -5,15 +5,13 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
-import { buildSceneBytes } from '../scene/build.js'
+import { buildSceneBytes, type SceneJson } from '../scene/build.js'
 import { withProcessExitThrow } from '../testUtils/processExit.js'
 import { captureStderr, captureStdout } from '../testUtils/stdout.js'
 import { validateCommand } from './validate.js'
 
-type PersistedSceneInput = Parameters<typeof buildSceneBytes>[0]
-
-function malformedSceneInput(value: Record<string, unknown>): PersistedSceneInput {
-  return value as unknown as PersistedSceneInput
+function malformedSceneInput(value: Record<string, unknown>): SceneJson {
+  return value as unknown as SceneJson
 }
 
 test('validate command prints JSON validation results', async () => {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -26,18 +26,20 @@ import * as Y from 'yjs'
 // the schema below is the same shape the agent produces.
 
 export interface SceneJson {
-  meta?: {
-    id?: string
-    name?: string
-    duration?: number
-    frameRate?: number
-    canvas?: Partial<SceneCanvas>
-  }
+  meta?: SceneMetaJson
   root?: string
   activeCameraId?: string | null
   nodes?: Record<string, NodeJson>
   tracks?: Record<string, TrackJson>
   sections?: Record<string, SectionJson>
+}
+
+export interface SceneMetaJson {
+  id?: string
+  name?: string
+  duration?: number
+  frameRate?: number
+  canvas?: Partial<SceneCanvas>
 }
 
 export type TextAlignJson = 'start' | 'center' | 'end'


### PR DESCRIPTION
## Summary
- add an explicit exported SceneMetaJson type for CLI scene authoring metadata
- update command tests to use the named scene metadata/scene JSON types directly

## Verification
- pnpm --dir cli test