### PR TITLE
fix(cli): resolve info_scene paths

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -208,3 +208,41 @@ test('info_scene trims padded scene paths before reading', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('info_scene resolves padded relative scene paths before reading', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-relative-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const previousCwd = process.cwd()
+
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Relative Info MCP',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+    process.chdir(dir)
+
+    const result = await handleInfoScene({ scene: ' ./scene.hype ' })
+    const summary = JSON.parse(assertToolText(result)) as SceneSummary
+
+    assert.equal(result.isError, undefined)
+    assert.equal(summary.meta.name, 'Relative Info MCP')
+  } finally {
+    process.chdir(previousCwd)
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -10,6 +10,7 @@
 import { z } from 'zod'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
+import path from 'node:path'
 import { readSceneSummary, type SceneSummary } from '../../scene/build.js'
 
 const InfoInput = z.object({
@@ -55,13 +56,14 @@ export async function handleInfoScene(
   }
 
   const input: InfoInputData = parsed.data
-  const scenePath = input.scene.trim()
-  if (!scenePath) {
+  const trimmedScenePath = input.scene.trim()
+  if (!trimmedScenePath) {
     return {
       isError: true,
       content: [{ type: 'text' as const, text: 'info_scene: scene path is required' }],
     }
   }
+  const scenePath = path.resolve(trimmedScenePath)
   let bytes: Buffer
   try {
     const stats = fs.statSync(scenePath)


### PR DESCRIPTION
## Summary
- Normalize trimmed info_scene paths with path.resolve before stat/read/error handling
- Add coverage for padded relative info_scene paths

## Tests
- pnpm test