### PR TITLE
Avoid camera warning for camera-free scenes

### DIFF
--- a/cli/src/commands/validate.test.ts
+++ b/cli/src/commands/validate.test.ts
@@ -50,7 +50,7 @@ test('validate command prints JSON validation results', async () => {
     assert.deepEqual(JSON.parse(stdout), {
       ok: true,
       errors: [],
-      warnings: ['scene.activeCameraId is missing'],
+      warnings: [],
     })
     assert.equal(process.exitCode, previousExitCode)
   } finally {
@@ -164,7 +164,7 @@ test('validate command prints human-readable validation errors', async () => {
 
     assert.match(stdout, /^Scene is invalid$/m)
     assert.match(stdout, /^error: node root has missing child: missing-child$/m)
-    assert.match(stdout, /^warning: scene\.activeCameraId is missing$/m)
+    assert.doesNotMatch(stdout, /^warning: scene\.activeCameraId is missing$/m)
     assert.equal(process.exitCode, 1)
   } finally {
     process.exitCode = previousExitCode
@@ -206,7 +206,7 @@ test('validate command prints JSON validation errors', async () => {
     assert.deepEqual(JSON.parse(stdout), {
       ok: false,
       errors: ['node root has missing child: missing-child'],
-      warnings: ['scene.activeCameraId is missing'],
+      warnings: [],
     })
     assert.equal(process.exitCode, 1)
   } finally {

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -197,7 +197,7 @@ test('validate_scene returns validation JSON for readable scenes', async () => {
     assert.deepEqual(JSON.parse(assertToolText(result)), {
       ok: true,
       errors: [],
-      warnings: ['scene.activeCameraId is missing'],
+      warnings: [],
     })
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
@@ -268,7 +268,7 @@ test('validate_scene marks structurally invalid scenes as MCP errors', async () 
     assert.deepEqual(JSON.parse(assertToolText(result)), {
       ok: false,
       errors: ['node root has missing child: missing-child'],
-      warnings: ['scene.activeCameraId is missing'],
+      warnings: [],
     })
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })

--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -1013,6 +1013,18 @@ test('validateScene warns when no active camera is selected', () => {
   assert.deepEqual(result.warnings, ['scene.activeCameraId is missing'])
 })
 
+test('validateScene accepts scenes without cameras', () => {
+  const scene = sampleScene()
+  delete scene.nodes?.camera
+  scene.activeCameraId = null
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.equal(result.ok, true)
+  assert.deepEqual(result.errors, [])
+  assert.deepEqual(result.warnings, [])
+})
+
 test('validateScene rejects unsupported track property ids', () => {
   const doc = new Y.Doc()
   Y.applyUpdate(doc, buildSceneBytes(sampleScene()))

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -876,6 +876,9 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
   const tracks = asRecord(data.tracks)
   const root = typeof data.root === 'string' ? data.root : ''
   const activeCameraId = typeof data.activeCameraId === 'string' ? data.activeCameraId : ''
+  const cameraIds = Object.entries(nodes)
+    .filter(([, raw]) => asRecord(raw).kind === 'camera')
+    .map(([id]) => id)
 
   if (data.meta !== undefined && !isPlainObject(data.meta)) {
     errors.push('scene.meta must be an object')
@@ -902,9 +905,9 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
 
   if (data.activeCameraId !== undefined && data.activeCameraId !== null && typeof data.activeCameraId !== 'string') {
     errors.push('scene.activeCameraId must be a string')
-  } else if (!activeCameraId) warnings.push('scene.activeCameraId is missing')
-  else if (!nodes[activeCameraId]) errors.push(`scene.activeCameraId points to missing node: ${activeCameraId}`)
-  else if (asRecord(nodes[activeCameraId]).kind !== 'camera') {
+  } else if (!activeCameraId && cameraIds.length > 0) warnings.push('scene.activeCameraId is missing')
+  else if (activeCameraId && !nodes[activeCameraId]) errors.push(`scene.activeCameraId points to missing node: ${activeCameraId}`)
+  else if (activeCameraId && asRecord(nodes[activeCameraId]).kind !== 'camera') {
     errors.push(`scene.activeCameraId is not a camera node: ${activeCameraId}`)
   }
 
@@ -962,9 +965,6 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
     }
   }
 
-  const cameraIds = Object.entries(nodes)
-    .filter(([, raw]) => asRecord(raw).kind === 'camera')
-    .map(([id]) => id)
   if (cameraIds.length > 1) {
     errors.push(`scene has multiple camera nodes: ${cameraIds.join(', ')}`)
   }


### PR DESCRIPTION
## Summary
- suppress the active-camera warning when a scene has no camera nodes
- keep the warning for scenes that include cameras but have no active camera
- update CLI and MCP validation expectations

## Tests
- pnpm --dir cli test