### PR TITLE
test(cli): keep create scene output docs in sync

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -14,7 +14,8 @@ test('create_scene input schema marks output as non-empty', () => {
     type: 'string',
     minLength: 1,
     pattern: '\\S',
-    description: 'Absolute, non-blank path to write the .hype file to.',
+    description:
+      'Absolute, non-blank path to write the .hype file to. Parent dirs are created if missing.',
   })
 })
 

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -36,12 +36,15 @@ import {
 import { pushSceneToRunningApp } from '../../electron/live.js'
 import type { McpToolArgs } from './schema.js'
 
+const OUTPUT_PATH_DESCRIPTION =
+  'Absolute, non-blank path to write the .hype file to. Parent dirs are created if missing.'
+
 const CreateInput = z.object({
   output: z
     .string()
     .trim()
     .min(1, 'output path is required')
-    .describe('Absolute path to write the .hype file to. Parent dirs are created if missing.'),
+    .describe(OUTPUT_PATH_DESCRIPTION),
   scene: z
     .union([
       z.string().describe('A JSON string containing the SceneJson'),
@@ -98,7 +101,7 @@ export const createSceneTool: Tool = {
         type: 'string',
         minLength: 1,
         pattern: '\\S',
-        description: 'Absolute, non-blank path to write the .hype file to.',
+        description: OUTPUT_PATH_DESCRIPTION,
       },
       scene: {
         anyOf: [{ type: 'string' }, { type: 'object' }],


### PR DESCRIPTION
## Summary
- Reuse one shared create_scene output-path description across Zod and MCP JSON schemas
- Update the schema assertion so the exposed MCP contract includes the parent-directory behavior

## Tests
- pnpm --dir cli test