### PR TITLE
Handle blank JSON render errors

### DIFF
--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -224,7 +224,10 @@ function readRenderErrorMessage(errorPath: string): string | null {
     if (raw.length === 0) return null
     try {
       const data: unknown = JSON.parse(raw)
-      if (hasErrorMessage(data)) message = data.message.trim()
+      if (hasErrorMessage(data)) {
+        const trimmed = data.message.trim()
+        if (trimmed) message = trimmed
+      }
     } catch {
       if (raw.trimStart().startsWith('{')) return null
       const text = raw.trim()


### PR DESCRIPTION
## Summary\n- Treat JSON render error sentinels with blank messages as generic render failures instead of continuing to poll.\n\n## Tests\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js\n- pnpm test