### PR TITLE
Tighten query scene schema test helper

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -21,9 +21,21 @@ import {
 
 type ToolSchemaProperty = Record<string, unknown> | undefined
 
+function inputProperty(
+  tool: typeof listLayersTool,
+  name: string,
+): ToolSchemaProperty {
+  const property = tool.inputSchema.properties?.[name]
+  assert.ok(
+    property === undefined ||
+      (typeof property === 'object' && !Array.isArray(property)),
+  )
+  return property as ToolSchemaProperty
+}
+
 test('query scene MCP tool schemas describe their path and node id inputs', () => {
   for (const tool of [listLayersTool, getLayerTool, listTracksTool, listCamerasTool]) {
-    const sceneProperty = tool.inputSchema.properties?.scene as ToolSchemaProperty
+    const sceneProperty = inputProperty(tool, 'scene')
 
     assert.equal(sceneProperty?.type, 'string')
     assert.equal(sceneProperty?.minLength, 1)
@@ -39,13 +51,13 @@ test('query scene MCP tool schemas describe their path and node id inputs', () =
   assert.deepEqual(listTracksTool.inputSchema.required, ['scene'])
   assert.deepEqual(listCamerasTool.inputSchema.required, ['scene'])
 
-  const getNodeIdProperty = getLayerTool.inputSchema.properties?.nodeId as ToolSchemaProperty
+  const getNodeIdProperty = inputProperty(getLayerTool, 'nodeId')
   assert.equal(getNodeIdProperty?.type, 'string')
   assert.equal(getNodeIdProperty?.minLength, 1)
   assert.equal(getNodeIdProperty?.pattern, '\\S')
   assert.equal(getNodeIdProperty?.description, 'Stable layer/node id to return.')
 
-  const filterNodeIdProperty = listTracksTool.inputSchema.properties?.nodeId as ToolSchemaProperty
+  const filterNodeIdProperty = inputProperty(listTracksTool, 'nodeId')
   assert.equal(filterNodeIdProperty?.type, 'string')
   assert.equal(filterNodeIdProperty?.minLength, 1)
   assert.equal(filterNodeIdProperty?.pattern, '\\S')


### PR DESCRIPTION
## Summary
- add a small helper for query-scene MCP schema property assertions
- keep schema field checks the same while pairing the property cast with a runtime shape assertion

## Tests
- pnpm test