### PR TITLE
Clarify create_scene output schema test

### DIFF
--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -9,7 +9,7 @@ import { PROPERTY_IDS, readSceneSummary } from '../scene/build.js'
 import { assertToolText } from '../testUtils/mcp.js'
 import { createSceneTool, handleCreateScene } from './tools/createScene.js'
 
-test('create_scene input schema marks output as non-empty', () => {
+test('create_scene input schema marks output as absolute and non-empty', () => {
   assert.deepEqual(createSceneTool.inputSchema.properties?.output, {
     type: 'string',
     minLength: 1,


### PR DESCRIPTION
## Summary
- Rename the create_scene MCP schema test so it reflects the absolute-path output contract it already asserts.

## Verification
- pnpm --dir cli test -- createScene.test.js