### PR TITLE
docs(cli): mention MCP app path env

### DIFF
--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -16,10 +16,16 @@
  *
  *   claude mcp add -s user hypermotion -- hypermotion-mcp
  *
+ * If the desktop app is installed somewhere non-standard, include
+ * HYPERMOTION_APP_PATH in the registration environment.
+ *
  * To wire into Codex CLI, they add to ~/.codex/config.toml:
  *
  *   [mcp_servers.hypermotion]
  *   command = "hypermotion-mcp"
+ *
+ *   [mcp_servers.hypermotion.env]
+ *   HYPERMOTION_APP_PATH = "/Applications/hyper-motion.app/Contents/MacOS/hyper-motion"
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'


### PR DESCRIPTION
## Summary
- document HYPERMOTION_APP_PATH in the MCP server setup comment
- keep the Codex config example aligned with the agent setup guide

## Tests
- pnpm --dir cli test