### PR TITLE
fix(cli): clarify missing query scene files

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -159,10 +159,7 @@ test('query scene MCP handlers report missing scene files as MCP errors', async 
     for (const entry of cases) {
       const result = await entry.run()
       assert.equal(result.isError, true)
-      assert.match(
-        assertToolText(result),
-        new RegExp(`^${entry.name}: failed to read ${escapeRegExp(missingScene)}:`),
-      )
+      assert.equal(assertToolText(result), `${entry.name}: scene file not found: ${missingScene}`)
     }
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -192,6 +192,13 @@ function read(toolName: QuerySceneToolName, scenePath: string): ReadSceneResult 
 
   let bytes: Buffer
   try {
+    if (!fs.existsSync(normalizedScenePath)) {
+      return {
+        ok: false,
+        result: errorText(`${toolName}: scene file not found: ${normalizedScenePath}`),
+      }
+    }
+
     const stats = fs.statSync(normalizedScenePath)
     if (!stats.isFile()) {
       return {


### PR DESCRIPTION
## Summary
- report missing query MCP scene files with a clear file-not-found message
- update the query scene MCP test expectation for the clearer error

## Tests
- pnpm test