### PR TITLE
Type empty-args MCP tools

### DIFF
--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -3,6 +3,10 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js'
 
 export type McpToolArgs = Record<string, unknown>
+export type EmptyArgsToolName =
+  | 'doctor'
+  | 'get_capabilities'
+  | 'list_keyframeable_properties'
 
 export const EMPTY_OBJECT_INPUT_SCHEMA = {
   type: 'object',
@@ -12,7 +16,7 @@ export const EMPTY_OBJECT_INPUT_SCHEMA = {
 } as const satisfies Tool['inputSchema']
 
 export function rejectUnexpectedEmptyArgs(
-  toolName: string,
+  toolName: EmptyArgsToolName,
   args: McpToolArgs,
 ): string | null {
   const keys = Object.keys(args)


### PR DESCRIPTION
## Summary
- add a narrow EmptyArgsToolName union for shared empty-argument MCP schema validation
- keep rejectUnexpectedEmptyArgs limited to the empty-argument MCP tools that use it

## Tests
- pnpm --dir cli test