### PR TITLE
chore(cli): share MCP scene path schema constants

### DIFF
--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -13,8 +13,16 @@ import fs from 'node:fs'
 import { readSceneSummary, type SceneSummary } from '../../scene/build.js'
 import type { McpToolArgs } from './schema.js'
 
+const SCENE_PATH_DESCRIPTION = 'Absolute or relative path to a .hype scene file.'
+const SCENE_PATH_PROPERTY = {
+  type: 'string',
+  minLength: 1,
+  pattern: '\\S',
+  description: SCENE_PATH_DESCRIPTION,
+} as const
+
 const InfoInput = z.object({
-  scene: z.string().trim().min(1, 'scene path is required').describe('Absolute or relative path to a .hype scene file.'),
+  scene: z.string().trim().min(1, 'scene path is required').describe(SCENE_PATH_DESCRIPTION),
 }).strict()
 type InfoInputData = z.infer<typeof InfoInput>
 
@@ -27,12 +35,7 @@ export const infoSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: {
-        type: 'string',
-        minLength: 1,
-        pattern: '\\S',
-        description: 'Absolute or relative path to a .hype scene file.',
-      },
+      scene: SCENE_PATH_PROPERTY,
     },
     required: ['scene'],
     additionalProperties: false,

--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -6,8 +6,16 @@ import fs from 'node:fs'
 import { validateScene, type SceneValidationResult } from '../../scene/build.js'
 import type { McpToolArgs } from './schema.js'
 
+const SCENE_PATH_DESCRIPTION = 'Absolute or relative path to a .hype scene file.'
+const SCENE_PATH_PROPERTY = {
+  type: 'string',
+  minLength: 1,
+  pattern: '\\S',
+  description: SCENE_PATH_DESCRIPTION,
+} as const
+
 const ValidateInput = z.object({
-  scene: z.string().trim().min(1, 'scene path is required').describe('Absolute or relative path to a .hype scene file.'),
+  scene: z.string().trim().min(1, 'scene path is required').describe(SCENE_PATH_DESCRIPTION),
 }).strict()
 type ValidateInputData = z.infer<typeof ValidateInput>
 
@@ -28,12 +36,7 @@ export const validateSceneTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      scene: {
-        type: 'string',
-        minLength: 1,
-        pattern: '\\S',
-        description: 'Absolute or relative path to a .hype scene file.',
-      },
+      scene: SCENE_PATH_PROPERTY,
     },
     required: ['scene'],
     additionalProperties: false,


### PR DESCRIPTION
## Summary
- Hoist shared scene-path descriptions and schema objects in the info_scene and validate_scene MCP tools
- Keeps advertised MCP input schema and Zod descriptions aligned without changing behavior

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/infoScene.test.js cli/dist/mcp/validateScene.test.js
- pnpm test