### PR TITLE
test(cli): validate MCP text payloads

### DIFF
--- a/cli/src/testUtils/mcp.test.ts
+++ b/cli/src/testUtils/mcp.test.ts
@@ -57,3 +57,14 @@ test('assertToolText rejects non-text first content items', () => {
     /expected first MCP content item to be text/,
   )
 })
+
+test('assertToolText rejects malformed text payloads', () => {
+  const result = {
+    content: [{ type: 'text', text: undefined }],
+  } as unknown as CallToolResult
+
+  assert.throws(
+    () => assertToolText(result),
+    /expected MCP text content to be a string/,
+  )
+})

--- a/cli/src/testUtils/mcp.ts
+++ b/cli/src/testUtils/mcp.ts
@@ -9,6 +9,7 @@ export function assertToolText(result: CallToolResult): string {
   assert.equal(result.content.length, 1, 'expected exactly one MCP content item')
   const item = result.content[0]
   assert.ok(isToolTextContent(item), 'expected first MCP content item to be text')
+  assert.equal(typeof item.text, 'string', 'expected MCP text content to be a string')
   return item.text
 }
 


### PR DESCRIPTION
## Summary
- guard CLI MCP text test helper against malformed non-string text payloads
- add a focused unit test for malformed text content

## Verification
- pnpm test