### PR TITLE
chore(cli): type query scene schema test helper

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -19,7 +19,12 @@ import {
   listTracksTool,
 } from './tools/queryScene.js'
 
-type ToolSchemaProperty = Record<string, unknown> | undefined
+type ToolSchemaProperty = {
+  readonly type?: string
+  readonly minLength?: number
+  readonly pattern?: string
+  readonly description?: string
+} | undefined
 type PersistedNodeChildren = NonNullable<
   NonNullable<Parameters<typeof buildSceneBytes>[0]['nodes']>[string]['children']
 >


### PR DESCRIPTION
## Summary
- replace the loose query-scene schema test helper alias with the specific schema fields asserted by the tests

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/queryScene.test.js
- pnpm test