### PR TITLE
chore(figma): remove import frame debug log

### DIFF
--- a/src/import/figma/walk.ts
+++ b/src/import/figma/walk.ts
@@ -405,13 +405,6 @@ function createFrame(
   // case the heuristic gets wrong.
   const corner = maxCornerRadius(appearance)
   const importedClips = node.clipsContent && corner > 0
-  console.log(
-    `[figma-import]   frame "${node.name}" → ${size.width}×${size.height} ` +
-      `layout=${layout.mode}/${layout.direction} gap=${layout.gap} ` +
-      `padding=${layout.padding.top}/${layout.padding.right}/` +
-      `${layout.padding.bottom}/${layout.padding.left} ` +
-      `clip=${importedClips}(figma=${node.clipsContent},corner=${corner})`,
-  )
   const id = api.createNode('frame', parentId, {
     name: node.name || 'Frame',
     visible: node.visible,


### PR DESCRIPTION
## Summary
- Remove a stray per-frame Figma import debug log from `src/import/figma/walk.ts`.
- Keeps the existing clip heuristic and imported scene behavior unchanged.

## Verification
- PASS: `pnpm test`
- PASS: `pnpm exec eslint src/import/figma/walk.ts`
- INFO: `pnpm lint` still fails on pre-existing unrelated repo issues.
- INFO: `pnpm typecheck` still fails on pre-existing unrelated repo issues.