### PR TITLE
Stabilize info command stat test cleanup

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -462,6 +462,7 @@ test('info command reports stat failures as read errors', async () => {
   const originalStatSync = fs.statSync
   try {
     Object.defineProperty(fs, 'statSync', {
+      configurable: true,
       value: ((statPath: fs.PathLike) => {
         if (statPath === scenePath) throw new Error('stat failed')
         return originalStatSync(statPath)


### PR DESCRIPTION
## Summary
- Make the info command stat-failure test's temporary fs.statSync replacement configurable so cleanup can reliably restore it.

## Tests
- pnpm --dir cli test