### PR TITLE
Mark CLI command options readonly

### DIFF
--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -49,7 +49,7 @@ import path from 'node:path'
 import { buildSceneBytes, readSceneSummary, type SceneJson } from '../scene/build.js'
 
 interface CreateCommandOptions {
-  from?: string
+  readonly from?: string
 }
 
 export function createCommand(): Command {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -34,11 +34,11 @@ const QUALITY_HELP = RENDER_QUALITIES.join(' / ')
 const EMPTY_OPTION_LABEL = '<empty>'
 
 interface RenderOptions {
-  output: string
-  format?: string
-  quality?: string
-  fps?: string
-  scene?: string
+  readonly output: string
+  readonly format?: string
+  readonly quality?: string
+  readonly fps?: string
+  readonly scene?: string
 }
 
 export interface RenderCommandDeps {


### PR DESCRIPTION
## Summary
- Mark CLI create/render command option interfaces as readonly to reflect read-only handler usage.

## Tests
- pnpm --dir cli test