### PR TITLE
chore(cli): mark patch options readonly

### DIFF
--- a/cli/src/commands/patch.ts
+++ b/cli/src/commands/patch.ts
@@ -6,8 +6,8 @@ import path from 'node:path'
 import { applyScenePatch, type ScenePatch, type PatchOperation } from '../scene/build.js'
 
 interface PatchCommandOptions {
-  from: string
-  output?: string
+  readonly from: string
+  readonly output?: string
 }
 
 export function patchCommand(): Command {


### PR DESCRIPTION
## Summary\n- mark the CLI patch command options as readonly, matching the other command option types\n\n## Tests\n- pnpm --dir cli test