### PR TITLE
chore(cli): mark info options readonly

### DIFF
--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -14,7 +14,7 @@ import path from 'node:path'
 import { readSceneSummary, type SceneSummary } from '../scene/build.js'
 
 type InfoCommandOptions = {
-  json?: boolean
+  readonly json?: boolean
 }
 
 type PrintableCanvas = {


### PR DESCRIPTION
## Summary
- mark info command options as readonly to match the CLI command option typing pattern

## Tests
- pnpm --dir cli run build
- node --test --test-concurrency=1 cli/dist/commands/info.test.js