### PR TITLE
chore: ignore nested dist outputs in lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', '**/dist']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [


### PR DESCRIPTION
## Summary\n- Extend ESLint generated-output ignores to cover package-level dist directories such as cli/dist.\n\n## Verification\n- pnpm exec eslint cli/dist/mcp/tools/schema.d.ts --no-warn-ignored\n- pnpm test\n\nNote: top-level pnpm lint and pnpm typecheck still have unrelated pre-existing failures on main; this change verifies the generated-file lint case directly.