### PR TITLE
chore(cli): mark serve options readonly

### DIFF
--- a/cli/src/commands/serve.ts
+++ b/cli/src/commands/serve.ts
@@ -17,11 +17,11 @@ import { Command } from 'commander'
 import { startMcpServer } from '../mcp/server.js'
 
 interface ServeCommandDeps {
-  startServer?: () => Promise<void>
+  readonly startServer?: () => Promise<void>
 }
 
 type ServeCommandOptions = {
-  mcp?: boolean
+  readonly mcp?: boolean
 }
 
 export function serveCommand(deps: ServeCommandDeps = {}): Command {


### PR DESCRIPTION
## Summary
- Mark the CLI serve command dependency and parsed options types as readonly.

## Verification
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/commands/serve.test.js
- pnpm --dir cli test