### PR TITLE
test(cli): cover deterministic MCP schema errors

### DIFF
--- a/cli/src/mcp/tools/schema.test.ts
+++ b/cli/src/mcp/tools/schema.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { rejectUnexpectedEmptyArgs } from './schema.js'
+
+test('rejectUnexpectedEmptyArgs allows empty argument objects', () => {
+  assert.equal(rejectUnexpectedEmptyArgs('doctor', {}), null)
+})
+
+test('rejectUnexpectedEmptyArgs reports unexpected keys deterministically', () => {
+  assert.equal(
+    rejectUnexpectedEmptyArgs('get_capabilities', {
+      zeta: true,
+      alpha: true,
+    }),
+    'get_capabilities: invalid arguments — Unrecognized key(s): alpha, zeta',
+  )
+})

--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -19,7 +19,7 @@ export function rejectUnexpectedEmptyArgs(
   toolName: EmptyArgsToolName,
   args: McpToolArgs,
 ): string | null {
-  const keys = Object.keys(args)
+  const keys = Object.keys(args).sort()
   if (keys.length === 0) return null
   return `${toolName}: invalid arguments — Unrecognized key(s): ${keys.join(', ')}`
 }


### PR DESCRIPTION
## Summary
- Sort unexpected no-arg MCP tool argument keys before formatting errors
- Add focused coverage for empty args and deterministic unknown-key ordering

## Verification
- pnpm --dir cli test