### PR TITLE
chore(cli): clarify desktop app override comment

### DIFF
--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -10,8 +10,9 @@
  *   Windows — Best-effort lookup for development builds; no public release yet.
  *   Linux   — Best-effort lookup for development builds; no public release yet.
  *
- * Override path with the `HYPERMOTION_APP_PATH` environment variable if installed somewhere
- * non-standard.
+ * Override lookup with `HYPERMOTION_APP_PATH` when the app is installed
+ * somewhere non-standard. The override may point at the desktop binary or
+ * the macOS `.app` bundle.
  *
  * Returns `null` if not found — callers surface a clean install hint.
  */


### PR DESCRIPTION
## Summary
- clarify that HYPERMOTION_APP_PATH may point to the desktop binary or macOS .app bundle

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/locator.test.js
- pnpm --dir cli test