### PR TITLE
chore(cli): mark validate options readonly

### DIFF
--- a/cli/src/commands/validate.ts
+++ b/cli/src/commands/validate.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 import { validateScene, type SceneValidationResult } from '../scene/build.js'
 
 type ValidateCommandOptions = {
-  json?: boolean
+  readonly json?: boolean
 }
 
 export function validateCommand(): Command {


### PR DESCRIPTION
## Summary\n- Mark the validate command options object as readonly to match neighboring CLI command option types.\n\n## Tests\n- pnpm test