### PR TITLE
Centralize empty-args MCP tool names

### DIFF
--- a/cli/src/mcp/tools/schema.test.ts
+++ b/cli/src/mcp/tools/schema.test.ts
@@ -2,7 +2,15 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { rejectUnexpectedEmptyArgs } from './schema.js'
+import { EMPTY_ARGS_TOOL_NAMES, rejectUnexpectedEmptyArgs } from './schema.js'
+
+test('EMPTY_ARGS_TOOL_NAMES lists tools handled by the empty-args helper', () => {
+  assert.deepEqual(EMPTY_ARGS_TOOL_NAMES, [
+    'doctor',
+    'get_capabilities',
+    'list_keyframeable_properties',
+  ])
+})
 
 test('rejectUnexpectedEmptyArgs allows empty argument objects', () => {
   assert.equal(rejectUnexpectedEmptyArgs('doctor', {}), null)

--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -3,10 +3,12 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js'
 
 export type McpToolArgs = Record<string, unknown>
-export type EmptyArgsToolName =
-  | 'doctor'
-  | 'get_capabilities'
-  | 'list_keyframeable_properties'
+export const EMPTY_ARGS_TOOL_NAMES = [
+  'doctor',
+  'get_capabilities',
+  'list_keyframeable_properties',
+] as const
+export type EmptyArgsToolName = (typeof EMPTY_ARGS_TOOL_NAMES)[number]
 
 export const EMPTY_OBJECT_INPUT_SCHEMA = {
   type: 'object',


### PR DESCRIPTION
## Summary
- centralize the MCP empty-args tool names as a typed constant
- cover the exported list in the schema helper tests

## Verification
- pnpm --dir cli test