### PR TITLE
fix(cli): ignore stale query scene node entries

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -408,6 +408,8 @@ test('query scene MCP handlers return layers, tracks, and cameras', async () => 
     const doc = new Y.Doc()
     Y.applyUpdate(doc, bytes)
     const scene = doc.getMap('scene')
+    const nodes = scene.get('nodes') as Y.Map<unknown>
+    nodes.set('staleNodeEntry', 'not a node')
     const tracks = scene.get('tracks') as Y.Map<unknown>
     tracks.set('staleTrackEntry', 'not a track')
     fs.writeFileSync(scenePath, Y.encodeStateAsUpdate(doc))

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -117,11 +117,11 @@ export async function handleListLayers(
   const loaded = read('list_layers', input.scene)
   if (!loaded.ok) return loaded.result
 
-  const nodes = record(loaded.scene.nodes)
+  const nodes = Object.values(record(loaded.scene.nodes)).filter(isRecord)
   return text({
     root: loaded.scene.root ?? null,
     activeCameraId: loaded.scene.activeCameraId ?? null,
-    layers: Object.values(nodes).map((raw): LayerSummary => {
+    layers: nodes.map((raw): LayerSummary => {
       const n = record(raw)
       return {
         id: n.id,


### PR DESCRIPTION
## Summary\n- ignore malformed persisted node entries in list_layers query output\n- extend query scene coverage alongside existing stale track-entry coverage\n\n## Tests\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/queryScene.test.js\n- pnpm test