### PR TITLE
chore(cli): mark MCP tool args readonly

### DIFF
--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -2,7 +2,7 @@
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js'
 
-export type McpToolArgs = Record<string, unknown>
+export type McpToolArgs = Readonly<Record<string, unknown>>
 export const EMPTY_ARGS_TOOL_NAMES = [
   'doctor',
   'get_capabilities',


### PR DESCRIPTION
## Summary
- mark the shared MCP tool args type as readonly to match handler usage

## Verification
- pnpm --dir cli test

Note: root pnpm typecheck still fails on existing app-level TypeScript errors outside this CLI-only change.