### PR TITLE
Clarify env helper rejection test

### DIFF
--- a/cli/src/testUtils/env.test.ts
+++ b/cli/src/testUtils/env.test.ts
@@ -198,8 +198,8 @@ test('withEnvVar returns async callback values', async () => {
   }
 })
 
-test('withEnvVar restores values after async callback failures', async () => {
-  const name = 'HYPERMOTION_TEST_ENV_ASYNC_THROW'
+test('withEnvVar restores values after async callback rejection', async () => {
+  const name = 'HYPERMOTION_TEST_ENV_ASYNC_REJECT'
   process.env[name] = 'before'
 
   try {


### PR DESCRIPTION
## Summary
- Rename the duplicate async-failure env helper test case to describe callback rejection specifically.
- Give that fixture its own environment variable name to keep test state easier to diagnose.

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/testUtils/env.test.js
- pnpm --dir cli test