### PR TITLE
chore(cli): type scene tool schemas

### DIFF
--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -25,6 +25,7 @@ const InfoInput = z.object({
   scene: z.string().trim().min(1, 'scene path is required').describe(SCENE_PATH_DESCRIPTION),
 }).strict()
 type InfoInputData = z.infer<typeof InfoInput>
+type ToolInputSchema = Tool['inputSchema']
 
 export const infoSceneTool: Tool = {
   name: 'info_scene',
@@ -39,7 +40,7 @@ export const infoSceneTool: Tool = {
     },
     required: ['scene'],
     additionalProperties: false,
-  },
+  } satisfies ToolInputSchema,
 }
 
 export async function handleInfoScene(

--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -18,6 +18,7 @@ const ValidateInput = z.object({
   scene: z.string().trim().min(1, 'scene path is required').describe(SCENE_PATH_DESCRIPTION),
 }).strict()
 type ValidateInputData = z.infer<typeof ValidateInput>
+type ToolInputSchema = Tool['inputSchema']
 
 export type ValidateSceneDeps = {
   statSync: (path: fs.PathLike) => fs.Stats
@@ -40,7 +41,7 @@ export const validateSceneTool: Tool = {
     },
     required: ['scene'],
     additionalProperties: false,
-  },
+  } satisfies ToolInputSchema,
 }
 
 export async function handleValidateScene(


### PR DESCRIPTION
## Summary
- add compile-time input schema checks to info_scene and validate_scene MCP tools
- keep runtime behavior unchanged while matching newer MCP tool schema typing

## Tests
- pnpm --dir cli test