### PR TITLE
chore(cli): export open command deps type

### DIFF
--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -9,7 +9,7 @@ import { locateDesktopApp } from '../electron/locator.js'
 
 type OpenSpawnOptions = Readonly<Pick<SpawnOptions, 'detached' | 'stdio'>>
 
-interface OpenCommandDeps {
+export interface OpenCommandDeps {
   readonly locateApp: typeof locateDesktopApp
   readonly existsSync: typeof fs.existsSync
   readonly statSync: typeof fs.statSync


### PR DESCRIPTION
## Summary\n- Export the OpenCommandDeps interface so CLI open-command dependency injection has a typed public surface like nearby commands.\n\n## Verification\n- pnpm --dir cli run build && pnpm --dir cli test\n- pnpm test