### PR TITLE
chore(cli): mark doctor options readonly

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -29,7 +29,7 @@ export interface DoctorReport {
 }
 
 type DoctorCommandOptions = {
-  json?: boolean
+  readonly json?: boolean
 }
 
 export async function getDoctorReport(): Promise<DoctorReport> {


### PR DESCRIPTION
## Summary\n- Mark the doctor command options type as readonly for consistency with other CLI command option types.\n\n## Tests\n- pnpm --dir cli test