### PR TITLE
chore(cli): prefix open scene app errors

### DIFF
--- a/cli/src/mcp/openScene.test.ts
+++ b/cli/src/mcp/openScene.test.ts
@@ -150,7 +150,7 @@ test('open_scene reports missing desktop apps as MCP errors', async () => {
     )
 
     assert.equal(result.isError, true)
-    assert.equal(assertToolText(result), 'hyper-motion desktop app not found.')
+    assert.equal(assertToolText(result), 'open_scene: hyper-motion desktop app not found.')
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }

--- a/cli/src/mcp/tools/openScene.ts
+++ b/cli/src/mcp/tools/openScene.ts
@@ -111,7 +111,7 @@ export async function handleOpenScene(
   if (!opened) {
     return {
       isError: true,
-      content: [{ type: 'text' as const, text: 'hyper-motion desktop app not found.' }],
+      content: [{ type: 'text' as const, text: 'open_scene: hyper-motion desktop app not found.' }],
     }
   }
   return {


### PR DESCRIPTION
## Summary
- Prefix the MCP open_scene missing-desktop-app error with the tool name for consistency.
- Update the focused open_scene test expectation.

## Tests
- pnpm run build && node --test --test-concurrency=1 dist/mcp/openScene.test.js
- pnpm test