### PR TITLE
chore(cli): resolve info scene paths

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -208,3 +208,41 @@ test('info_scene trims padded scene paths before reading', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('info_scene resolves relative scene paths before reading', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-relative-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const originalCwd = process.cwd()
+
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Relative Info MCP',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    process.chdir(dir)
+    const result = await handleInfoScene({ scene: 'scene.hype' })
+    const summary = JSON.parse(assertToolText(result)) as SceneSummary
+
+    assert.equal(result.isError, undefined)
+    assert.equal(summary.meta.name, 'Relative Info MCP')
+  } finally {
+    process.chdir(originalCwd)
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -10,6 +10,7 @@
 import { z } from 'zod'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
+import path from 'node:path'
 import { readSceneSummary, type SceneSummary } from '../../scene/build.js'
 import type { McpToolArgs } from './schema.js'
 
@@ -60,13 +61,7 @@ export async function handleInfoScene(
   }
 
   const input: InfoInputData = parsed.data
-  const scenePath = input.scene.trim()
-  if (!scenePath) {
-    return {
-      isError: true,
-      content: [{ type: 'text' as const, text: 'info_scene: scene path is required' }],
-    }
-  }
+  const scenePath = path.resolve(input.scene)
   let bytes: Buffer
   try {
     const stats = fs.statSync(scenePath)


### PR DESCRIPTION
## Summary
- Resolve MCP info_scene inputs before reading so relative paths are normalized like the CLI info/open paths.
- Add regression coverage for relative scene paths.

## Tests
- pnpm --dir cli test