### PR TITLE
test: cover empty MCP input schema

### DIFF
--- a/cli/src/mcp/tools/schema.test.ts
+++ b/cli/src/mcp/tools/schema.test.ts
@@ -2,7 +2,11 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { EMPTY_ARGS_TOOL_NAMES, rejectUnexpectedEmptyArgs } from './schema.js'
+import {
+  EMPTY_ARGS_TOOL_NAMES,
+  EMPTY_OBJECT_INPUT_SCHEMA,
+  rejectUnexpectedEmptyArgs,
+} from './schema.js'
 
 test('EMPTY_ARGS_TOOL_NAMES lists tools handled by the empty-args helper', () => {
   assert.deepEqual(EMPTY_ARGS_TOOL_NAMES, [
@@ -10,6 +14,15 @@ test('EMPTY_ARGS_TOOL_NAMES lists tools handled by the empty-args helper', () =>
     'get_capabilities',
     'list_keyframeable_properties',
   ])
+})
+
+test('EMPTY_OBJECT_INPUT_SCHEMA rejects extra MCP arguments', () => {
+  assert.deepEqual(EMPTY_OBJECT_INPUT_SCHEMA, {
+    type: 'object',
+    properties: {},
+    required: [],
+    additionalProperties: false,
+  })
 })
 
 test('rejectUnexpectedEmptyArgs allows empty argument objects', () => {


### PR DESCRIPTION
## Summary
- add coverage for the shared empty-object MCP input schema used by no-argument tools

## Tests
- pnpm test