### PR TITLE
chore(cli): ignore malformed query scene nodes

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -408,7 +408,9 @@ test('query scene MCP handlers return layers, tracks, and cameras', async () => 
     const doc = new Y.Doc()
     Y.applyUpdate(doc, bytes)
     const scene = doc.getMap('scene')
+    const nodes = scene.get('nodes') as Y.Map<unknown>
     const tracks = scene.get('tracks') as Y.Map<unknown>
+    nodes.set('staleNodeEntry', 'not a node')
     tracks.set('staleTrackEntry', 'not a track')
     fs.writeFileSync(scenePath, Y.encodeStateAsUpdate(doc))
 

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -122,16 +122,15 @@ export async function handleListLayers(
   return text({
     root: loaded.scene.root ?? null,
     activeCameraId: loaded.scene.activeCameraId ?? null,
-    layers: Object.values(nodes).map((raw): LayerSummary => {
-      const n = record(raw)
-      return {
+    layers: Object.values(nodes)
+      .filter(isRecord)
+      .map((n): LayerSummary => ({
         id: n.id,
         name: n.name,
         kind: n.kind,
         parent: n.parent,
         children: stringArray(n.children),
-      }
-    }),
+      })),
   })
 }
 


### PR DESCRIPTION
## Summary
- skip malformed non-object node entries when listing scene layers
- extend the query-scene MCP test fixture to cover stale node entries alongside stale tracks

## Tests
- pnpm --dir cli test -- queryScene