### PR TITLE
chore(cli): guard empty MCP args helper

### DIFF
--- a/cli/src/mcp/tools/schema.test.ts
+++ b/cli/src/mcp/tools/schema.test.ts
@@ -6,6 +6,7 @@ import {
   EMPTY_ARGS_TOOL_NAMES,
   EMPTY_OBJECT_INPUT_SCHEMA,
   rejectUnexpectedEmptyArgs,
+  type McpToolArgs,
 } from './schema.js'
 
 test('EMPTY_ARGS_TOOL_NAMES lists tools handled by the empty-args helper', () => {
@@ -27,6 +28,17 @@ test('EMPTY_OBJECT_INPUT_SCHEMA rejects extra MCP arguments', () => {
 
 test('rejectUnexpectedEmptyArgs allows empty argument objects', () => {
   assert.equal(rejectUnexpectedEmptyArgs('doctor', {}), null)
+})
+
+test('rejectUnexpectedEmptyArgs rejects non-object arguments clearly', () => {
+  assert.equal(
+    rejectUnexpectedEmptyArgs('doctor', [] as unknown as McpToolArgs),
+    'doctor: invalid arguments — Expected an object',
+  )
+  assert.equal(
+    rejectUnexpectedEmptyArgs('doctor', null as unknown as McpToolArgs),
+    'doctor: invalid arguments — Expected an object',
+  )
 })
 
 test('rejectUnexpectedEmptyArgs reports unexpected keys deterministically', () => {

--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -21,7 +21,14 @@ export function rejectUnexpectedEmptyArgs(
   toolName: EmptyArgsToolName,
   args: McpToolArgs,
 ): string | null {
+  if (!isPlainObject(args)) {
+    return `${toolName}: invalid arguments — Expected an object`
+  }
   const keys = Object.keys(args).sort()
   if (keys.length === 0) return null
   return `${toolName}: invalid arguments — Unrecognized key(s): ${keys.join(', ')}`
+}
+
+function isPlainObject(value: unknown): value is McpToolArgs {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }


### PR DESCRIPTION
## Summary
- Return a clean MCP validation error when the shared empty-args helper receives non-object arguments.
- Add focused coverage for array and null malformed arguments.

## Tests
- pnpm --dir cli test