### PR TITLE
fix(cli): reject directory render outputs

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -272,6 +272,26 @@ test('render_scene reports output directory creation failures as MCP errors', as
   }
 })
 
+test('render_scene reports directory output paths before locating the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-dir-'))
+  const outputPath = path.join(dir, 'out.mp4')
+  fs.mkdirSync(outputPath)
+
+  try {
+    const result = await handleRenderScene({
+      output: outputPath,
+    })
+
+    assert.equal(result.isError, true)
+    assert.equal(
+      assertToolText(result),
+      `render_scene: output path is a directory: ${outputPath}`,
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render_scene creates missing output directories before rendering', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-create-'))
   const outDir = path.join(dir, 'exports', 'nested')

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -209,6 +209,36 @@ export async function handleRenderScene(
   }
 
   const outDir = path.dirname(outputPath)
+  if (deps.existsSync(outputPath)) {
+    let stats: fs.Stats
+    try {
+      stats = deps.statSync(outputPath)
+    } catch (err) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: `render_scene: failed to inspect output path ${outputPath}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          },
+        ],
+      }
+    }
+    if (stats.isDirectory()) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: `render_scene: output path is a directory: ${outputPath}`,
+          },
+        ],
+      }
+    }
+  }
+
   if (deps.existsSync(outDir)) {
     let stats: fs.Stats
     try {


### PR DESCRIPTION
## Summary
- reject `render_scene` requests when the resolved output path already exists as a directory
- add a regression test so the MCP tool returns a clear error before locating the desktop app

## Tests
- `pnpm --dir cli test`
