### PR TITLE
Harden empty MCP arg validation

### DIFF
--- a/cli/src/mcp/tools/schema.test.ts
+++ b/cli/src/mcp/tools/schema.test.ts
@@ -30,6 +30,11 @@ test('rejectUnexpectedEmptyArgs allows empty argument objects', () => {
   assert.equal(rejectUnexpectedEmptyArgs('doctor', {}), null)
 })
 
+test('rejectUnexpectedEmptyArgs allows null-prototype argument records', () => {
+  const args = Object.create(null) as McpToolArgs
+  assert.equal(rejectUnexpectedEmptyArgs('doctor', args), null)
+})
+
 test('rejectUnexpectedEmptyArgs rejects non-object arguments clearly', () => {
   assert.equal(
     rejectUnexpectedEmptyArgs('doctor', [] as unknown as McpToolArgs),
@@ -37,6 +42,10 @@ test('rejectUnexpectedEmptyArgs rejects non-object arguments clearly', () => {
   )
   assert.equal(
     rejectUnexpectedEmptyArgs('doctor', null as unknown as McpToolArgs),
+    'doctor: invalid arguments — Expected an object',
+  )
+  assert.equal(
+    rejectUnexpectedEmptyArgs('doctor', new Date() as unknown as McpToolArgs),
     'doctor: invalid arguments — Expected an object',
   )
 })

--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -30,5 +30,9 @@ export function rejectUnexpectedEmptyArgs(
 }
 
 function isPlainObject(value: unknown): value is McpToolArgs {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
 }


### PR DESCRIPTION
## Summary\n- Tighten empty-argument MCP validation to accept only plain JSON-style records\n- Add coverage for null-prototype records and non-plain object rejection\n\n## Tests\n- pnpm --dir cli test