### PR TITLE
test(cli): harden MCP text helper

### DIFF
--- a/cli/src/testUtils/mcp.test.ts
+++ b/cli/src/testUtils/mcp.test.ts
@@ -36,6 +36,15 @@ test('assertToolText reports missing text content clearly', () => {
   )
 })
 
+test('assertToolText rejects missing content arrays clearly', () => {
+  const result = {} as unknown as CallToolResult
+
+  assert.throws(
+    () => assertToolText(result),
+    /expected MCP content to be an array/,
+  )
+})
+
 test('assertToolText rejects undefined content items', () => {
   const result = {
     content: [undefined],

--- a/cli/src/testUtils/mcp.ts
+++ b/cli/src/testUtils/mcp.ts
@@ -6,6 +6,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 type ToolTextContent = Extract<CallToolResult['content'][number], { type: 'text' }>
 
 export function assertToolText(result: CallToolResult): string {
+  assert.ok(Array.isArray(result.content), 'expected MCP content to be an array')
   assert.equal(result.content.length, 1, 'expected exactly one MCP content item')
   const item = result.content[0]
   assert.ok(isToolTextContent(item), 'expected first MCP content item to be text')


### PR DESCRIPTION
## Summary
- Assert MCP tool results expose a content array before reading helper output
- Add coverage for malformed results with missing content arrays

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/testUtils/mcp.test.js
- pnpm test