### PR TITLE
Validate create output before building

### DIFF
--- a/cli/src/commands/create.test.ts
+++ b/cli/src/commands/create.test.ts
@@ -233,6 +233,37 @@ test('create command rejects directory output paths', async () => {
   }
 })
 
+test('create command rejects directory output paths before building scenes', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-create-dir-output-'))
+  const sourcePath = path.join(dir, 'scene.json')
+  const outputPath = path.join(dir, 'existing-output')
+  try {
+    fs.mkdirSync(outputPath)
+    fs.writeFileSync(
+      sourcePath,
+      JSON.stringify({
+        nodes: {
+          broken: null,
+        },
+      }),
+    )
+
+    const stderr = await withProcessExitThrow(async () => {
+      return captureStderr(async () => {
+        await assert.rejects(
+          createCommand()
+            .parseAsync([outputPath, '--from', sourcePath], { from: 'user' }),
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.equal(stderr, `[create] output path is a directory: ${outputPath}\n`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('create command rejects blank output paths before reading input', async () => {
   const stderr = await withProcessExitThrow(async () => {
     return captureStderr(async () => {

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -106,20 +106,6 @@ export function createCommand(): Command {
         process.exit(2)
       }
 
-      // Build the Y.Doc bytes. This is pure data work — no desktop app
-      // needed, no IndexedDB, no React. Just JSON → Y.Doc → bytes.
-      let bytes: Uint8Array
-      try {
-        bytes = buildSceneBytes(json)
-      } catch (err) {
-        console.error(
-          `[create] failed to build scene: ${
-            err instanceof Error ? err.message : err
-          }`,
-        )
-        process.exit(1)
-      }
-
       // Make sure the output's parent directory exists. Tools and
       // agents tend to specify deeply-nested paths; we don't want a
       // simple ENOENT to obscure the real error.
@@ -152,6 +138,20 @@ export function createCommand(): Command {
       if (outputStats?.isDirectory()) {
         console.error(`[create] output path is a directory: ${outputPath}`)
         process.exit(2)
+      }
+
+      // Build the Y.Doc bytes. This is pure data work — no desktop app
+      // needed, no IndexedDB, no React. Just JSON → Y.Doc → bytes.
+      let bytes: Uint8Array
+      try {
+        bytes = buildSceneBytes(json)
+      } catch (err) {
+        console.error(
+          `[create] failed to build scene: ${
+            err instanceof Error ? err.message : err
+          }`,
+        )
+        process.exit(1)
       }
 
       try {


### PR DESCRIPTION
## Summary
- validate the create command output path before building scene bytes
- add regression coverage for directory outputs masking scene-build failures

## Tests
- pnpm --dir cli test -- create.test.js
- pnpm test