### PR TITLE
chore(cli): preserve readonly partial arrays

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -457,7 +457,7 @@ export interface JsonObject {
 export type KeyframeValueJson = JsonValue
 
 type DeepPartial<T> = {
-  [K in keyof T]?: T[K] extends unknown[]
+  [K in keyof T]?: T[K] extends readonly unknown[]
     ? T[K]
     : T[K] extends object
       ? DeepPartial<T[K]>


### PR DESCRIPTION
## Summary
- Preserve readonly array properties in the CLI scene builder DeepPartial helper.
- Keep the change type-only and scoped to scene authoring types.

## Tests
- pnpm --dir cli test