### PR TITLE
fix(cli): resolve validate scene paths

### DIFF
--- a/cli/src/mcp/tools/validateScene.ts
+++ b/cli/src/mcp/tools/validateScene.ts
@@ -3,6 +3,7 @@
 import { z } from 'zod'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
+import path from 'node:path'
 import { validateScene, type SceneValidationResult } from '../../scene/build.js'
 import type { McpToolArgs } from './schema.js'
 
@@ -62,13 +63,14 @@ export async function handleValidateScene(
   }
 
   const input: ValidateInputData = parsed.data
-  const scenePath = input.scene.trim()
-  if (!scenePath) {
+  const trimmedScenePath = input.scene.trim()
+  if (!trimmedScenePath) {
     return {
       isError: true,
       content: [{ type: 'text' as const, text: 'validate_scene: scene path is required' }],
     }
   }
+  const scenePath = path.resolve(trimmedScenePath)
   let bytes: Buffer
   let stat: fs.Stats
   try {

--- a/cli/src/mcp/validateScene.test.ts
+++ b/cli/src/mcp/validateScene.test.ts
@@ -238,6 +238,51 @@ test('validate_scene trims padded scene paths before reading', async () => {
   }
 })
 
+test('validate_scene resolves relative scene paths before reading', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-relative-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const relativeScenePath = path.relative(process.cwd(), scenePath)
+  const statPaths: string[] = []
+
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Validate Relative MCP',
+          canvas: { width: 320, height: 180 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 320, height: 180 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const result = await handleValidateScene(
+      { scene: relativeScenePath },
+      testDeps({
+        statSync: (statPath) => {
+          statPaths.push(String(statPath))
+          return fs.statSync(statPath)
+        },
+      }),
+    )
+
+    assert.equal(result.isError, undefined)
+    assert.deepEqual(statPaths, [scenePath])
+    assert.equal(JSON.parse(assertToolText(result)).ok, true)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('validate_scene marks structurally invalid scenes as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-validate-invalid-'))
   const scenePath = path.join(dir, 'invalid.hype')


### PR DESCRIPTION
## Summary
- Resolve MCP validate_scene inputs before stat/read, matching other scene MCP tools
- Add a regression test for relative validate_scene paths

## Tests
- pnpm test (in cli/)