### PR TITLE
test: cover patched node parent linking

### DIFF
--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -762,6 +762,25 @@ test('applyScenePatch fills workspaceOnly default for created nodes', () => {
   assert.equal(nodes.badge.workspaceOnly, false)
 })
 
+test('applyScenePatch links created nodes into their parent children list', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const patched = applyScenePatch(bytes, [
+    {
+      op: 'createNode',
+      node: {
+        id: 'badge',
+        kind: 'rect',
+        parent: 'root',
+      },
+    },
+  ])
+  const data = inspectScene(patched)
+  const nodes = data.nodes as PlainSceneMap
+
+  assert.deepEqual(nodes.root.children, ['title', 'badge'])
+  assert.equal(validateScene(patched).ok, true)
+})
+
 test('applyScenePatch fills text defaults for created nodes', () => {
   const bytes = buildSceneBytes(sampleScene())
   const patched = applyScenePatch(bytes, [


### PR DESCRIPTION
## Summary
- Add a focused CLI scene patch regression test for `createNode` parent-child wiring.
- Validate the patched scene after linking the new node into the root children list.

## Tests
- `pnpm --dir cli test`
