### PR TITLE
Share MCP schema property types

### DIFF
--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -34,7 +34,7 @@ import {
   type SceneJson,
 } from '../../scene/build.js'
 import { pushSceneToRunningApp } from '../../electron/live.js'
-import type { McpToolArgs } from './schema.js'
+import type { BooleanSchemaProperty, McpToolArgs, StringSchemaProperty } from './schema.js'
 
 const OUTPUT_PATH_DESCRIPTION =
   'Absolute, non-blank path to write the .hype file to. Parent dirs are created if missing.'
@@ -59,17 +59,6 @@ const CreateInput = z.object({
     .describe('Open the newly-created scene in the desktop app. Defaults to true.'),
 }).strict()
 type CreateInputData = z.infer<typeof CreateInput>
-type StringSchemaProperty = {
-  readonly type: 'string'
-  readonly minLength?: number
-  readonly pattern?: string
-  readonly description: string
-}
-type BooleanSchemaProperty = {
-  readonly type: 'boolean'
-  readonly description: string
-  readonly default: boolean
-}
 type SceneSchemaProperty = {
   readonly anyOf: readonly [{ readonly type: 'string' }, { readonly type: 'object' }]
   readonly description: string

--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -23,7 +23,12 @@ import {
   inferRenderFormatFromPath,
 } from '../../renderOptions.js'
 import type { RenderFormat, RenderQuality } from '../../renderOptions.js'
-import type { McpToolArgs } from './schema.js'
+import type {
+  EnumStringSchemaProperty,
+  IntegerSchemaProperty,
+  McpToolArgs,
+  StringSchemaProperty,
+} from './schema.js'
 
 const RenderInput = z.object({
   output: z
@@ -50,21 +55,6 @@ const RenderInput = z.object({
     ),
 }).strict()
 type RenderInputData = z.infer<typeof RenderInput>
-type StringSchemaProperty = {
-  readonly type: 'string'
-  readonly minLength?: number
-  readonly pattern?: string
-  readonly description: string
-}
-type EnumStringSchemaProperty<Value extends string> = StringSchemaProperty & {
-  readonly enum: readonly Value[]
-}
-type IntegerSchemaProperty = {
-  readonly type: 'integer'
-  readonly minimum: number
-  readonly maximum: number
-  readonly description: string
-}
 export type RenderSceneDeps = {
   existsSync: typeof fs.existsSync
   statSync: (path: fs.PathLike) => fs.Stats

--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -3,6 +3,27 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js'
 
 export type McpToolArgs = Readonly<Record<string, unknown>>
+export type StringSchemaProperty = {
+  readonly type: 'string'
+  readonly minLength?: number
+  readonly pattern?: string
+  readonly description: string
+}
+export type BooleanSchemaProperty = {
+  readonly type: 'boolean'
+  readonly description: string
+  readonly default: boolean
+}
+export type EnumStringSchemaProperty<Value extends string> = StringSchemaProperty & {
+  readonly enum: readonly Value[]
+}
+export type IntegerSchemaProperty = {
+  readonly type: 'integer'
+  readonly minimum: number
+  readonly maximum: number
+  readonly description: string
+}
+
 export const EMPTY_ARGS_TOOL_NAMES = [
   'doctor',
   'get_capabilities',


### PR DESCRIPTION
## Summary
- Move shared MCP JSON schema property helper types into the common schema module
- Reuse those types from create_scene and render_scene tool definitions

## Verification
- pnpm --dir cli test

## Notes
- pnpm typecheck still fails on existing app-wide TypeScript errors unrelated to this CLI-only type cleanup.