### PR TITLE
Tighten MCP text test helper typing

### DIFF
--- a/cli/src/testUtils/mcp.test.ts
+++ b/cli/src/testUtils/mcp.test.ts
@@ -37,7 +37,7 @@ test('assertToolText reports missing text content clearly', () => {
 })
 
 test('assertToolText rejects missing content arrays clearly', () => {
-  const result = {} as unknown as CallToolResult
+  const result = {}
 
   assert.throws(
     () => assertToolText(result),
@@ -48,7 +48,7 @@ test('assertToolText rejects missing content arrays clearly', () => {
 test('assertToolText rejects undefined content items', () => {
   const result = {
     content: [undefined],
-  } as unknown as CallToolResult
+  }
 
   assert.throws(
     () => assertToolText(result),
@@ -70,7 +70,7 @@ test('assertToolText rejects non-text first content items', () => {
 test('assertToolText rejects malformed text payloads', () => {
   const result = {
     content: [{ type: 'text', text: undefined }],
-  } as unknown as CallToolResult
+  }
 
   assert.throws(
     () => assertToolText(result),

--- a/cli/src/testUtils/mcp.ts
+++ b/cli/src/testUtils/mcp.ts
@@ -5,13 +5,24 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
 type ToolTextContent = Extract<CallToolResult['content'][number], { type: 'text' }>
 
-export function assertToolText(result: CallToolResult): string {
-  assert.ok(Array.isArray(result.content), 'expected MCP content to be an array')
+export function assertToolText(result: unknown): string {
+  assert.ok(isCallToolResultLike(result), 'expected MCP content to be an array')
   assert.equal(result.content.length, 1, 'expected exactly one MCP content item')
   const item = result.content[0]
   assert.ok(isToolTextContent(item), 'expected first MCP content item to be text')
   assert.equal(typeof item.text, 'string', 'expected MCP text content to be a string')
   return item.text
+}
+
+function isCallToolResultLike(
+  result: unknown,
+): result is { content: CallToolResult['content'] } {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'content' in result &&
+    Array.isArray(result.content)
+  )
 }
 
 function isToolTextContent(


### PR DESCRIPTION
## Summary
- Let the MCP text assertion helper accept unknown payloads and validate their shape internally
- Remove double assertions from malformed-payload helper tests

## Tests
- pnpm --dir cli run build && node --test cli/dist/testUtils/mcp.test.js
- pnpm test