### PR TITLE
Tighten empty MCP args helper typing

### DIFF
--- a/cli/src/mcp/tools/schema.test.ts
+++ b/cli/src/mcp/tools/schema.test.ts
@@ -6,7 +6,6 @@ import {
   EMPTY_ARGS_TOOL_NAMES,
   EMPTY_OBJECT_INPUT_SCHEMA,
   rejectUnexpectedEmptyArgs,
-  type McpToolArgs,
 } from './schema.js'
 
 test('EMPTY_ARGS_TOOL_NAMES lists tools handled by the empty-args helper', () => {
@@ -31,21 +30,21 @@ test('rejectUnexpectedEmptyArgs allows empty argument objects', () => {
 })
 
 test('rejectUnexpectedEmptyArgs allows null-prototype argument records', () => {
-  const args = Object.create(null) as McpToolArgs
+  const args = Object.create(null)
   assert.equal(rejectUnexpectedEmptyArgs('doctor', args), null)
 })
 
 test('rejectUnexpectedEmptyArgs rejects non-object arguments clearly', () => {
   assert.equal(
-    rejectUnexpectedEmptyArgs('doctor', [] as unknown as McpToolArgs),
+    rejectUnexpectedEmptyArgs('doctor', []),
     'doctor: invalid arguments — Expected an object',
   )
   assert.equal(
-    rejectUnexpectedEmptyArgs('doctor', null as unknown as McpToolArgs),
+    rejectUnexpectedEmptyArgs('doctor', null),
     'doctor: invalid arguments — Expected an object',
   )
   assert.equal(
-    rejectUnexpectedEmptyArgs('doctor', new Date() as unknown as McpToolArgs),
+    rejectUnexpectedEmptyArgs('doctor', new Date()),
     'doctor: invalid arguments — Expected an object',
   )
 })

--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -40,7 +40,7 @@ export const EMPTY_OBJECT_INPUT_SCHEMA = {
 
 export function rejectUnexpectedEmptyArgs(
   toolName: EmptyArgsToolName,
-  args: McpToolArgs,
+  args: unknown,
 ): string | null {
   if (!isPlainObject(args)) {
     return `${toolName}: invalid arguments — Expected an object`


### PR DESCRIPTION
## Summary
- widen rejectUnexpectedEmptyArgs input to unknown to match its runtime validation behavior
- remove unnecessary casts from the empty-args schema tests

## Tests
- pnpm --dir cli test