### PR TITLE
Tighten info command canvas typing

### DIFF
--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -18,8 +18,8 @@ type InfoCommandOptions = {
 }
 
 type PrintableCanvas = {
-  width: number | '?'
-  height: number | '?'
+  readonly width: number | '?'
+  readonly height: number | '?'
 }
 
 export function infoCommand(): Command {


### PR DESCRIPTION
## Summary\n- Mark the info command's printable canvas fields as readonly to match their derived display-only usage.\n\n## Tests\n- pnpm --dir cli exec tsc && node --test --test-concurrency=1 cli/dist/commands/info.test.js\n- pnpm test