### PR TITLE
Harden inspect command test cleanup

### DIFF
--- a/cli/src/commands/inspect.test.ts
+++ b/cli/src/commands/inspect.test.ts
@@ -228,6 +228,7 @@ test('inspect command reports stat failures as read errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-stat-'))
   const scenePath = path.join(dir, 'scene.hype')
   const originalStatSync = fs.statSync
+  const originalStatSyncDescriptor = Object.getOwnPropertyDescriptor(fs, 'statSync')
   try {
     Object.defineProperty(fs, 'statSync', {
       configurable: true,
@@ -251,7 +252,11 @@ test('inspect command reports stat failures as read errors', async () => {
       `[inspect] failed to read ${path.resolve(scenePath)}: stat failed\n`,
     )
   } finally {
-    Object.defineProperty(fs, 'statSync', { value: originalStatSync })
+    if (originalStatSyncDescriptor) {
+      Object.defineProperty(fs, 'statSync', originalStatSyncDescriptor)
+    } else {
+      Object.defineProperty(fs, 'statSync', { value: originalStatSync })
+    }
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
@@ -260,6 +265,10 @@ test('inspect command reports read failures after stat succeeds', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-inspect-read-'))
   const scenePath = path.join(dir, 'scene.hype')
   const originalReadFileSync = fs.readFileSync
+  const originalReadFileSyncDescriptor = Object.getOwnPropertyDescriptor(
+    fs,
+    'readFileSync',
+  )
   try {
     fs.writeFileSync(scenePath, '')
     Object.defineProperty(fs, 'readFileSync', {
@@ -284,7 +293,11 @@ test('inspect command reports read failures after stat succeeds', async () => {
       `[inspect] failed to read ${path.resolve(scenePath)}: read failed\n`,
     )
   } finally {
-    Object.defineProperty(fs, 'readFileSync', { value: originalReadFileSync })
+    if (originalReadFileSyncDescriptor) {
+      Object.defineProperty(fs, 'readFileSync', originalReadFileSyncDescriptor)
+    } else {
+      Object.defineProperty(fs, 'readFileSync', { value: originalReadFileSync })
+    }
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Summary
- Restore exact fs method property descriptors after inspect command tests monkey-patch fs.statSync and fs.readFileSync.
- Keeps the change test-only and reduces cross-test global state leakage risk.

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/commands/inspect.test.js
- pnpm --dir cli test