### PR TITLE
Reject directory render outputs

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -603,6 +603,35 @@ test('render command reports output parent files before launching the app', asyn
   }
 })
 
+test('render command reports directory output paths before launching the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-dir-'))
+  const outPath = path.join(dir, 'out.mp4')
+  fs.mkdirSync(outPath)
+  try {
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          renderCommand({
+            locateApp: async () => {
+              throw new Error('should not locate app')
+            },
+            driveRender: async () => {
+              throw new Error('should not render')
+            },
+          }).parseAsync(['-o', outPath], {
+            from: 'user',
+          }),
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.match(stderr, /^\[render\] output path is a directory: .*out\.mp4$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render command reports output directory creation failures before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-mkdir-'))
   const outPath = path.join(dir, 'exports', 'out.mp4')

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -144,6 +144,23 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
           process.exit(2)
         }
       }
+      if (existsSync(outputPath)) {
+        let outputStats: fs.Stats
+        try {
+          outputStats = statSync(outputPath)
+        } catch (err) {
+          console.error(
+            `[render] failed to inspect output path ${outputPath}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          )
+          process.exit(2)
+        }
+        if (outputStats.isDirectory()) {
+          console.error(`[render] output path is a directory: ${outputPath}`)
+          process.exit(2)
+        }
+      }
 
       const sceneInput = opts.scene?.trim()
       if (opts.scene !== undefined && !sceneInput) {


### PR DESCRIPTION
## Summary
- Reject directory paths passed to the CLI render output option before locating or launching the desktop app
- Add a regression test covering the preflight failure

## Tests
- pnpm --dir cli test