### PR TITLE
Guard malformed camera query results

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -582,6 +582,48 @@ test('list_cameras returns an empty list when the scene has no camera nodes', as
   }
 })
 
+test('list_cameras ignores malformed camera-shaped node entries', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-query-malformed-camera-'))
+  const scenePath = path.join(dir, 'scene.hype')
+
+  try {
+    const bytes = buildSceneBytes({
+      meta: {
+        name: 'Malformed Camera Query',
+        canvas: { width: 320, height: 180 },
+      },
+      nodes: {
+        root: {
+          id: 'root',
+          kind: 'frame',
+          parent: null,
+          children: [],
+          size: { width: 320, height: 180 },
+          layout: { mode: 'none' },
+        },
+      },
+    })
+    const doc = new Y.Doc()
+    Y.applyUpdate(doc, bytes)
+    const scene = doc.getMap('scene')
+    const nodes = scene.get('nodes') as Y.Map<unknown>
+    nodes.set('malformedCameraEntry', { id: 42, kind: 'camera' })
+    fs.writeFileSync(scenePath, Y.encodeStateAsUpdate(doc))
+
+    const result = await handleListCameras({ scene: scenePath })
+    const payload = JSON.parse(assertToolText(result)) as {
+      activeCameraId: string | null
+      cameras: unknown[]
+    }
+
+    assert.equal(result.isError, undefined)
+    assert.equal(payload.activeCameraId, null)
+    assert.deepEqual(payload.cameras, [])
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -40,6 +40,10 @@ type LayerSummary = {
   parent: unknown
   children: string[]
 }
+type CameraSummary = McpToolArgs & {
+  id: string
+  kind: 'camera'
+}
 
 const SCENE_PATH_PROPERTY: StringSchemaProperty = {
   type: 'string',
@@ -177,7 +181,7 @@ export async function handleListCameras(
   const loaded = read('list_cameras', input.scene)
   if (!loaded.ok) return loaded.result
 
-  const cameras = Object.values(record(loaded.scene.nodes)).filter((raw) => record(raw).kind === 'camera')
+  const cameras = Object.values(record(loaded.scene.nodes)).filter(isCameraNode)
   return text({ activeCameraId: loaded.scene.activeCameraId ?? null, cameras })
 }
 
@@ -242,6 +246,10 @@ function record(value: unknown): McpToolArgs {
 
 function isRecord(value: unknown): value is McpToolArgs {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isCameraNode(value: unknown): value is CameraSummary {
+  return isRecord(value) && value.kind === 'camera' && typeof value.id === 'string'
 }
 
 function stringArray(value: unknown): string[] {


### PR DESCRIPTION
## Summary
- add a typed camera-node guard for the CLI MCP list_cameras handler
- cover malformed camera-shaped persisted nodes with a regression test

## Verification
- pnpm --dir cli test

Note: repo-wide pnpm typecheck still fails on existing app-side TypeScript errors outside this change.