### PR TITLE
Cover non-record query MCP args

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -96,6 +96,24 @@ test('query scene MCP handlers report invalid arguments as MCP errors', async ()
   }
 })
 
+test('query scene MCP handlers reject non-record argument payloads', async () => {
+  const cases: Array<{
+    name: string
+    run: () => Promise<CallToolResult>
+  }> = [
+    { name: 'list_layers', run: () => handleListLayers(null as never) },
+    { name: 'get_layer', run: () => handleGetLayer([] as never) },
+    { name: 'list_tracks', run: () => handleListTracks('scene.hype' as never) },
+    { name: 'list_cameras', run: () => handleListCameras(false as never) },
+  ]
+
+  for (const entry of cases) {
+    const result = await entry.run()
+    assert.equal(result.isError, true)
+    assert.match(assertToolText(result), new RegExp(`^${entry.name}: invalid arguments`))
+  }
+})
+
 test('query scene MCP handlers reject unknown arguments as MCP errors', async () => {
   const cases: Array<{
     name: string


### PR DESCRIPTION
## Summary
- add query MCP handler coverage for non-record argument payloads

## Tests
- pnpm --dir cli test