### PR TITLE
Tighten render command option types

### DIFF
--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -36,8 +36,8 @@ const EMPTY_OPTION_LABEL = '<empty>'
 interface RenderOptions {
   readonly output: string
   readonly format?: string
-  readonly quality?: string
-  readonly fps?: string
+  readonly quality: string
+  readonly fps: string
   readonly scene?: string
 }
 


### PR DESCRIPTION
## Summary
- Mark the render command's defaulted quality and fps options as required in the internal Commander option type.

## Tests
- pnpm --dir cli test
- pnpm test