### PR TITLE
chore(cli): mark process exit test error code readonly

### DIFF
--- a/cli/src/testUtils/processExit.ts
+++ b/cli/src/testUtils/processExit.ts
@@ -5,7 +5,7 @@ type ProcessExitCode = Parameters<typeof process.exit>[0]
 type NormalizedProcessExitCode = NonNullable<ProcessExitCode>
 
 export interface ProcessExitError extends Error {
-  exitCode: NormalizedProcessExitCode
+  readonly exitCode: NormalizedProcessExitCode
 }
 
 export async function withProcessExitThrow<T>(


### PR DESCRIPTION
## Summary\n- Mark the synthetic CLI test ProcessExitError exitCode as readonly to keep the captured exit status immutable.\n\n## Tests\n- pnpm --dir cli test