### PR TITLE
chore(cli): accept readonly open spawn args

### DIFF
--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -15,7 +15,7 @@ export interface OpenCommandDeps {
   readonly statSync: typeof fs.statSync
   readonly spawnApp: (
     command: string,
-    args: string[],
+    args: readonly string[],
     options: OpenSpawnOptions,
   ) => Pick<ChildProcess, 'unref'>
 }


### PR DESCRIPTION
## Summary
- tighten the open command dependency type to accept readonly spawn args

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/commands/open.test.js
- pnpm test