### PR TITLE
chore(cli): mark MCP test content readonly

### DIFF
--- a/cli/src/testUtils/mcp.ts
+++ b/cli/src/testUtils/mcp.ts
@@ -16,7 +16,7 @@ export function assertToolText(result: unknown): string {
 
 function isCallToolResultLike(
   result: unknown,
-): result is { content: CallToolResult['content'] } {
+): result is { readonly content: readonly CallToolResult['content'][number][] } {
   return (
     typeof result === 'object' &&
     result !== null &&


### PR DESCRIPTION
## Summary\n- mark the MCP test helper's validated content shape as readonly\n\n## Tests\n- pnpm --dir cli test