### PR TITLE
test(cli): cover output path stat failures

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -632,6 +632,37 @@ test('render command reports directory output paths before launching the app', a
   }
 })
 
+test('render command reports output path stat failures before launching the app', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-file-stat-'))
+  const outPath = path.join(dir, 'out.mp4')
+  fs.writeFileSync(outPath, '')
+  try {
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          renderCommand({
+            locateApp: async () => path.join(dir, 'hyper-motion'),
+            driveRender: async () => {
+              throw new Error('should not render')
+            },
+            statSync: (targetPath: fs.PathLike) => {
+              if (targetPath === outPath) throw new Error('stat failed')
+              return fs.statSync(targetPath)
+            },
+          }).parseAsync(['-o', outPath], {
+            from: 'user',
+          }),
+          { exitCode: 2 },
+        )
+      })
+    })
+
+    assert.equal(stderr, `[render] failed to inspect output path ${outPath}: stat failed\n`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render command reports output directory creation failures before launching the app', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-mkdir-'))
   const outPath = path.join(dir, 'exports', 'out.mp4')


### PR DESCRIPTION
## Summary
- add a focused render command regression test for existing output file stat failures
- verify the command exits before locating the desktop app or invoking the render driver

## Tests
- pnpm --dir cli test