### PR TITLE
Tighten render command option types

### DIFF
--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -36,8 +36,8 @@ const EMPTY_OPTION_LABEL = '<empty>'
 interface RenderOptions {
   readonly output: string
   readonly format?: string
-  readonly quality: string
-  readonly fps: string
+  readonly quality?: string
+  readonly fps?: string
   readonly scene?: string
 }
 


### PR DESCRIPTION
## Summary
- Mark defaulted render command options as optional in the local Commander option type
- Keep existing runtime defaults and validation unchanged

## Tests
- pnpm --dir cli test