### PR TITLE
chore(cli): type render scene schema

### DIFF
--- a/cli/src/mcp/tools/renderScene.ts
+++ b/cli/src/mcp/tools/renderScene.ts
@@ -55,6 +55,7 @@ const RenderInput = z.object({
     ),
 }).strict()
 type RenderInputData = z.infer<typeof RenderInput>
+type ToolInputSchema = Tool['inputSchema']
 export type RenderSceneDeps = {
   existsSync: typeof fs.existsSync
   statSync: (path: fs.PathLike) => fs.Stats
@@ -129,7 +130,7 @@ export const renderSceneTool: Tool = {
     },
     required: ['output'],
     additionalProperties: false,
-  },
+  } satisfies ToolInputSchema,
 }
 
 export async function handleRenderScene(


### PR DESCRIPTION
## Summary
- add an explicit Tool['inputSchema'] type check to the render_scene MCP schema
- keeps the render_scene schema aligned with nearby typed MCP tool schemas

## Tests
- pnpm --dir cli test
- pnpm --dir cli run build