### PR TITLE
Allow omitted args for empty MCP tools

### DIFF
--- a/cli/src/mcp/tools/schema.test.ts
+++ b/cli/src/mcp/tools/schema.test.ts
@@ -29,6 +29,10 @@ test('rejectUnexpectedEmptyArgs allows empty argument objects', () => {
   assert.equal(rejectUnexpectedEmptyArgs('doctor', {}), null)
 })
 
+test('rejectUnexpectedEmptyArgs allows omitted arguments for empty tools', () => {
+  assert.equal(rejectUnexpectedEmptyArgs('doctor', undefined), null)
+})
+
 test('rejectUnexpectedEmptyArgs allows null-prototype argument records', () => {
   const args = Object.create(null)
   assert.equal(rejectUnexpectedEmptyArgs('doctor', args), null)

--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -42,6 +42,7 @@ export function rejectUnexpectedEmptyArgs(
   toolName: EmptyArgsToolName,
   args: unknown,
 ): string | null {
+  if (args === undefined) return null
   if (!isPlainObject(args)) {
     return `${toolName}: invalid arguments — Expected an object`
   }


### PR DESCRIPTION
## Summary
- Treat omitted MCP arguments as an empty object for empty-args tools
- Add unit coverage for omitted arguments in the empty-args schema helper

## Verification
- pnpm --dir cli test -- --test-name-pattern='rejectUnexpectedEmptyArgs|EMPTY_OBJECT_INPUT_SCHEMA|EMPTY_ARGS_TOOL_NAMES'

Note: the CLI test script ran the full compiled CLI test suite; 448 tests passed.