### PR TITLE
Tighten render option set types

### DIFF
--- a/cli/src/renderOptions.ts
+++ b/cli/src/renderOptions.ts
@@ -8,15 +8,15 @@ export const RENDER_QUALITIES = ['comp', '720p', '2k', '4k'] as const
 export type RenderFormat = (typeof RENDER_FORMATS)[number]
 export type RenderQuality = (typeof RENDER_QUALITIES)[number]
 
-const RENDER_FORMAT_SET: ReadonlySet<string> = new Set(RENDER_FORMATS)
-const RENDER_QUALITY_SET: ReadonlySet<string> = new Set(RENDER_QUALITIES)
+const RENDER_FORMAT_SET: ReadonlySet<RenderFormat> = new Set(RENDER_FORMATS)
+const RENDER_QUALITY_SET: ReadonlySet<RenderQuality> = new Set(RENDER_QUALITIES)
 
 export function isRenderFormat(value: unknown): value is RenderFormat {
-  return typeof value === 'string' && RENDER_FORMAT_SET.has(value)
+  return typeof value === 'string' && RENDER_FORMAT_SET.has(value as RenderFormat)
 }
 
 export function isRenderQuality(value: unknown): value is RenderQuality {
-  return typeof value === 'string' && RENDER_QUALITY_SET.has(value)
+  return typeof value === 'string' && RENDER_QUALITY_SET.has(value as RenderQuality)
 }
 
 export function inferRenderFormatFromPath(filePath: string): RenderFormat {


### PR DESCRIPTION
## Summary
- type render format and quality lookup sets with their literal unions
- keep guard behavior unchanged while preserving narrower set types

## Verification
- `pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/renderOptions.test.js cli/dist/mcp/renderScene.test.js`

Note: a prior full `pnpm --dir cli test` run had 447/448 passing and one long-running `render_scene normalizes padded format and quality values` failure after ~15 minutes; the same test passed in focused reruns.