### PR TITLE
test(cli): cover info scene read failures

### DIFF
--- a/cli/src/mcp/infoScene.test.ts
+++ b/cli/src/mcp/infoScene.test.ts
@@ -8,6 +8,15 @@ import test from 'node:test'
 import { buildSceneBytes, type SceneSummary } from '../scene/build.js'
 import { assertToolText } from '../testUtils/mcp.js'
 import { handleInfoScene, infoSceneTool } from './tools/infoScene.js'
+import type { InfoSceneDeps } from './tools/infoScene.js'
+
+function testDeps(overrides: Partial<InfoSceneDeps>): InfoSceneDeps {
+  return {
+    statSync: fs.statSync,
+    readFileSync: fs.readFileSync,
+    ...overrides,
+  }
+}
 
 test('info_scene input schema exposes required scene path', () => {
   assert.deepEqual(infoSceneTool.inputSchema, {
@@ -135,6 +144,51 @@ test('info_scene reports missing files as MCP errors', async () => {
     const text = assertToolText(result)
     assert.match(text, /^info_scene: failed to read /)
     assert.match(text, /hypermotion-missing-/)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('info_scene reports stat failures as read errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-stat-'))
+  const scenePath = path.join(dir, 'scene.hype')
+
+  try {
+    const result = await handleInfoScene(
+      { scene: scenePath },
+      testDeps({
+        statSync: (statPath: fs.PathLike) => {
+          if (statPath === scenePath) throw new Error('stat failed')
+          return fs.statSync(statPath)
+        },
+      }),
+    )
+
+    assert.equal(result.isError, true)
+    assert.equal(assertToolText(result), `info_scene: failed to read ${scenePath}: stat failed`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('info_scene reports read failures after stat succeeds', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-read-'))
+  const scenePath = path.join(dir, 'scene.hype')
+
+  try {
+    fs.writeFileSync(scenePath, '')
+
+    const result = await handleInfoScene(
+      { scene: scenePath },
+      testDeps({
+        readFileSync: () => {
+          throw new Error('read failed')
+        },
+      }),
+    )
+
+    assert.equal(result.isError, true)
+    assert.equal(assertToolText(result), `info_scene: failed to read ${scenePath}: read failed`)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }

--- a/cli/src/mcp/tools/infoScene.ts
+++ b/cli/src/mcp/tools/infoScene.ts
@@ -28,6 +28,16 @@ const InfoInput = z.object({
 type InfoInputData = z.infer<typeof InfoInput>
 type ToolInputSchema = Tool['inputSchema']
 
+export type InfoSceneDeps = {
+  statSync: (path: fs.PathLike) => fs.Stats
+  readFileSync: (path: fs.PathOrFileDescriptor) => Buffer
+}
+
+const defaultDeps: InfoSceneDeps = {
+  statSync: fs.statSync,
+  readFileSync: fs.readFileSync,
+}
+
 export const infoSceneTool: Tool = {
   name: 'info_scene',
   description:
@@ -46,6 +56,7 @@ export const infoSceneTool: Tool = {
 
 export async function handleInfoScene(
   args: McpToolArgs,
+  deps: InfoSceneDeps = defaultDeps,
 ): Promise<CallToolResult> {
   const parsed = InfoInput.safeParse(args)
   if (!parsed.success) {
@@ -63,21 +74,35 @@ export async function handleInfoScene(
   const input: InfoInputData = parsed.data
   const scenePath = path.resolve(input.scene)
   let bytes: Buffer
+  let stats: fs.Stats
   try {
-    const stats = fs.statSync(scenePath)
-    if (!stats.isFile()) {
-      return {
-        isError: true,
-        content: [
-          {
-            type: 'text' as const,
-            text: `info_scene: scene path is not a file: ${scenePath}`,
-          },
-        ],
-      }
+    stats = deps.statSync(scenePath)
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `info_scene: failed to read ${scenePath}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
     }
-
-    bytes = fs.readFileSync(scenePath)
+  }
+  if (!stats.isFile()) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text' as const,
+          text: `info_scene: scene path is not a file: ${scenePath}`,
+        },
+      ],
+    }
+  }
+  try {
+    bytes = deps.readFileSync(scenePath)
   } catch (err) {
     return {
       isError: true,


### PR DESCRIPTION
## Summary\n- add typed filesystem dependencies to the info_scene MCP handler for deterministic tests\n- cover stat and read failure reporting without changing default fs behavior\n\n## Tests\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/infoScene.test.js\n\nNote: a broader CLI test run also exposed an unrelated pre-existing timeout in `driveHeadlessRender surfaces JSON error sentinel messages`; the modified info_scene tests pass after rebuild.