### PR TITLE
test(cli): cover null render sentinels

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -169,6 +169,7 @@ test('driveHeadlessRender clears stale error sentinels after successful renders'
       "if (!out) process.exit(2);",
       "fs.writeFileSync(out, 'fresh output');",
       "fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: 12 }));",
+      'setTimeout(() => {}, 500);',
     ].join('\n'),
   )
   fs.chmodSync(appPath, 0o755)
@@ -342,6 +343,44 @@ test('driveHeadlessRender ignores success sentinels with fractional metadata', a
   }
 })
 
+test('driveHeadlessRender ignores success sentinels with null metadata', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
+  const appPath = path.join(dir, 'fake-app.mjs')
+  const outputPath = path.join(dir, 'out.mp4')
+
+  fs.writeFileSync(
+    appPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = await import('node:fs');",
+      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
+      "const out = outArg?.slice('--out='.length);",
+      "if (!out) process.exit(2);",
+      "fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: null, bytes: null }));",
+      "setTimeout(() => {",
+      "  fs.writeFileSync(out, 'fresh output');",
+      "  fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: 12 }));",
+      '}, 100);',
+    ].join('\n'),
+  )
+  fs.chmodSync(appPath, 0o755)
+
+  try {
+    await driveHeadlessRender({
+      appPath,
+      outputPath,
+      format: 'mp4',
+      quality: 'comp',
+      fps: 30,
+    })
+
+    assert.equal(fs.readFileSync(outputPath, 'utf-8'), 'fresh output')
+    assert.equal(fs.existsSync(`${outputPath}.done`), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('driveHeadlessRender enables Electron logging when verbose mode is set', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
   const appPath = path.join(dir, 'fake-app.mjs')
@@ -465,6 +504,7 @@ test('driveHeadlessRender surfaces JSON error sentinel messages', async () => {
       "const out = outArg?.slice('--out='.length);",
       "if (!out) process.exit(2);",
       "fs.writeFileSync(`${out}.error`, JSON.stringify({ message: 'encoder reported JSON failure' }));",
+      'setTimeout(() => {}, 500);',
     ].join('\n'),
   )
   fs.chmodSync(appPath, 0o755)


### PR DESCRIPTION
## Summary
- Add CLI render driver coverage for success sentinels whose metadata is null.
- Verifies the driver keeps polling until a complete sentinel is written.

## Tests
- pnpm --dir cli test