### PR TITLE
test(cli): cover custom MCP empty args instances

### DIFF
--- a/cli/src/mcp/tools/schema.test.ts
+++ b/cli/src/mcp/tools/schema.test.ts
@@ -35,6 +35,8 @@ test('rejectUnexpectedEmptyArgs allows null-prototype argument records', () => {
 })
 
 test('rejectUnexpectedEmptyArgs rejects non-object arguments clearly', () => {
+  class CustomArgs {}
+
   assert.equal(
     rejectUnexpectedEmptyArgs('doctor', []),
     'doctor: invalid arguments — Expected an object',
@@ -45,6 +47,10 @@ test('rejectUnexpectedEmptyArgs rejects non-object arguments clearly', () => {
   )
   assert.equal(
     rejectUnexpectedEmptyArgs('doctor', new Date()),
+    'doctor: invalid arguments — Expected an object',
+  )
+  assert.equal(
+    rejectUnexpectedEmptyArgs('doctor', new CustomArgs()),
     'doctor: invalid arguments — Expected an object',
   )
 })


### PR DESCRIPTION
## Summary\n- add schema coverage for rejecting custom class instances passed to empty-args MCP tools\n\n## Verification\n- pnpm test\n- pnpm run build && node --test dist/mcp/tools/schema.test.js