### PR TITLE
test(cli): cover primitive empty-args inputs

### DIFF
--- a/cli/src/mcp/tools/schema.test.ts
+++ b/cli/src/mcp/tools/schema.test.ts
@@ -36,6 +36,18 @@ test('rejectUnexpectedEmptyArgs allows null-prototype argument records', () => {
 
 test('rejectUnexpectedEmptyArgs rejects non-object arguments clearly', () => {
   assert.equal(
+    rejectUnexpectedEmptyArgs('doctor', 'unexpected'),
+    'doctor: invalid arguments — Expected an object',
+  )
+  assert.equal(
+    rejectUnexpectedEmptyArgs('doctor', 1),
+    'doctor: invalid arguments — Expected an object',
+  )
+  assert.equal(
+    rejectUnexpectedEmptyArgs('doctor', true),
+    'doctor: invalid arguments — Expected an object',
+  )
+  assert.equal(
     rejectUnexpectedEmptyArgs('doctor', []),
     'doctor: invalid arguments — Expected an object',
   )


### PR DESCRIPTION
## Summary\n- add primitive input assertions for the MCP empty-args helper\n\n## Tests\n- pnpm --dir cli test