### PR TITLE
Bound headless render error sentinel waits

### DIFF
--- a/cli/src/commands/doctor.test.ts
+++ b/cli/src/commands/doctor.test.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
+import { RENDER_FORMATS, RENDER_QUALITIES } from '../renderOptions.js'
 import { withEnvVar } from '../testUtils/env.js'
 import { captureStderr } from '../testUtils/stdout.js'
 import { getDoctorReport } from './doctor.js'
@@ -30,6 +31,8 @@ test('doctor report lists supported commands and MCP tools once', async () => {
     assert.ok(report.mcpTools.includes('doctor'))
     assert.ok(report.mcpTools.includes('get_capabilities'))
     assert.ok(report.mcpTools.includes('render_scene'))
+    assert.deepEqual(report.render.formats, RENDER_FORMATS)
+    assert.deepEqual(report.render.qualities, RENDER_QUALITIES)
     assert.equal(report.render.fileSceneInput, true)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -64,6 +64,13 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
   cleanFile(sentinelPath)
   cleanFile(errorPath)
 
+  try {
+    fs.accessSync(req.appPath, fs.constants.X_OK)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new Error(`Failed to spawn desktop app: ${message}`)
+  }
+
   // Use `--key=value` form (not `--key value`) for every value flag.
   // Electron's `second-instance` event delivers argv pre-processed by
   // Chromium's CommandLine class, which drops bare values between
@@ -137,6 +144,10 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
       if (message) {
         cleanFile(errorPath)
         throw new Error(message)
+      }
+      if (exitedAt > 0 && Date.now() - exitedAt > POST_EXIT_GRACE_MS) {
+        cleanFile(errorPath)
+        throw new Error('Render failed (no details available)')
       }
     }
     // If the child exited with a non-zero code AND no sentinel has


### PR DESCRIPTION
## Summary
- Preflight the headless render app path for executability after stale output/sentinel cleanup.
- Fall back to a generic render error when an error sentinel remains unreadable after the spawned process exits and the grace window elapses.
- Cover doctor report render formats and quality presets against the shared constants.

## Tests
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js
- pnpm --dir cli test