### PR TITLE
chore(cli): mark locator candidates readonly

### DIFF
--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -63,7 +63,7 @@ function resolveOverrideBinary(override: string): string | null {
 }
 
 function locateMac(): string | null {
-  const candidates = [
+  const candidates: readonly string[] = [
     '/Applications/hyper-motion.app/Contents/MacOS/hyper-motion',
     path.join(os.homedir(), 'Applications/hyper-motion.app/Contents/MacOS/hyper-motion'),
   ]
@@ -76,7 +76,7 @@ function locateMac(): string | null {
 function locateWindows(): string | null {
   const programFiles = process.env['ProgramFiles'] ?? 'C:\\Program Files'
   const localAppData = process.env['LOCALAPPDATA'] ?? path.join(os.homedir(), 'AppData', 'Local')
-  const candidates = [
+  const candidates: readonly string[] = [
     path.join(programFiles, 'hyper-motion', 'hyper-motion.exe'),
     path.join(localAppData, 'Programs', 'hyper-motion', 'hyper-motion.exe'),
   ]
@@ -87,7 +87,7 @@ function locateWindows(): string | null {
 }
 
 function locateLinux(): string | null {
-  const candidates = [
+  const candidates: readonly string[] = [
     '/opt/hyper-motion/hyper-motion',
     '/usr/bin/hyper-motion',
     path.join(os.homedir(), 'Applications/hyper-motion.AppImage'),


### PR DESCRIPTION
## Summary
- Mark desktop app locator candidate lists as readonly arrays.
- Keeps the platform lookup paths immutable at the type level without changing runtime behavior.

## Tests
- PASS: pnpm --dir cli test (448 tests, 0 failures) before rebasing onto latest main.
- PASS: pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/renderScene.test.js --test-name-pattern "render_scene normalizes padded format and quality values" after rebasing.
- NOTE: a full post-rebase rerun hit a transient timeout in render_scene normalizes padded format and quality values; the same test passed when isolated immediately after.