### PR TITLE
chore(cli): mark render error sentinel readonly

### DIFF
--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -239,7 +239,7 @@ function readRenderErrorMessage(errorPath: string): string | null {
   return message
 }
 
-function hasErrorMessage(value: unknown): value is { message: string } {
+function hasErrorMessage(value: unknown): value is Readonly<{ message: string }> {
   return (
     typeof value === 'object' &&
     value !== null &&


### PR DESCRIPTION
## Summary\n- mark the render error sentinel message guard as readonly\n\n## Verification\n- pnpm --dir cli test