### PR TITLE
test(cli): cover unset env empty mutation

### DIFF
--- a/cli/src/testUtils/env.test.ts
+++ b/cli/src/testUtils/env.test.ts
@@ -118,6 +118,18 @@ test('withEnvVar removes variables that were originally unset', async () => {
   assert.equal(process.env[name], undefined)
 })
 
+test('withEnvVar removes originally unset variables after callback sets empty string', async () => {
+  const name = 'HYPERMOTION_TEST_ENV_UNSET_MUTATED_EMPTY'
+  delete process.env[name]
+
+  await withEnvVar(name, 'during', () => {
+    process.env[name] = ''
+    assert.equal(process.env[name], '')
+  })
+
+  assert.equal(process.env[name], undefined)
+})
+
 test('withEnvVar removes originally unset variables after callback failures', async () => {
   const name = 'HYPERMOTION_TEST_ENV_UNSET_THROW'
   delete process.env[name]


### PR DESCRIPTION
## Summary
- Add CLI helper coverage for restoring an originally unset env var after a callback mutates it to an empty string.

## Verification
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/testUtils/env.test.js
- pnpm test

Mergify should handle merge if checks pass.