### PR TITLE
Validate CLI fps as decimal input

### DIFF
--- a/cli/src/commands/render.test.ts
+++ b/cli/src/commands/render.test.ts
@@ -378,6 +378,27 @@ test('render command rejects fractional fps before launching the app', async () 
   assert.match(stderr, /^\[render\] invalid fps: 30\.5$/m)
 })
 
+test('render command rejects JavaScript numeric fps notation before launching the app', async () => {
+  for (const fpsInput of ['1e2', '0x10']) {
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          renderCommand({
+            locateApp: async () => {
+              throw new Error('should not locate app')
+            },
+          }).parseAsync(['-o', 'out.mp4', '--fps', fpsInput], {
+            from: 'user',
+          }),
+          { exitCode: 1 },
+        )
+      })
+    })
+
+    assert.match(stderr, new RegExp(`^\\[render\\] invalid fps: ${fpsInput}$`, 'm'))
+  }
+})
+
 test('render command reports unsupported formats before launching the app', async () => {
   const stderr = await captureStderr(() => {
     return withProcessExitThrow(async () => {

--- a/cli/src/commands/render.ts
+++ b/cli/src/commands/render.ts
@@ -32,6 +32,7 @@ import {
 const FORMAT_HELP = RENDER_FORMATS.join(' / ')
 const QUALITY_HELP = RENDER_QUALITIES.join(' / ')
 const EMPTY_OPTION_LABEL = '<empty>'
+const FPS_INPUT_RE = /^\d+$/
 
 interface RenderOptions {
   readonly output: string
@@ -108,7 +109,7 @@ export function renderCommand(deps: RenderCommandDeps = {}): Command {
 
       const fpsInput = opts.fps?.trim() ?? '30'
       const fps = Number(fpsInput)
-      if (!Number.isInteger(fps) || fps <= 0 || fps > 120) {
+      if (!FPS_INPUT_RE.test(fpsInput) || fps <= 0 || fps > 120) {
         console.error(`[render] invalid fps: ${fpsInput}`)
         process.exit(1)
       }


### PR DESCRIPTION
## Summary
- require CLI render --fps values to be plain decimal integer input
- add a regression test for JavaScript numeric notation like 1e2 and 0x10

## Verification
- pnpm --dir cli test
- pnpm exec eslint cli/src/commands/render.ts cli/src/commands/render.test.ts

## Notes
- pnpm typecheck currently fails on unrelated app-level TypeScript errors outside this change.
- pnpm lint currently fails on unrelated app-level ESLint errors outside this change.