### PR TITLE
Reject symbol keys in empty MCP args

### DIFF
--- a/cli/src/mcp/tools/schema.test.ts
+++ b/cli/src/mcp/tools/schema.test.ts
@@ -92,3 +92,14 @@ test('rejectUnexpectedEmptyArgs reports unexpected null-prototype keys', () => {
     'list_keyframeable_properties: invalid arguments — Unrecognized key(s): alpha, zeta',
   )
 })
+
+test('rejectUnexpectedEmptyArgs reports unexpected symbol keys', () => {
+  const internal = Symbol('internal')
+
+  assert.equal(
+    rejectUnexpectedEmptyArgs('doctor', {
+      [internal]: true,
+    }),
+    'doctor: invalid arguments — Unrecognized key(s): Symbol(internal)',
+  )
+})

--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -46,9 +46,18 @@ export function rejectUnexpectedEmptyArgs(
   if (!isPlainObject(args)) {
     return `${toolName}: invalid arguments — Expected an object`
   }
-  const keys = Object.keys(args).sort()
+  const keys = ownEnumerableKeyNames(args).sort()
   if (keys.length === 0) return null
   return `${toolName}: invalid arguments — Unrecognized key(s): ${keys.join(', ')}`
+}
+
+function ownEnumerableKeyNames(value: McpToolArgs): string[] {
+  return [
+    ...Object.keys(value),
+    ...Object.getOwnPropertySymbols(value)
+      .filter((symbol) => Object.prototype.propertyIsEnumerable.call(value, symbol))
+      .map(String),
+  ]
 }
 
 function isPlainObject(value: unknown): value is McpToolArgs {


### PR DESCRIPTION
## Summary
- reject own enumerable symbol keys in empty-argument MCP tool validation
- add a focused schema regression test for symbol-only argument records

## Tests
- pnpm --dir cli run build && node --test cli/dist/mcp/tools/schema.test.js
- pnpm --dir cli test