### PR TITLE
test(cli): cover capability MCP non-record args

### DIFF
--- a/cli/src/mcp/capabilities.test.ts
+++ b/cli/src/mcp/capabilities.test.ts
@@ -126,6 +126,18 @@ test('capability tools reject unknown arguments as MCP errors', async () => {
   assert.match(assertToolText(keyframeable), /Unrecognized key/)
 })
 
+test('capability tools reject non-record arguments as MCP errors', async () => {
+  const capabilities = await handleGetCapabilities(null as never)
+  const keyframeable = await handleListKeyframeableProperties([] as never)
+
+  assert.equal(capabilities.isError, true)
+  assert.match(assertToolText(capabilities), /^get_capabilities: invalid arguments/)
+  assert.match(assertToolText(capabilities), /Expected an object/)
+  assert.equal(keyframeable.isError, true)
+  assert.match(assertToolText(keyframeable), /^list_keyframeable_properties: invalid arguments/)
+  assert.match(assertToolText(keyframeable), /Expected an object/)
+})
+
 test('get_capabilities description mentions agent-facing capability groups', () => {
   const getCapabilities = TOOLS.find((tool) => tool.name === 'get_capabilities')
   const description = getCapabilities?.description ?? ''


### PR DESCRIPTION
## Summary
- add MCP capability handler coverage for non-record argument payloads

## Tests
- `pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/mcp/capabilities.test.js`
- `pnpm --dir cli run build && node --test --test-concurrency=1 --test-name-pattern "driveHeadlessRender disables Electron logging by default|render_scene normalizes padded format and quality values" cli/dist/electron/driver.test.js cli/dist/mcp/renderScene.test.js`

Note: an initial full `pnpm --dir cli test` run hit two existing long-timeout render sentinel flakes; both failing tests passed when rerun directly.