### PR TITLE
test(cli): narrow malformed scene test input type

### DIFF
--- a/cli/src/commands/validate.test.ts
+++ b/cli/src/commands/validate.test.ts
@@ -10,7 +10,11 @@ import { withProcessExitThrow } from '../testUtils/processExit.js'
 import { captureStderr, captureStdout } from '../testUtils/stdout.js'
 import { validateCommand } from './validate.js'
 
-function malformedSceneInput(value: Record<string, unknown>): SceneJson {
+type MalformedSceneJson = Omit<SceneJson, 'nodes'> & {
+  nodes: Record<string, Record<string, unknown>>
+}
+
+function malformedSceneInput(value: MalformedSceneJson): SceneJson {
   return value as unknown as SceneJson
 }
 


### PR DESCRIPTION
## Summary
- add a named malformed scene test type for validate command fixtures
- keep the invalid-scene cast localized while narrowing the helper input shape

## Tests
- pnpm --dir cli test (passed before rebase: 451 tests, 0 failures)
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/commands/validate.test.js (passed after final rebase: 20 tests, 0 failures)

Note: a post-rebase full CLI rerun later hit unrelated long-timeout render-driver flakes in driveHeadlessRender/render_scene tests; the touched validation test file passed after rebasing onto current main.