### PR TITLE
Tighten MCP text assertion guard

### DIFF
--- a/cli/src/testUtils/mcp.test.ts
+++ b/cli/src/testUtils/mcp.test.ts
@@ -74,6 +74,6 @@ test('assertToolText rejects malformed text payloads', () => {
 
   assert.throws(
     () => assertToolText(result),
-    /expected MCP text content to be a string/,
+    /expected first MCP content item to be text/,
   )
 })

--- a/cli/src/testUtils/mcp.ts
+++ b/cli/src/testUtils/mcp.ts
@@ -28,5 +28,5 @@ function isCallToolResultLike(
 function isToolTextContent(
   item: CallToolResult['content'][number] | undefined,
 ): item is ToolTextContent {
-  return item?.type === 'text'
+  return item?.type === 'text' && typeof item.text === 'string'
 }


### PR DESCRIPTION
## Summary\n- require MCP text assertion helper payloads to include a string text field before narrowing\n- update the malformed payload test expectation for the stricter guard\n\n## Tests\n- pnpm test\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/testUtils/mcp.test.js