### PR TITLE
test(cli): cover function empty MCP args

### DIFF
--- a/cli/src/mcp/tools/schema.test.ts
+++ b/cli/src/mcp/tools/schema.test.ts
@@ -69,6 +69,10 @@ test('rejectUnexpectedEmptyArgs rejects non-object arguments clearly', () => {
     rejectUnexpectedEmptyArgs('doctor', new CustomArgs()),
     'doctor: invalid arguments — Expected an object',
   )
+  assert.equal(
+    rejectUnexpectedEmptyArgs('doctor', () => ({})),
+    'doctor: invalid arguments — Expected an object',
+  )
 })
 
 test('rejectUnexpectedEmptyArgs reports unexpected keys deterministically', () => {


### PR DESCRIPTION
## Summary
- Add function payload coverage for the empty-args MCP helper.
- Keeps behavior unchanged; this only verifies function arguments are rejected with the existing message.

## Tests
- PASS: pnpm --dir cli exec tsc && node --test --test-concurrency=1 cli/dist/mcp/tools/schema.test.js
- NOTE: earlier full run of pnpm --dir cli test failed in unrelated render driver sentinel tests: driveHeadlessRender surfaces plain-text error sentinels, driveHeadlessRender surfaces JSON error sentinel messages, and render_scene normalizes padded format and quality values.