### PR TITLE
test(cli): reduce render driver sentinel flakes

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -280,10 +280,10 @@ test('driveHeadlessRender ignores malformed success sentinels', async () => {
       "const out = outArg?.slice('--out='.length);",
       "if (!out) process.exit(2);",
       "fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: -1 }));",
-      "setTimeout(() => {",
+      "setImmediate(() => {",
       "  fs.writeFileSync(out, 'fresh output');",
       "  fs.writeFileSync(`${out}.done`, JSON.stringify({ ts: Date.now(), bytes: 12 }));",
-      '}, 100);',
+      '});',
     ].join('\n'),
   )
   fs.chmodSync(appPath, 0o755)
@@ -500,7 +500,10 @@ test('driveHeadlessRender trims JSON error sentinel messages', async () => {
       "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
       "const out = outArg?.slice('--out='.length);",
       "if (!out) process.exit(2);",
-      "fs.writeFileSync(`${out}.error`, JSON.stringify({ message: '  encoder reported JSON failure  ' }));",
+      "const writeError = () => fs.writeFileSync(`${out}.error`, JSON.stringify({ message: '  encoder reported JSON failure  ' }));",
+      'writeError();',
+      'const timer = setInterval(writeError, 50);',
+      'setTimeout(() => clearInterval(timer), 500);',
     ].join('\n'),
   )
   fs.chmodSync(appPath, 0o755)


### PR DESCRIPTION
## Summary\n- make the malformed success sentinel fixture complete on the next event-loop turn instead of a wall-clock timer\n- keep the trimmed JSON error sentinel visible briefly so the polling loop reliably observes it under load\n\n## Verification\n- pnpm run build && node --test --test-concurrency=1 --test-name-pattern='driveHeadlessRender (ignores malformed success sentinels|trims JSON error sentinel messages)' dist/electron/driver.test.js\n\nNote: a full `pnpm test` run was attempted before this narrower fix and exposed broader pre-existing render-driver timing flakes in other cases under heavy load.