### PR TITLE
test: cover non-error open launch failures

### DIFF
--- a/cli/src/commands/open.test.ts
+++ b/cli/src/commands/open.test.ts
@@ -237,3 +237,29 @@ test('open command reports desktop launch failures', async () => {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('open command reports non-Error desktop launch failures', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-open-launch-string-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  const appPath = path.join(dir, 'hyper-motion')
+  fs.writeFileSync(scenePath, '')
+  try {
+    const stderr = await captureStderr(() => {
+      return withProcessExitThrow(async () => {
+        await assert.rejects(
+          openCommand({
+            locateApp: async () => appPath,
+            spawnApp: () => {
+              throw new String('launch failed')
+            },
+          }).parseAsync([scenePath], { from: 'user' }),
+          { exitCode: 1 },
+        )
+      })
+    })
+
+    assert.equal(stderr, `[open] failed to open ${scenePath}: launch failed\n`)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary\n- add coverage for non-Error desktop launch failures in the CLI open command\n\n## Tests\n- pnpm --dir cli test (passed once before final rebase: 450 passed, 0 failed)\n- pnpm exec eslint cli/src/commands/open.test.ts\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js cli/dist/commands/open.test.js (28 passed, 0 failed; reran after one unrelated driver timeout)\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/commands/open.test.js (10 passed, 0 failed after final rebase)\n\nNote: a later full CLI rerun hit an unrelated existing driver timeout in `driveHeadlessRender ignores success sentinels with fractional metadata`; the same driver test passed in the focused rerun.