### PR TITLE
test(cli): cover render_scene output stat failures

### DIFF
--- a/cli/src/mcp/renderScene.test.ts
+++ b/cli/src/mcp/renderScene.test.ts
@@ -217,6 +217,34 @@ test('render_scene reports output parent files before locating the app', async (
   }
 })
 
+test('render_scene reports output path stat failures as MCP errors', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-file-stat-'))
+  const outputPath = path.join(dir, 'out.mp4')
+  fs.writeFileSync(outputPath, 'existing output')
+
+  try {
+    const result = await handleRenderScene(
+      {
+        output: outputPath,
+      },
+      testDeps({
+        statSync: (targetPath: fs.PathLike) => {
+          if (targetPath === outputPath) throw new Error('stat failed')
+          return fs.statSync(targetPath)
+        },
+      }),
+    )
+
+    assert.equal(result.isError, true)
+    assert.equal(
+      assertToolText(result),
+      `render_scene: failed to inspect output path ${outputPath}: stat failed`,
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('render_scene reports output directory stat failures as MCP errors', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-render-out-stat-'))
   const outDir = path.join(dir, 'exports')


### PR DESCRIPTION
## Summary
- Add focused MCP coverage for `render_scene` when an existing output path cannot be inspected.
- Verifies the handler returns the existing user-facing MCP error before attempting app lookup or render.

## Verification
- `pnpm --dir cli run build && node --test --test-name-pattern="render_scene reports output path stat failures as MCP errors" cli/dist/mcp/renderScene.test.js`

## Note
- A broader `pnpm --dir cli test` run hit intermittent fake-app driver timeouts unrelated to this branch; the targeted post-rebase test above passed.
