### PR TITLE
Tighten query scene handler input types

### DIFF
--- a/cli/src/mcp/queryScene.test.ts
+++ b/cli/src/mcp/queryScene.test.ts
@@ -101,10 +101,10 @@ test('query scene MCP handlers reject non-record argument payloads', async () =>
     name: string
     run: () => Promise<CallToolResult>
   }> = [
-    { name: 'list_layers', run: () => handleListLayers(null as never) },
-    { name: 'get_layer', run: () => handleGetLayer([] as never) },
-    { name: 'list_tracks', run: () => handleListTracks('scene.hype' as never) },
-    { name: 'list_cameras', run: () => handleListCameras(false as never) },
+    { name: 'list_layers', run: () => handleListLayers(null) },
+    { name: 'get_layer', run: () => handleGetLayer([]) },
+    { name: 'list_tracks', run: () => handleListTracks('scene.hype') },
+    { name: 'list_cameras', run: () => handleListCameras(false) },
   ]
 
   for (const entry of cases) {

--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -107,7 +107,7 @@ export const listCamerasTool: Tool = {
 }
 
 export async function handleListLayers(
-  args: McpToolArgs,
+  args: unknown,
 ): Promise<CallToolResult> {
   const parsed = SceneInput.safeParse(args)
   if (!parsed.success) return invalidArgs('list_layers', parsed.error.message)
@@ -133,7 +133,7 @@ export async function handleListLayers(
 }
 
 export async function handleGetLayer(
-  args: McpToolArgs,
+  args: unknown,
 ): Promise<CallToolResult> {
   const parsed = LayerInput.safeParse(args)
   if (!parsed.success) return invalidArgs('get_layer', parsed.error.message)
@@ -148,7 +148,7 @@ export async function handleGetLayer(
 }
 
 export async function handleListTracks(
-  args: McpToolArgs,
+  args: unknown,
 ): Promise<CallToolResult> {
   const parsed = TrackInput.safeParse(args)
   if (!parsed.success) return invalidArgs('list_tracks', parsed.error.message)
@@ -166,7 +166,7 @@ export async function handleListTracks(
 }
 
 export async function handleListCameras(
-  args: McpToolArgs,
+  args: unknown,
 ): Promise<CallToolResult> {
   const parsed = SceneInput.safeParse(args)
   if (!parsed.success) return invalidArgs('list_cameras', parsed.error.message)


### PR DESCRIPTION
## Summary
- Accept unknown payloads at the query-scene MCP handler boundary so signatures match runtime schema validation.
- Remove forced casts from the non-record payload regression test.

## Verification
- pnpm --dir cli run build
- node --test --test-concurrency=1 cli/dist/mcp/queryScene.test.js

Note: a full pnpm --dir cli test run hit the existing long-running driver sentinel test timeout in `driveHeadlessRender surfaces JSON error sentinel messages`; the targeted query-scene build/test path passed after rebasing onto latest main.