### PR TITLE
test(cli): consolidate JSON error sentinel coverage

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -464,42 +464,6 @@ test('driveHeadlessRender surfaces JSON error sentinel messages', async () => {
       "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
       "const out = outArg?.slice('--out='.length);",
       "if (!out) process.exit(2);",
-      "fs.writeFileSync(`${out}.error`, JSON.stringify({ message: 'encoder reported JSON failure' }));",
-    ].join('\n'),
-  )
-  fs.chmodSync(appPath, 0o755)
-
-  try {
-    await assert.rejects(
-      driveHeadlessRender({
-        appPath,
-        outputPath,
-        format: 'mp4',
-        quality: 'comp',
-        fps: 30,
-      }),
-      /encoder reported JSON failure/,
-    )
-    assert.equal(fs.existsSync(outputPath), false)
-    assert.equal(fs.existsSync(`${outputPath}.error`), false)
-  } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
-  }
-})
-
-test('driveHeadlessRender trims JSON error sentinel messages', async () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
-  const appPath = path.join(dir, 'fake-app.mjs')
-  const outputPath = path.join(dir, 'out.mp4')
-
-  fs.writeFileSync(
-    appPath,
-    [
-      '#!/usr/bin/env node',
-      "const fs = await import('node:fs');",
-      "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
-      "const out = outArg?.slice('--out='.length);",
-      "if (!out) process.exit(2);",
       "fs.writeFileSync(`${out}.error`, JSON.stringify({ message: '  encoder reported JSON failure  ' }));",
     ].join('\n'),
   )
@@ -516,6 +480,7 @@ test('driveHeadlessRender trims JSON error sentinel messages', async () => {
       }),
       /^Error: encoder reported JSON failure$/,
     )
+    assert.equal(fs.existsSync(outputPath), false)
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- Consolidate duplicate JSON error sentinel driver coverage into one test
- Preserve trimmed message assertion and stale output cleanup check while removing one fake-app spawn

## Verification
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js
- pnpm --dir cli test