### PR TITLE
test(cli): avoid invalid blank sentinel fixture

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -608,7 +608,7 @@ test('driveHeadlessRender falls back when JSON error sentinel messages are blank
       "const outArg = process.argv.find((arg) => arg.startsWith('--out='));",
       "const out = outArg?.slice('--out='.length);",
       "if (!out) process.exit(2);",
-      "fs.writeFileSync(`${out}.error`, JSON.stringify({ message: '  \\n\\t  ' }));",
+      "fs.writeFileSync(`${out}.error`, JSON.stringify({ message: '      ' }));",
     ].join('\n'),
   )
   fs.chmodSync(appPath, 0o755)


### PR DESCRIPTION
## Summary\n- keep the blank JSON error sentinel fixture whitespace-only without embedding a newline in generated JS\n- avoids a timeout in the driver test when the fake app fails before writing the sentinel\n\n## Tests\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js\n- pnpm --dir cli test