### PR TITLE
chore(cli): accept readonly scene arrays

### DIFF
--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -1439,9 +1439,9 @@ function ensureNodeChildren(node: Y.Map<unknown>): Y.Array<string> {
   return next
 }
 
-function arrayToY(items: unknown[]): Y.Array<unknown> {
+function arrayToY(items: readonly unknown[]): Y.Array<unknown> {
   const arr = new Y.Array<unknown>()
-  if (items.length > 0) arr.push(items)
+  if (items.length > 0) arr.push(Array.from(items))
   return arr
 }
 


### PR DESCRIPTION
## Summary\n- accept readonly arrays in the scene-to-Yjs array conversion helper\n- copy readonly inputs at the Yjs boundary before pushing\n\n## Tests\n- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/scene/build.test.js\n- pnpm --dir cli test\n- pnpm --dir cli test (after rebasing onto latest origin/main)