### PR TITLE
Fix locator override trailing slash handling

### DIFF
--- a/cli/src/electron/locator.test.ts
+++ b/cli/src/electron/locator.test.ts
@@ -56,6 +56,21 @@ test('locator accepts a HYPERMOTION_APP_PATH symlink to the app binary', async (
   }
 })
 
+test('locator accepts a HYPERMOTION_APP_PATH binary with trailing slash', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-binary-slash-'))
+  const appPath = path.join(dir, 'hyper-motion')
+
+  try {
+    fs.writeFileSync(appPath, '')
+
+    await withEnvVar('HYPERMOTION_APP_PATH', `${appPath}${path.sep}`, async () => {
+      assert.equal(await locateDesktopApp(), appPath)
+    })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('locator accepts a HYPERMOTION_APP_PATH macOS app bundle', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-locator-bundle-'))
   const bundlePath = path.join(dir, 'hyper-motion.app')

--- a/cli/src/electron/locator.ts
+++ b/cli/src/electron/locator.ts
@@ -52,14 +52,23 @@ export async function locateDesktopApp(): Promise<string | null> {
 }
 
 function resolveOverrideBinary(override: string): string | null {
-  if (isFile(override)) return override
+  const normalizedOverride = trimTrailingPathSeparators(override)
+  if (isFile(normalizedOverride)) return normalizedOverride
 
-  if (path.basename(override).toLowerCase().endsWith('.app')) {
-    const bundleBinary = path.join(override, 'Contents', 'MacOS', 'hyper-motion')
+  if (path.basename(normalizedOverride).toLowerCase().endsWith('.app')) {
+    const bundleBinary = path.join(normalizedOverride, 'Contents', 'MacOS', 'hyper-motion')
     if (isFile(bundleBinary)) return bundleBinary
   }
 
   return null
+}
+
+function trimTrailingPathSeparators(value: string): string {
+  let end = value.length
+  while (end > 1 && (value[end - 1] === '/' || value[end - 1] === '\\')) {
+    end -= 1
+  }
+  return value.slice(0, end)
 }
 
 function locateMac(): string | null {


### PR DESCRIPTION
## Summary
- normalize `HYPERMOTION_APP_PATH` before file/bundle detection so direct binary paths with a trailing slash still resolve
- cover the binary trailing-slash override case in the CLI locator tests

## Testing
- `cd cli && pnpm run build && node --test dist/electron/locator.test.js`

## Notes
- `pnpm --dir cli test` currently has unrelated pre-existing failures in `dist/electron/driver.test.js` and `dist/mcp/renderScene.test.js`.
