### PR TITLE
Tighten process exit test helper type

### DIFF
--- a/cli/src/testUtils/processExit.ts
+++ b/cli/src/testUtils/processExit.ts
@@ -2,7 +2,7 @@
 
 type ProcessExitCallback<T> = () => Promise<T> | T
 type ProcessExitCode = Parameters<typeof process.exit>[0]
-type NormalizedProcessExitCode = NonNullable<ProcessExitCode>
+type NormalizedProcessExitCode = Exclude<ProcessExitCode, null | undefined>
 
 export interface ProcessExitError extends Error {
   readonly exitCode: NormalizedProcessExitCode


### PR DESCRIPTION
## Summary\n- tighten the normalized process.exit code helper type to exclude only null/undefined\n\n## Tests\n- pnpm --dir cli exec tsc --noEmit\n- pnpm --dir cli run build && node --test cli/dist/testUtils/processExit.test.js cli/dist/electron/driver.test.js\n- pnpm --dir cli run build && node --test cli/dist/testUtils/processExit.test.js\n\nNote: a full `pnpm --dir cli test` run was attempted twice, but the existing fake-app driver tests timed out during long serialized runs in this environment. The affected driver file passed directly.