### PR TITLE
Stabilize headless render driver timing

### DIFF
--- a/cli/src/electron/driver.test.ts
+++ b/cli/src/electron/driver.test.ts
@@ -8,6 +8,10 @@ import test from 'node:test'
 import { driveHeadlessRender } from './driver.js'
 import { withEnvVar } from '../testUtils/env.js'
 
+function removeTempDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
+}
+
 test('driveHeadlessRender passes saved scene paths and clears stale files', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-driver-'))
   const appPath = path.join(dir, 'fake-app.mjs')
@@ -51,7 +55,7 @@ test('driveHeadlessRender passes saved scene paths and clears stale files', asyn
     assert.equal(fs.existsSync(`${outputPath}.done`), false)
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -86,7 +90,7 @@ test('driveHeadlessRender surfaces plain-text error sentinels', async () => {
     )
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -115,7 +119,7 @@ test('driveHeadlessRender removes stale files before spawn failures', async () =
     assert.equal(fs.existsSync(`${outputPath}.done`), false)
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -149,7 +153,7 @@ test('driveHeadlessRender falls back for blank plain-text error sentinels', asyn
     )
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -187,7 +191,7 @@ test('driveHeadlessRender clears stale error sentinels after successful renders'
     assert.equal(fs.existsSync(`${outputPath}.done`), false)
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -225,7 +229,7 @@ test('driveHeadlessRender waits for complete success sentinels', async () => {
     assert.equal(fs.readFileSync(outputPath, 'utf-8'), 'fresh output')
     assert.equal(fs.existsSync(`${outputPath}.done`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -263,7 +267,7 @@ test('driveHeadlessRender waits for success sentinels with timestamps', async ()
     assert.equal(fs.readFileSync(outputPath, 'utf-8'), 'fresh output')
     assert.equal(fs.existsSync(`${outputPath}.done`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -301,7 +305,7 @@ test('driveHeadlessRender ignores malformed success sentinels', async () => {
     assert.equal(fs.readFileSync(outputPath, 'utf-8'), 'fresh output')
     assert.equal(fs.existsSync(`${outputPath}.done`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -339,7 +343,7 @@ test('driveHeadlessRender ignores success sentinels with fractional metadata', a
     assert.equal(fs.readFileSync(outputPath, 'utf-8'), 'fresh output')
     assert.equal(fs.existsSync(`${outputPath}.done`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -413,7 +417,7 @@ test('driveHeadlessRender enables Electron logging when verbose mode is set', as
 
     assert.equal(fs.readFileSync(outputPath, 'utf-8'), '1')
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -449,7 +453,7 @@ test('driveHeadlessRender disables Electron logging by default', async () => {
 
     assert.equal(fs.readFileSync(outputPath, 'utf-8'), '')
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -485,7 +489,7 @@ test('driveHeadlessRender only enables Electron logging for verbose value 1', as
 
     assert.equal(fs.readFileSync(outputPath, 'utf-8'), '')
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -523,7 +527,7 @@ test('driveHeadlessRender surfaces JSON error sentinel messages', async () => {
     assert.equal(fs.existsSync(outputPath), false)
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -561,7 +565,7 @@ test('driveHeadlessRender trims JSON error sentinel messages', async () => {
     )
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -596,7 +600,7 @@ test('driveHeadlessRender falls back when JSON error sentinels omit messages', a
     )
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -634,7 +638,7 @@ test('driveHeadlessRender waits for complete JSON error sentinels', async () => 
     )
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -669,7 +673,7 @@ test('driveHeadlessRender falls back when JSON error sentinel messages are blank
     )
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -704,6 +708,6 @@ test('driveHeadlessRender falls back when JSON error sentinel messages are not s
     )
     assert.equal(fs.existsSync(`${outputPath}.error`), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })

--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -27,6 +27,7 @@
 
 import { spawn } from 'node:child_process'
 import fs from 'node:fs'
+import { performance } from 'node:perf_hooks'
 import type { RenderFormat, RenderQuality } from '../renderOptions.js'
 
 export interface HeadlessRenderRequest {
@@ -122,13 +123,13 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
   child.on('exit', (code, signal) => {
     exitCode = code
     exitSignal = signal
-    exitedAt = Date.now()
+    exitedAt = performance.now()
   })
 
   // Poll until the success sentinel is fully written. Empty, partial, or
   // malformed sentinel files are ignored and retried.
-  const start = Date.now()
-  while (Date.now() - start < RENDER_TIMEOUT_MS) {
+  const start = performance.now()
+  while (performance.now() - start < RENDER_TIMEOUT_MS) {
     if (errorRef.current) {
       throw new Error(`Failed to spawn desktop app: ${errorRef.current.message}`)
     }
@@ -154,7 +155,7 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
     // appeared after the grace window, the render failed.
     if (
       exitedAt > 0 &&
-      Date.now() - exitedAt > POST_EXIT_GRACE_MS &&
+      performance.now() - exitedAt > POST_EXIT_GRACE_MS &&
       exitCode !== null &&
       exitCode !== 0
     ) {
@@ -165,7 +166,7 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
         }`,
       )
     }
-    if (exitSignal && Date.now() - exitedAt > POST_EXIT_GRACE_MS) {
+    if (exitSignal && performance.now() - exitedAt > POST_EXIT_GRACE_MS) {
       throw new Error(`Desktop app was killed by signal ${exitSignal}`)
     }
 


### PR DESCRIPTION
## Summary
- Use monotonic time for headless render timeout and post-exit grace checks
- Add retrying cleanup for driver test temp directories to avoid transient ENOTEMPTY races

## Verification
- pnpm --dir cli run build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js

Note: a full pnpm --dir cli test run passed before the final rebase, but later full-suite reruns were interrupted by unrelated timing instability while main was advancing. The focused driver suite passes on the final rebased commit.