### PR TITLE
Harden CLI info timing output

### DIFF
--- a/cli/src/commands/info.test.ts
+++ b/cli/src/commands/info.test.ts
@@ -228,6 +228,44 @@ test('info command prints builder default timing when scene meta omits it', asyn
   }
 })
 
+test('info command replaces malformed timing metadata with defaults', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
+  const scenePath = path.join(dir, 'scene.hype')
+  try {
+    fs.writeFileSync(
+      scenePath,
+      buildSceneBytes({
+        meta: {
+          name: 'Malformed Timing',
+          duration: Number.NaN,
+          frameRate: Number.POSITIVE_INFINITY,
+          canvas: { width: 400, height: 300 },
+        },
+        nodes: {
+          root: {
+            id: 'root',
+            kind: 'frame',
+            parent: null,
+            children: [],
+            size: { width: 400, height: 300 },
+            layout: { mode: 'none' },
+          },
+        },
+      }),
+    )
+
+    const stdout = await captureStdout(async () => {
+      await infoCommand().exitOverride().parseAsync([scenePath], {
+        from: 'user',
+      })
+    })
+
+    assert.match(stdout, /^ {2}Duration: {2}0s @ 60fps$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('info command falls back for blank scene names', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hypermotion-info-'))
   const scenePath = path.join(dir, 'scene.hype')

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -22,6 +22,11 @@ type PrintableCanvas = {
   readonly height: number | '?'
 }
 
+type PrintableTiming = {
+  readonly duration: number
+  readonly frameRate: number
+}
+
 export function infoCommand(): Command {
   return new Command('info')
     .description('Read a .hype scene file and print a summary.')
@@ -81,13 +86,12 @@ export function infoCommand(): Command {
 
       const { meta } = summary
       const canvas = printableCanvas(meta.canvas)
+      const timing = printableTiming(meta.duration, meta.frameRate)
       const name = printableSceneName(meta.name)
-      const duration = meta.duration ?? 0
-      const frameRate = meta.frameRate ?? 60
 
       console.log(`Scene: ${name}`)
       console.log(`  Canvas:    ${canvas.width} × ${canvas.height}`)
-      console.log(`  Duration:  ${duration}s @ ${frameRate}fps`)
+      console.log(`  Duration:  ${timing.duration}s @ ${timing.frameRate}fps`)
       console.log(`  Layers:    ${summary.layerCount}`)
       console.log(`  Tracks:    ${summary.trackCount}`)
       console.log(`  Sections:  ${summary.sectionCount}`)
@@ -119,6 +123,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function printableCanvasValue(value: unknown): number | '?' {
   if (typeof value === 'number' && Number.isFinite(value)) return value
   return '?'
+}
+
+function printableTiming(duration: unknown, frameRate: unknown): PrintableTiming {
+  return {
+    duration: printableTimingValue(duration, 0),
+    frameRate: printableTimingValue(frameRate, 60),
+  }
+}
+
+function printableTimingValue(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  return fallback
 }
 
 function printableSceneName(value: unknown): string {


### PR DESCRIPTION
## Summary
- sanitize malformed persisted duration/frameRate values in `hypermotion info`
- keep human-readable output on the existing 0s / 60fps defaults for invalid timing metadata
- cover the malformed-timing case with a focused CLI test

## Testing
- pnpm --dir cli build
- pnpm --dir cli test -- --test-name-pattern='info command'
