### PR TITLE
Tighten MCP empty args type

### DIFF
--- a/cli/src/mcp/tools/schema.ts
+++ b/cli/src/mcp/tools/schema.ts
@@ -2,7 +2,7 @@
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js'
 
-export type McpToolArgs = Readonly<Record<string, unknown>>
+export type McpToolArgs = Readonly<Record<string | symbol, unknown>>
 export type StringSchemaProperty = {
   readonly type: 'string'
   readonly minLength?: number


### PR DESCRIPTION
## Summary
- Include symbol keys in the MCP empty-args helper type to match its runtime validation path.

## Tests
- PATH="/Users/siddharthponnapalli/.nvm/versions/node/v24.14.0/bin:/Users/siddharthponnapalli/.cargo/bin:/Users/siddharthponnapalli/.codex/tmp/arg0/codex-arg0Xn7qpZ:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/ChatGPT.app/Contents/Resources" corepack pnpm test