### PR TITLE
Mark query scene snapshot readonly

### DIFF
--- a/cli/src/mcp/tools/queryScene.ts
+++ b/cli/src/mcp/tools/queryScene.ts
@@ -17,10 +17,10 @@ type LayerInputData = z.infer<typeof LayerInput>
 type TrackInputData = z.infer<typeof TrackInput>
 type QuerySceneToolName = 'list_layers' | 'get_layer' | 'list_tracks' | 'list_cameras'
 type QuerySceneSnapshot = {
-  root?: unknown
-  activeCameraId?: unknown
-  nodes?: unknown
-  tracks?: unknown
+  readonly root?: unknown
+  readonly activeCameraId?: unknown
+  readonly nodes?: unknown
+  readonly tracks?: unknown
 }
 type ReadSceneResult =
   | { ok: true; scene: QuerySceneSnapshot }


### PR DESCRIPTION
## What changed

- Mark the internal query-scene snapshot fields as `readonly`.

## Why

The snapshot represents parsed scene data that query handlers only inspect. Encoding that immutability in the type prevents accidental assignments without changing runtime behavior or the public API.

## Impact

No user-visible behavior changes. This is an internal type-safety maintenance improvement.

## Validation

- `pnpm --dir cli test` (457 tests passed)
- `pnpm exec eslint cli/src/mcp/tools/queryScene.ts`
- `git diff --check`
