### PR TITLE
Prepare v0.1.12 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Plus everything you expect from a Jitter-class tool: a real timeline,
 in/out presets, easing curves, 3D camera with depth-of-field, and MP4 /
 WebM / GIF export.
 
-## Status — v0.1.11 research preview
+## Status — v0.1.12 research preview
 
 The semantic-layout-animation bet works end-to-end, with desktop
 editing, Figma import, pixel-correct export, and CLI / MCP workflows for
@@ -34,7 +34,7 @@ copies the app into `/Applications`, strips macOS's download quarantine,
 applies a local ad-hoc signature, and opens it. No drag-to-Applications,
 no "damaged" dialog, no per-version steps.
 
-For a specific version: `curl ... | bash -s -- v0.1.11`.
+For a specific version: `curl ... | bash -s -- v0.1.12`.
 
 ### Manual install
 
@@ -91,27 +91,32 @@ pnpm build
 Full step-by-step at [hypermotion.app/docs#figma-plugin](https://hypermotion.app/docs#figma-plugin).
 Figma Community publish (one-click install) is on the v0.2 roadmap.
 
-## What's in v0.1.11
+## What's in v0.1.12
 
-- **Semantic keyframes.** Animate variant, opacity, scale, rotation, gap,
-  padding — never raw `x` / `y`. Layouts can shift without breaking
-  timing.
-- **Auto-layout containers.** Flex with gap, padding, alignment. Same
-  model designers think in from Figma.
-- **3D camera** — X / Y / Z position, three-axis rotation, real
-  depth-of-field with aperture and focus distance.
+- **Curve-driven text animation.** Animate letters, words, lines, or whole
+  layers with 21 presets, editable stagger curves, Bézier motion paths,
+  and independent X / Y / Z travel.
+- **Reversible stagger choreography.** Set layer or text order to Forward
+  or Reverse, duplicate a stagger safely, or create an exact return that
+  restores the original state.
+- **Camera effects.** Add keyframeable Bloom and Chromatic Aberration
+  alongside animated focus, aperture, falloff, and depth of field.
+- **Smooth realtime preview.** Text-heavy scenes and camera effects use a
+  bounded preview budget while final exports retain full quality.
+- **Semantic keyframes + auto layout.** Animate variant, opacity, scale,
+  rotation, gap, and padding without breaking the layout model.
 - **Timeline with chapters** — named sections you can isolate, loop,
-  and export individually or concatenated.
+  and export individually or concatenated, with video and waveform-backed
+  audio on the same timeline.
 - **Pixel-correct export.** MP4 up to 4K (WebCodecs + mp4-muxer), WebM
-  via tab capture, GIF via gifenc. Captured directly from the renderer
-  — no screen-recording compromise.
+  via tab capture, and GIF via gifenc, with stalled render workers cleaned
+  up automatically.
 - **Figma import** — plugin that brings frames, text, layout sizing,
-  per-corner radii, individual stroke weights, and layout grids into the
-  canvas.
-- **AI-driveable** — included CLI + Model Context Protocol server. Claude
-  Code, Codex CLI, and any MCP-compatible agent can create `.hype`
-  scenes, inspect scene metadata, and render MP4 / WebM / GIF exports
-  from the terminal. See [`AGENTS.md`](./AGENTS.md).
+  fills, strokes, gradients, per-corner radii, and layout grids into the
+  canvas with improved fidelity.
+- **Scriptable `.hype` scenes.** The included CLI and MCP server can create,
+  inspect, patch, validate, open, and render saved scenes. See
+  [`AGENTS.md`](./AGENTS.md).
 - **Open source from day one.** Apache 2.0. Yjs-backed data model so
   real-time collab arrives without a rewrite.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,7 +1,73 @@
 # Releases
 
-Human-friendly release notes. The GitHub Releases page mirrors the entries
-below for the corresponding tag, plus auto-generated commit summaries.
+Human-friendly release notes. The GitHub Releases page mirrors the matching
+entry below for each corresponding tag.
+
+## v0.1.12 — Curve-driven text motion + camera effects (2026-07-20)
+
+Hyper Motion's text system can now animate letters, words, lines, or whole
+layers through editable motion. Shape stagger timing with custom Bézier
+curves, move text through XYZ along adjustable paths, reverse sequence order,
+build exact return animations, and finish scenes with camera-wide Bloom and
+Chromatic Aberration.
+
+### Curve-driven text animation
+
+- Animate by letter, word, line, or whole layer with 21 presets, including
+  Curve Drop, Scramble, Typewriter, Character Wave, Blur, Flip, and Gradient
+  Reveal.
+- Draw editable Bézier motion paths on the canvas or in the inspector, with
+  independent X, Y, and Z travel controls.
+- Shape stagger progression with a point-and-handle curve editor for
+  continuous, progressive entry instead of isolated letter drops.
+- Switch segmentation or animation type without breaking the stagger
+  relationship or manufacturing disconnected keyframes.
+
+### Reversible stagger choreography
+
+- Set Layer, Letter, Word, and Line order to Forward or Reverse without
+  reversing the underlying motion.
+- Duplicate a stagger as an independent animation or create an exact return
+  that restores the state before the stagger began.
+- Preserve custom paths, timing curves, values, and Bézier easing when
+  reversing or returning motion.
+
+### Camera effects and depth
+
+- Add camera-wide Bloom and Chromatic Aberration, with keyframeable amount,
+  direction, strength, radius, and threshold controls.
+- Keep the same effect in editor preview, fallback rendering, and final
+  export.
+- Improved depth-of-field movement, focus transitions, bokeh quality, and
+  opacity consistency across flat, 3D-plane, and grouped 3D render modes.
+
+### Smoother playback and safer exports
+
+- Reduced per-frame work for segment-based text animation and effect-heavy
+  scenes through cached geometry, coalesced updates, and adaptive realtime
+  quality. Final exports remain full quality.
+- Stabilized playhead timing, keyboard playback, zoom behavior, hit testing,
+  and stacked text-animation ordering.
+- Added automatic cleanup for stalled or orphaned hidden export workers so a
+  reload cannot leave a 4K render consuming CPU and GPU in the background.
+- Suspended hidden WebGL work while editing text to keep direct manipulation
+  responsive.
+
+### CLI and scene workflows
+
+- Expanded `.hype` workflows for creating, inspecting, patching, validating,
+  opening, and rendering saved scenes through the CLI and MCP server.
+- Added the new text-animation, stagger-path, camera-focus, and camera-effect
+  properties to scene authoring and validation.
+- Hardened scene and render argument validation, path handling, and error
+  reporting for agent-driven workflows.
+
+### Install on macOS
+
+Download the Apple Silicon or Intel DMG from this release, or use the
+one-line installer in the [installation guide](https://hypermotion.app/docs#install).
+The v0.1.x builds remain unsigned and macOS-only, so macOS may require the
+first-time setup described in that guide.
 
 ## v0.1.11 — Audio timeline + focus export workflow (2026-06-22)
 

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 #
 # Or for a specific version:
 #
-#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.11
+#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.12
 #
 # Works for every future release without changes — the script always
 # resolves the latest tag from the GitHub API unless you pass one.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyper-motion-electron",
   "private": true,
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "main": "dist-electron/main.cjs",
   "description": "Native motion design tool with Figma-style structural layout. Auto-layout, 3D camera, semantic keyframes, pixel-correct MP4 / WebM / GIF.",


### PR DESCRIPTION
## Summary

- bump the desktop app to v0.1.12
- add curated release notes for curve-driven text motion, reversible stagger, camera effects, playback, and CLI/MCP workflows
- refresh README and installer examples

## Validation

- pnpm test:canvas (297 tests)
- pnpm --dir cli test (461 tests)
- pnpm exec vite build
- release-note extraction smoke test
- git diff --check