### PR TITLE
Prepare v0.1.13 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Plus everything you expect from a Jitter-class tool: a real timeline,
 in/out presets, easing curves, 3D camera with depth-of-field, and MP4 /
 WebM / GIF export.
 
-## Status — v0.1.12 research preview
+## Status — v0.1.13 research preview
 
 The semantic-layout-animation bet works end-to-end, with desktop
 editing, Figma import, pixel-correct export, and CLI / MCP workflows for
@@ -34,7 +34,7 @@ copies the app into `/Applications`, strips macOS's download quarantine,
 applies a local ad-hoc signature, and opens it. No drag-to-Applications,
 no "damaged" dialog, no per-version steps.
 
-For a specific version: `curl ... | bash -s -- v0.1.12`.
+For a specific version: `curl ... | bash -s -- v0.1.13`.
 
 ### Manual install
 
@@ -76,8 +76,13 @@ open release/mac-arm64/hyper-motion.app
 
 ## Figma plugin
 
-Copy frames, text, layout, and strokes from Figma straight into
-hyper-motion. The plugin source lives in
+Copy frames, text, layout, and vector artwork from Figma straight into
+hyper-motion. Payload v2 imports supported artwork as native vector-backed
+layers and retains the canonical point/segment graph, Bézier controls,
+transforms, ordered paints, gradient metadata, and detailed strokes. Version 1
+payloads remain compatible, while complex constructs keep a sanitized SVG
+fallback for visual fidelity. Direct point editing remains a follow-up. The
+plugin source lives in
 [`figma-plugin/`](./figma-plugin) inside this repo.
 
 ```sh
@@ -91,7 +96,7 @@ pnpm build
 Full step-by-step at [hypermotion.app/docs#figma-plugin](https://hypermotion.app/docs#figma-plugin).
 Figma Community publish (one-click install) is on the v0.2 roadmap.
 
-## What's in v0.1.12
+## What's in v0.1.13
 
 - **Curve-driven text animation.** Animate letters, words, lines, or whole
   layers with 21 presets, editable stagger curves, Bézier motion paths,
@@ -111,9 +116,10 @@ Figma Community publish (one-click install) is on the v0.2 roadmap.
 - **Pixel-correct export.** MP4 up to 4K (WebCodecs + mp4-muxer), WebM
   via tab capture, and GIF via gifenc, with stalled render workers cleaned
   up automatically.
-- **Figma import** — plugin that brings frames, text, layout sizing,
-  fills, strokes, gradients, per-corner radii, and layout grids into the
-  canvas with improved fidelity.
+- **Figma v2 vector import.** Bring supported Figma artwork across as native
+  vector-backed layers with retained geometry, transforms, paint stacks,
+  gradients, and detailed strokes; older payloads and complex SVGs continue
+  through safe compatibility fallbacks.
 - **Scriptable `.hype` scenes.** The included CLI and MCP server can create,
   inspect, patch, validate, open, and render saved scenes. See
   [`AGENTS.md`](./AGENTS.md).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,50 @@
 Human-friendly release notes. The GitHub Releases page mirrors the matching
 entry below for each corresponding tag.
 
+## v0.1.13 — Figma v2 vector import (2026-07-20)
+
+Hyper Motion's Figma importer now brings supported vector artwork across as
+native vector-backed layers instead of flattening it to an image-only node.
+Payload v2 retains vector geometry, transforms, paint stacks, gradients, and
+detailed stroke metadata, while older payloads and complex artwork continue
+through safe compatibility paths.
+
+### Native vector-backed imports
+
+- Retain stable points, segments, Bézier controls, contours, regions, and path
+  winding in the scene document for supported Figma vectors.
+- Preserve direct-parent transforms through nested groups and boolean
+  operations, plus Figma sizing metadata for more faithful placement.
+- Keep version 1 clipboard payloads readable; legacy vectors continue through
+  the existing SVG image path.
+
+### Higher-fidelity appearance
+
+- Retain ordered fill and stroke stacks, opacity and blend metadata, gradient
+  stops and transforms, plus stroke width, alignment, dashes, offset, caps,
+  joins, and miter limits.
+- Keep a sanitized copy of the original SVG when artwork uses constructs that
+  cannot yet be converted losslessly to the canonical vector graph.
+- Use a PNG fallback only when Figma returns no usable SVG or reports collapsed
+  vector bounds.
+- Render vector-backed layers consistently in realtime preview and final Pixi
+  export, with a stable raster cache for animation frames.
+
+### More reliable paste flow
+
+- Prefer a fresh Figma clipboard payload over stale in-app copied layers.
+- Fall back to Electron's native clipboard bridge when the browser paste event
+  cannot expose text.
+- Show clear progress, success, unsupported-selection, malformed-data, and
+  plugin-version messages without interfering with ordinary text paste.
+
+### Install on macOS
+
+Download the Apple Silicon or Intel DMG from this release, or use the one-line
+installer in the [installation guide](https://hypermotion.app/docs#install).
+The v0.1.x builds remain unsigned and macOS-only, so macOS may require the
+first-time setup described in that guide.
+
 ## v0.1.12 — Curve-driven text motion + camera effects (2026-07-20)
 
 Hyper Motion's text system can now animate letters, words, lines, or whole

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 #
 # Or for a specific version:
 #
-#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.12
+#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.13
 #
 # Works for every future release without changes — the script always
 # resolves the latest tag from the GitHub API unless you pass one.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyper-motion-electron",
   "private": true,
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "main": "dist-electron/main.cjs",
   "description": "Native motion design tool with Figma-style structural layout. Auto-layout, 3D camera, semantic keyframes, pixel-correct MP4 / WebM / GIF.",


### PR DESCRIPTION
## Summary

- bump the desktop package to v0.1.13
- document the Figma v2 vector importer and its compatibility/fidelity behavior
- update the pinned installer example for v0.1.13

## Verification

- pnpm test:figma — 33 tests passed
- pnpm exec vite build — passed
- CSC_IDENTITY_AUTO_DISCOVERY=false pnpm run build:mac — passed
- verified local arm64 and Intel DMGs, with the arm64 app reporting version 0.1.13
- git diff --check — passed