### PR TITLE
Prepare v0.1.14 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Plus everything you expect from a Jitter-class tool: a real timeline,
 in/out presets, easing curves, 3D camera with depth-of-field, and MP4 /
 WebM / GIF export.
 
-## Status — v0.1.13 research preview
+## Status — v0.1.14 research preview
 
 The semantic-layout-animation bet works end-to-end, with desktop
 editing, Figma import, pixel-correct export, and CLI / MCP workflows for
@@ -34,7 +34,7 @@ copies the app into `/Applications`, strips macOS's download quarantine,
 applies a local ad-hoc signature, and opens it. No drag-to-Applications,
 no "damaged" dialog, no per-version steps.
 
-For a specific version: `curl ... | bash -s -- v0.1.13`.
+For a specific version: `curl ... | bash -s -- v0.1.14`.
 
 ### Manual install
 
@@ -96,8 +96,11 @@ pnpm build
 Full step-by-step at [hypermotion.app/docs#figma-plugin](https://hypermotion.app/docs#figma-plugin).
 Figma Community publish (one-click install) is on the v0.2 roadmap.
 
-## What's in v0.1.13
+## What's in v0.1.14
 
+- **Camera-accurate selection and resize.** Selection polygons, hit testing,
+  and all eight resize handles now follow workspace zoom, camera XYZ, tilt,
+  roll, FOV, and camera keyframe playback using the same projection as WebGL.
 - **Curve-driven text animation.** Animate letters, words, lines, or whole
   layers with 21 presets, editable stagger curves, Bézier motion paths,
   and independent X / Y / Z travel.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,50 @@
 Human-friendly release notes. The GitHub Releases page mirrors the matching
 entry below for each corresponding tag.
 
+## v0.1.14 — Camera-accurate selection and resize (2026-07-20)
+
+Selection chrome now uses the same world planes and live camera projection as
+the WebGL scene. Outlines, click targets, and resize handles stay attached to
+their layers through workspace zoom, camera movement, perspective changes, and
+camera animation instead of drifting back to the untransformed layout box.
+
+### Selection follows the active camera
+
+- Project every selected layer's four real world-space corners through camera
+  X, Y, and Z movement, dolly, X/Y tilt, roll, and field of view.
+- Update selection polygons continuously during camera keyframe playback,
+  timeline scrubbing, and transient camera gestures.
+- Sample the current animation-engine and gesture-preview camera state for
+  click and double-click hit testing, avoiding stale UI-frame coordinates.
+- Keep accurate individual outlines for multi-selection and the fixed viewport
+  outline for the root artboard.
+
+### Perspective-correct resize handles
+
+- Place all eight handles at projected corners and edge midpoints instead of
+  an axis-aligned approximation.
+- Rotate resize cursors to match the visible layer axes after camera or layer
+  rotation.
+- Ray-cast pointer movement back into the selected plane's local coordinates,
+  so every handle changes the intended width or height under perspective.
+- Refresh the drag projection while the camera animates rather than retaining
+  the camera frame captured at pointer-down.
+
+### Scoped realtime work
+
+- Resolve only selected nodes and the ancestor paths needed for their world
+  transforms, avoiding a second full-scene plane build on every camera frame.
+- Preserve the existing DOM selection fallback when WebGL is unavailable or
+  inline text editing temporarily owns the canvas.
+- Keep all editor selection chrome out of exported media.
+
+### Install on macOS
+
+Download the Apple Silicon or Intel DMG from this release, or use the one-line
+installer in the [installation guide](https://hypermotion.app/docs#install).
+The v0.1.x builds remain unsigned and macOS-only, so macOS may require the
+first-time setup described in that guide.
+
 ## v0.1.13 — Figma v2 vector import (2026-07-20)
 
 Hyper Motion's Figma importer now brings supported vector artwork across as

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 #
 # Or for a specific version:
 #
-#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.13
+#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.14
 #
 # Works for every future release without changes — the script always
 # resolves the latest tag from the GitHub API unless you pass one.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyper-motion-electron",
   "private": true,
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "main": "dist-electron/main.cjs",
   "description": "Native motion design tool with Figma-style structural layout. Auto-layout, 3D camera, semantic keyframes, pixel-correct MP4 / WebM / GIF.",


### PR DESCRIPTION
## Summary
- bump the desktop app to v0.1.14
- document camera-accurate selection, hit testing, and perspective resize handles
- update the pinned installer example and release notes

## Included fix
- PR #1257: camera-accurate selection and resize handles

## Validation
- PR #1257 CI passed
- pnpm test:canvas (306 tests)
- pnpm test:figma (33 tests)
- pnpm exec vite build