### PR TITLE
Bundle Figma importer and compact editor typography

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -42,6 +42,10 @@ Build-time dependencies:
   - Tailwind CSS (MIT)                  https://github.com/tailwindlabs/tailwindcss
   - ESLint (MIT)                        https://github.com/eslint/eslint
 
+Interface assets:
+  - Nucleo UI Essential icons           https://nucleoapp.com/free-ui-icons
+    Used under the Nucleo Icons License  https://nucleoapp.com/license
+
 A complete machine-readable list of dependencies and their pinned
 versions is maintained in pnpm-lock.yaml.
 

--- a/electron/figmaPlugin.test.ts
+++ b/electron/figmaPlugin.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { prepareFigmaPlugin } from './figmaPlugin'
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('prepareFigmaPlugin', () => {
+  it('copies a complete plugin to a stable user-data manifest path', () => {
+    const fixture = createFixture('first-build')
+
+    const result = prepareFigmaPlugin({
+      sourceDir: fixture.sourceDir,
+      userDataDir: fixture.userDataDir,
+      appVersion: '0.1.15',
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      exists: true,
+      version: '0.1.15',
+      path: path.join(
+        fixture.userDataDir,
+        'figma-plugin',
+        'manifest.json',
+      ),
+    })
+    expect(
+      fs.readFileSync(
+        path.join(fixture.userDataDir, 'figma-plugin', 'dist', 'code.js'),
+        'utf8',
+      ),
+    ).toBe('first-build')
+    expect(
+      fs.readFileSync(
+        path.join(fixture.userDataDir, 'figma-plugin', 'dist', 'ui.html'),
+        'utf8',
+      ),
+    ).toBe('<p>first-build</p>')
+  })
+
+  it('refreshes the same path when a newer app build starts', () => {
+    const fixture = createFixture('version-one')
+    const options = {
+      sourceDir: fixture.sourceDir,
+      userDataDir: fixture.userDataDir,
+      appVersion: '1.0.0',
+    }
+
+    prepareFigmaPlugin(options)
+    fs.writeFileSync(
+      path.join(fixture.sourceDir, 'dist', 'code.js'),
+      'version-two',
+    )
+    const result = prepareFigmaPlugin({ ...options, appVersion: '1.1.0' })
+
+    expect(result.path).toBe(
+      path.join(fixture.userDataDir, 'figma-plugin', 'manifest.json'),
+    )
+    expect(result.version).toBe('1.1.0')
+    expect(
+      fs.readFileSync(
+        path.join(fixture.userDataDir, 'figma-plugin', 'dist', 'code.js'),
+        'utf8',
+      ),
+    ).toBe('version-two')
+  })
+
+  it('keeps a previous good copy when the bundled source is incomplete', () => {
+    const fixture = createFixture('working-copy')
+    const options = {
+      sourceDir: fixture.sourceDir,
+      userDataDir: fixture.userDataDir,
+      appVersion: '1.0.0',
+    }
+
+    prepareFigmaPlugin(options)
+    fs.rmSync(path.join(fixture.sourceDir, 'dist', 'ui.html'))
+    const result = prepareFigmaPlugin({ ...options, appVersion: '1.1.0' })
+
+    expect(result.ok).toBe(false)
+    expect(result.exists).toBe(true)
+    expect(result.version).toBe('1.0.0')
+    expect(
+      fs.readFileSync(
+        path.join(fixture.userDataDir, 'figma-plugin', 'dist', 'ui.html'),
+        'utf8',
+      ),
+    ).toBe('<p>working-copy</p>')
+  })
+})
+
+function createFixture(contents: string): {
+  sourceDir: string
+  userDataDir: string
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hm-figma-plugin-test-'))
+  temporaryDirectories.push(root)
+  const sourceDir = path.join(root, 'source')
+  const userDataDir = path.join(root, 'user-data')
+  fs.mkdirSync(path.join(sourceDir, 'dist'), { recursive: true })
+  fs.writeFileSync(
+    path.join(sourceDir, 'manifest.json'),
+    JSON.stringify({ name: 'Hyper Motion Import', main: 'dist/code.js' }),
+  )
+  fs.writeFileSync(path.join(sourceDir, 'dist', 'code.js'), contents)
+  fs.writeFileSync(
+    path.join(sourceDir, 'dist', 'ui.html'),
+    `<p>${contents}</p>`,
+  )
+  return { sourceDir, userDataDir }
+}

--- a/electron/figmaPlugin.ts
+++ b/electron/figmaPlugin.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+export const FIGMA_PLUGIN_DIRECTORY = 'figma-plugin'
+
+/**
+ * Payload files required by Figma when it imports our development plugin.
+ * The manifest is copied last so it only points at complete build outputs.
+ */
+export const FIGMA_PLUGIN_FILES = [
+  'dist/code.js',
+  'dist/ui.html',
+  'LICENSE',
+  'NOTICE',
+  'README.md',
+  'manifest.json',
+] as const
+
+const REQUIRED_FIGMA_PLUGIN_FILES = [
+  'dist/code.js',
+  'dist/ui.html',
+  'manifest.json',
+] as const
+
+export interface FigmaPluginStatus {
+  ok: boolean
+  path: string
+  exists: boolean
+  message?: string
+  version?: string
+}
+
+interface PrepareFigmaPluginOptions {
+  sourceDir: string
+  userDataDir: string
+  appVersion: string
+}
+
+/**
+ * Copy the plugin bundled with this app into a stable, user-owned location.
+ *
+ * Figma remembers the manifest path after a development plugin is imported.
+ * App bundles move between downloads and updates, so exposing a manifest from
+ * Contents/Resources would break that registration. This function keeps the
+ * public path fixed under Electron's userData directory and refreshes its
+ * contents whenever Hyper Motion starts.
+ */
+export function prepareFigmaPlugin({
+  sourceDir,
+  userDataDir,
+  appVersion,
+}: PrepareFigmaPluginOptions): FigmaPluginStatus {
+  const destinationDir = path.join(userDataDir, FIGMA_PLUGIN_DIRECTORY)
+  const manifestPath = path.join(destinationDir, 'manifest.json')
+  const missing = REQUIRED_FIGMA_PLUGIN_FILES.filter(
+    (relativePath) => !isFile(path.join(sourceDir, relativePath)),
+  )
+
+  if (missing.length > 0) {
+    const exists = isFile(manifestPath)
+    return {
+      ok: false,
+      path: manifestPath,
+      exists,
+      version: readInstalledVersion(destinationDir),
+      message: exists
+        ? `The bundled plugin could not be refreshed (${missing.join(', ')} is missing). The previously installed copy is still available.`
+        : `The bundled Figma plugin is incomplete (${missing.join(', ')} is missing).`,
+    }
+  }
+
+  try {
+    fs.mkdirSync(destinationDir, { recursive: true })
+
+    for (const relativePath of FIGMA_PLUGIN_FILES) {
+      const sourcePath = path.join(sourceDir, relativePath)
+      if (!isFile(sourcePath)) continue
+      copyFileAtomically(sourcePath, path.join(destinationDir, relativePath))
+    }
+
+    writeFileAtomically(
+      path.join(destinationDir, '.hypermotion-plugin.json'),
+      `${JSON.stringify({ appVersion, updatedAt: new Date().toISOString() }, null, 2)}\n`,
+    )
+
+    return {
+      ok: true,
+      path: manifestPath,
+      exists: true,
+      version: appVersion,
+    }
+  } catch (error) {
+    const exists = isFile(manifestPath)
+    return {
+      ok: false,
+      path: manifestPath,
+      exists,
+      version: readInstalledVersion(destinationDir),
+      message:
+        error instanceof Error
+          ? `Could not prepare the Figma plugin: ${error.message}`
+          : 'Could not prepare the Figma plugin.',
+    }
+  }
+}
+
+function isFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile()
+  } catch {
+    return false
+  }
+}
+
+function copyFileAtomically(sourcePath: string, destinationPath: string): void {
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true })
+  const tempPath = `${destinationPath}.tmp-${process.pid}-${Date.now()}`
+  try {
+    fs.copyFileSync(sourcePath, tempPath)
+    replaceFile(tempPath, destinationPath)
+  } finally {
+    fs.rmSync(tempPath, { force: true })
+  }
+}
+
+function writeFileAtomically(destinationPath: string, contents: string): void {
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true })
+  const tempPath = `${destinationPath}.tmp-${process.pid}-${Date.now()}`
+  try {
+    fs.writeFileSync(tempPath, contents, 'utf8')
+    replaceFile(tempPath, destinationPath)
+  } finally {
+    fs.rmSync(tempPath, { force: true })
+  }
+}
+
+function replaceFile(tempPath: string, destinationPath: string): void {
+  try {
+    fs.renameSync(tempPath, destinationPath)
+  } catch (error) {
+    // POSIX rename replaces an existing file atomically. Windows can reject
+    // that replacement, so retain a narrow fallback for packaged Windows
+    // builds while still keeping the temp file on the same volume.
+    const code = (error as NodeJS.ErrnoException).code
+    if (code !== 'EEXIST' && code !== 'EPERM') throw error
+    fs.rmSync(destinationPath, { force: true })
+    fs.renameSync(tempPath, destinationPath)
+  }
+}
+
+function readInstalledVersion(destinationDir: string): string | undefined {
+  try {
+    const contents = fs.readFileSync(
+      path.join(destinationDir, '.hypermotion-plugin.json'),
+      'utf8',
+    )
+    const parsed = JSON.parse(contents) as { appVersion?: unknown }
+    return typeof parsed.appVersion === 'string' ? parsed.appVersion : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -31,6 +31,10 @@ import path from 'node:path'
 import fs from 'node:fs'
 import os from 'node:os'
 import { spawn, spawnSync } from 'node:child_process'
+import {
+  prepareFigmaPlugin,
+  type FigmaPluginStatus,
+} from './figmaPlugin'
 
 // Hyper Motion is a desktop editor: pressing Play in our own timeline should
 // always be allowed to start timeline audio, even if React applies the state
@@ -1057,6 +1061,39 @@ function mimeForClipboardFile(filePath: string): string {
 ipcMain.handle('updates:check', () => checkForUpdates())
 ipcMain.handle('updates:get-status', () => lastUpdateInfo)
 
+function figmaPluginSourceDirectory(): string {
+  const candidates = app.isPackaged
+    ? [path.join(process.resourcesPath, 'figma-plugin')]
+    : [
+        path.join(app.getAppPath(), 'figma-plugin'),
+        path.resolve(process.cwd(), 'figma-plugin'),
+      ]
+
+  return (
+    candidates.find((candidate) =>
+      fs.existsSync(path.join(candidate, 'manifest.json')),
+    ) ?? candidates[0]!
+  )
+}
+
+function prepareInstalledFigmaPlugin(): FigmaPluginStatus {
+  return prepareFigmaPlugin({
+    sourceDir: figmaPluginSourceDirectory(),
+    userDataDir: app.getPath('userData'),
+    appVersion: app.getVersion(),
+  })
+}
+
+ipcMain.handle('figma-plugin:get-manifest-status', () =>
+  prepareInstalledFigmaPlugin(),
+)
+
+ipcMain.handle('figma-plugin:reveal-manifest', () => {
+  const status = prepareInstalledFigmaPlugin()
+  if (status.exists) shell.showItemInFolder(status.path)
+  return status
+})
+
 ipcMain.handle('preview:open-window', async () => {
   if (previewWindow && !previewWindow.isDestroyed()) {
     if (previewWindow.isMinimized()) previewWindow.restore()
@@ -1786,6 +1823,14 @@ ipcMain.handle('export:headless-error', (_e, message: string) => {
 // reopen. Other platforms quit on last window close, matching native
 // expectations.
 app.whenReady().then(() => {
+  // Keep the Figma development plugin at one stable user-owned path. Figma
+  // remembers that path after the user's one-time manifest import, while app
+  // updates simply refresh the files in place on the next launch.
+  const figmaPluginStatus = prepareInstalledFigmaPlugin()
+  if (!figmaPluginStatus.ok) {
+    console.warn(`[figma-plugin] ${figmaPluginStatus.message}`)
+  }
+
   // Headless render branch — when the binary was launched with --render,
   // skip the menu + visible window entirely. The renderer carries out the
   // export and signals completion via IPC; the app exits when done.

--- a/figma-plugin/README.md
+++ b/figma-plugin/README.md
@@ -5,7 +5,19 @@ Motion editor recognizes when pasted. Auto layout, gradients, image
 fills, and text styles round-trip; vector shapes get rasterized to
 inline SVG.
 
-## Install (development)
+## Install from the Hyper Motion desktop app
+
+The packaged desktop app includes a built copy of this plugin. Open Hyper
+Motion and choose **Figma import** in the top bar, then click **Reveal
+manifest**. In the Figma desktop app choose **Plugins → Development → Import
+new plugin from manifest…** and select the revealed `manifest.json`.
+
+This is a one-time setup. Hyper Motion keeps the plugin at a stable path in
+the user's Application Support data and refreshes those files whenever the
+app starts, so application updates do not require importing the plugin again.
+No repository checkout or terminal command is needed.
+
+## Install while developing Hyper Motion
 
 1. From this folder:
    ```

--- a/package.json
+++ b/package.json
@@ -9,15 +9,17 @@
   "author": "Siddharth Ponnapalli",
   "homepage": "https://hypermotion.app",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build && electron-builder --publish=never",
-    "build:dir": "vite build && electron-builder --dir",
-    "build:mac": "vite build && electron-builder --mac --publish=never",
-    "build:win": "vite build && electron-builder --win --publish=never",
+    "build:figma-plugin": "pnpm --dir figma-plugin build",
+    "dev": "pnpm build:figma-plugin && vite",
+    "build": "pnpm build:figma-plugin && vite build && electron-builder --publish=never",
+    "build:dir": "pnpm build:figma-plugin && vite build && electron-builder --dir",
+    "build:mac": "pnpm build:figma-plugin && vite build && electron-builder --mac --publish=never",
+    "build:win": "pnpm build:figma-plugin && vite build && electron-builder --win --publish=never",
     "lint": "eslint .",
     "test": "pnpm --dir cli test",
     "test:canvas": "vitest run src/render/strokePattern.test.ts src/render/apertureBokeh.test.ts src/render/CameraPostEffectsFallback.test.tsx src/render3d/depthOfFieldShader.test.ts src/render3d/postEffects.test.ts src/render3d/texturePolicy.test.ts src/render3d/planeAnimationSnapshot.test.ts src/render3d/scene3d.focus.test.ts src/render3d/scene3d.hitTest.test.ts src/render3d/selectionProjection.test.ts src/render3d/textAnimationLayout.test.ts src/render3d/textSegmentBatch.test.ts src/render3d/textSegmentMaterial.test.ts src/anim/easingPresets.test.ts src/anim/engine.test.ts src/anim/multiKeyframes.test.ts src/anim/presets.test.ts src/anim/staggerSets.test.ts src/anim/textAnimations.test.ts src/anim/textMotionPath.test.ts src/anim/textMotionRail.test.ts src/anim/textMotionVector.test.ts src/anim/textScramble.test.ts src/anim/textSegmentEnvelope.test.ts src/anim/textSegmentMotion.test.ts src/anim/textStaggerCurve.test.ts src/scene/cameraDof.test.ts src/state/groupActions.test.ts src/state/staggerSelection.test.ts src/ui/GraphEditor.test.ts src/ui/StaggerCurveEditor.test.ts src/ui/TextMotionPathEditor.test.ts src/ui/hooks/useAnimatedValues.test.ts src/ui/cameraPreviewStore.test.ts src/ui/cameraWheel.test.ts src/ui/cameraReset.test.ts src/ui/canvasTextEditing.test.ts src/ui/keyframeDragPreviewStore.test.ts src/ui/multiRenderMode.test.ts src/ui/sectionDragPreviewStore.test.ts src/ui/textStaggerCurvePreviewStore.test.ts src/ui/timelineDragHitArea.test.ts src/ui/textAnimationSegments.test.ts",
     "test:figma": "vitest run src/import/figma src/scene/vector/path.test.ts src/scene/vector/svgSecurity.test.ts src/scene/vector/vectorNode.test.ts src/render/vectorPaint.test.ts src/render/vectorSource.test.ts src/layout/vectorMeasure.test.ts src/ui/fonts/googleFonts.test.ts",
+    "test:figma-plugin-shell": "vitest run electron/figmaPlugin.test.ts",
     "typecheck": "tsc -b",
     "preview": "vite preview"
   },
@@ -69,6 +71,20 @@
       "dist/**/*",
       "dist-electron/**/*",
       "package.json"
+    ],
+    "extraResources": [
+      {
+        "from": "figma-plugin",
+        "to": "figma-plugin",
+        "filter": [
+          "manifest.json",
+          "dist/code.js",
+          "dist/ui.html",
+          "LICENSE",
+          "NOTICE",
+          "README.md"
+        ]
+      }
     ],
     "mac": {
       "category": "public.app-category.graphics-design",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,18 @@ importers:
         specifier: ~5.7.2
         version: 5.7.3
 
+  figma-plugin:
+    devDependencies:
+      '@figma/plugin-typings':
+        specifier: ^1.100.2
+        version: 1.131.0
+      esbuild:
+        specifier: ^0.23.0
+        version: 0.23.1
+      typescript:
+        specifier: ^5.5.0
+        version: 5.7.3
+
 packages:
 
   7zip-bin@5.2.0:
@@ -246,6 +258,150 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.23.1':
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.23.1':
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.23.1':
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.23.1':
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.23.1':
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.23.1':
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.23.1':
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.23.1':
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.23.1':
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.23.1':
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.23.1':
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.23.1':
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.23.1':
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.23.1':
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.23.1':
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.23.1':
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.23.1':
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.23.1':
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.23.1':
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.23.1':
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.23.1':
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -295,6 +451,9 @@ packages:
   '@ffmpeg/util@0.12.2':
     resolution: {integrity: sha512-ouyoW+4JB7WxjeZ2y6KpRvB+dLp7Cp4ro8z0HIVpZVCM7AwFlHa0c4R8Y/a4M3wMqATpYKhC7lSFHQ0T11MEDw==}
     engines: {node: '>=18.x'}
+
+  '@figma/plugin-typings@1.131.0':
+    resolution: {integrity: sha512-XBTPNGc65myupitMaeemyiF/ir1jn/EXXTdoGUCEVCfVB6KPQUy+gbfHbnC+QQiHxdw/Naikdx+9v/u4d49gfA==}
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -1306,6 +1465,11 @@ packages:
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2637,11 +2801,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -3101,6 +3260,78 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm@0.23.1':
+    optional: true
+
+  '@esbuild/android-x64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.23.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.23.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.23.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.23.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.23.1':
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
@@ -3154,6 +3385,8 @@ snapshots:
   '@ffmpeg/types@0.12.4': {}
 
   '@ffmpeg/util@0.12.2': {}
+
+  '@figma/plugin-typings@1.131.0': {}
 
   '@gar/promisify@1.1.3': {}
 
@@ -4016,7 +4249,7 @@ snapshots:
   config-file-ts@0.2.8-rc1:
     dependencies:
       glob: 10.5.0
-      typescript: 5.9.3
+      typescript: 5.7.3
 
   console-control-strings@1.1.0: {}
 
@@ -4250,6 +4483,33 @@ snapshots:
 
   es6-error@4.1.1:
     optional: true
+
+  esbuild@0.23.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
 
   escalade@3.2.0: {}
 
@@ -5641,8 +5901,6 @@ snapshots:
       - supports-color
 
   typescript@5.7.3: {}
-
-  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - .
   - cli
+  - figma-plugin
 
 allowBuilds:
   electron: true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,6 +113,18 @@ function Shell() {
   const api = useSceneAPI()
   const exportPhase = useExportProgress((s) => s.phase)
 
+  useEffect(() => {
+    const previousDensity = document.body.dataset.hmUiDensity
+    document.body.dataset.hmUiDensity = 'compact'
+    return () => {
+      if (previousDensity === undefined) {
+        delete document.body.dataset.hmUiDensity
+      } else {
+        document.body.dataset.hmUiDensity = previousDensity
+      }
+    }
+  }, [])
+
   // Global wiring — must be mounted once, at the top of the scene tree.
   useKeyboardShortcuts()
   useFigmaPaste()
@@ -229,7 +241,10 @@ function Shell() {
   }, [api, sceneVersion])
 
   return (
-    <div className="flex h-full w-full flex-col bg-app-bg text-text">
+    <div
+      data-hm-editor-ui="1"
+      className="flex h-full w-full flex-col bg-app-bg text-text"
+    >
       <AnimationHost />
       <TopBar />
       <div className="flex min-h-0 flex-1">

--- a/src/index.css
+++ b/src/index.css
@@ -209,6 +209,59 @@ body {
   overflow: hidden; /* the app owns the scrolling, not the page */
 }
 
+/*
+ * Compact editor typography.
+ *
+ * Hyper Motion's inspector and timeline deliberately use explicit pixel
+ * utilities so dense numeric controls remain aligned. Lowering only body's
+ * inherited size would leave most of the interface unchanged, so this layer
+ * remaps the larger UI tokens by roughly 12–16% and keeps 10px as the
+ * legibility floor. Authored content under the canvas/node markers is excluded:
+ * changing editor density must never resize a user's design.
+ */
+body[data-hm-ui-density='compact'] {
+  font-size: 11.5px;
+}
+
+body[data-hm-ui-density='compact']
+  [class~='text-[28px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
+  font-size: 24px;
+}
+
+body[data-hm-ui-density='compact']
+  [class~='text-[18px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *),
+body[data-hm-ui-density='compact']
+  [class~='text-[17px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
+  font-size: 15px;
+}
+
+body[data-hm-ui-density='compact']
+  [class~='text-[15px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *),
+body[data-hm-ui-density='compact']
+  [class~='text-[16px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
+  font-size: 13px;
+}
+
+body[data-hm-ui-density='compact']
+  [class~='text-[14px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
+  font-size: 12px;
+}
+
+body[data-hm-ui-density='compact']
+  [class~='text-[13px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
+  font-size: 11px;
+}
+
+body[data-hm-ui-density='compact']
+  [class~='text-[12px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
+  font-size: 10.5px;
+}
+
+body[data-hm-ui-density='compact']
+  [class~='text-[11px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
+  font-size: 10px;
+}
+
 [data-canvas-root],
 [data-canvas-root] *,
 [data-node-id],

--- a/src/ui/FigmaPluginSetup.tsx
+++ b/src/ui/FigmaPluginSetup.tsx
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+import {
+  NucleoClipboardCheckIcon,
+  NucleoCloseIcon,
+  NucleoFileContentIcon,
+  NucleoPlugIcon,
+  NucleoWindowPointerIcon,
+} from '@/ui/icons/NucleoUiIcons'
+
+interface ManifestStatus {
+  ok: boolean
+  path: string
+  exists: boolean
+  message?: string
+  version?: string
+}
+
+function isManifestStatus(value: unknown): value is ManifestStatus {
+  if (!value || typeof value !== 'object') return false
+  const status = value as Partial<ManifestStatus>
+  return (
+    typeof status.ok === 'boolean' &&
+    typeof status.path === 'string' &&
+    typeof status.exists === 'boolean'
+  )
+}
+
+export function FigmaPluginSetupButton() {
+  const [open, setOpen] = useState(false)
+  const close = useCallback(() => setOpen(false), [])
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        title="Set up the Figma import plugin"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="flex h-8 items-center gap-1.5 rounded-md px-2.5 text-[12px] font-medium text-text-muted hover:bg-panel-raised hover:text-text"
+      >
+        <NucleoPlugIcon size={16} />
+        <span>Figma import</span>
+      </button>
+      {open && <FigmaPluginSetupModal onClose={close} />}
+    </>
+  )
+}
+
+function FigmaPluginSetupModal({ onClose }: { onClose: () => void }) {
+  const closeRef = useRef<HTMLButtonElement>(null)
+  const [manifest, setManifest] = useState<ManifestStatus | null>(null)
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    closeRef.current?.focus()
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+
+    let cancelled = false
+    const prepareManifest = async () => {
+      if (!window.hypermotion) {
+        if (!cancelled) {
+          setFeedback('Open this screen in the Hyper Motion desktop app.')
+        }
+        return
+      }
+      try {
+        const result = await window.hypermotion.invoke(
+          'figma-plugin:get-manifest-status',
+        )
+        if (!cancelled && isManifestStatus(result)) {
+          setManifest(result)
+          if (!result.ok) setFeedback(result.message ?? 'Plugin setup failed.')
+        }
+      } catch {
+        if (!cancelled) setFeedback('Could not prepare the Figma plugin.')
+      }
+    }
+    void prepareManifest()
+
+    return () => {
+      cancelled = true
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [onClose])
+
+  const copyManifestPath = async () => {
+    if (!manifest?.path) return
+    try {
+      const desktopClipboard = window.hypermotion?.clipboard
+      if (desktopClipboard) {
+        await desktopClipboard.writeText(manifest.path)
+      } else {
+        await navigator.clipboard.writeText(manifest.path)
+      }
+      setFeedback('Manifest path copied.')
+    } catch {
+      setFeedback('Could not copy the path. Select it manually below.')
+    }
+  }
+
+  const revealManifest = async () => {
+    if (!window.hypermotion) {
+      setFeedback('Reveal is available in the Hyper Motion desktop app.')
+      return
+    }
+    setBusy(true)
+    try {
+      const result = await window.hypermotion.invoke(
+        'figma-plugin:reveal-manifest',
+      )
+      if (isManifestStatus(result)) {
+        setManifest(result)
+        setFeedback(
+          result.exists
+            ? result.ok
+              ? 'Manifest revealed in Finder.'
+              : 'The previous plugin copy was revealed. Restart Hyper Motion to retry the update.'
+            : result.message ?? 'The plugin manifest is unavailable.',
+        )
+      } else {
+        setFeedback('Could not reveal the plugin manifest.')
+      }
+    } catch {
+      setFeedback('Could not reveal the plugin manifest.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const ready = manifest?.exists === true
+
+  return createPortal(
+    <div
+      data-hm-editor-ui="1"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="figma-plugin-setup-title"
+      onPointerDown={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+      className="fixed inset-0 z-[120] flex items-center justify-center bg-black/45 px-6 backdrop-blur-[2px]"
+    >
+      <div className="w-full max-w-[600px] overflow-hidden rounded-lg border border-border-strong bg-panel-raised shadow-2xl">
+        <div className="flex items-start justify-between border-b border-border px-5 py-4">
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent-soft text-accent">
+              <NucleoPlugIcon size={18} />
+            </div>
+            <div className="min-w-0">
+              <div className="mb-1 flex items-center gap-2">
+                <h2
+                  id="figma-plugin-setup-title"
+                  className="text-[14px] font-semibold text-text"
+                >
+                  Connect Figma to Hyper Motion
+                </h2>
+                <span className="rounded border border-border bg-panel px-1.5 py-0.5 text-[9px] font-medium tracking-wider text-text-dim">
+                  Bundled plugin
+                </span>
+              </div>
+              <p className="max-w-[460px] text-[11px] leading-5 text-text-muted">
+                No download, source code, or terminal is required. Hyper Motion
+                keeps this local plugin updated inside your Application Support
+                folder.
+              </p>
+            </div>
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            onClick={onClose}
+            aria-label="Close Figma plugin instructions"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-text-muted outline-none hover:bg-panel hover:text-text focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <NucleoCloseIcon size={16} />
+          </button>
+        </div>
+
+        <div className="px-5 py-5">
+          <div className="mb-4 rounded-md border border-border bg-panel px-3 py-3">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <span className="text-[10px] font-medium tracking-wider text-text-dim">
+                Plugin manifest
+              </span>
+              <span
+                className={[
+                  'rounded px-1.5 py-0.5 text-[9px] font-medium tracking-wide',
+                  ready
+                    ? 'bg-[oklch(0.7_0.14_145/0.14)] text-[oklch(0.62_0.14_145)]'
+                    : 'bg-panel-raised text-text-dim',
+                ].join(' ')}
+              >
+                {manifest ? (ready ? 'Ready' : 'Needs attention') : 'Preparing…'}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <code
+                title={manifest?.path}
+                className="min-w-0 flex-1 truncate rounded border border-border bg-app-bg px-2.5 py-2 text-[11px] normal-case text-text"
+              >
+                {manifest?.path ?? 'Preparing your local plugin…'}
+              </code>
+              <button
+                type="button"
+                disabled={!manifest?.path}
+                onClick={() => void copyManifestPath()}
+                className="h-8 shrink-0 rounded-md border border-border px-2.5 text-[10px] font-medium text-text-muted hover:bg-panel-raised hover:text-text disabled:opacity-40"
+              >
+                Copy path
+              </button>
+              <button
+                type="button"
+                disabled={busy || !ready}
+                onClick={() => void revealManifest()}
+                className="h-8 shrink-0 rounded-md bg-accent px-3 text-[10px] font-medium text-white shadow-sm hover:brightness-110 disabled:cursor-wait disabled:opacity-40"
+              >
+                {busy ? 'Revealing…' : 'Reveal manifest'}
+              </button>
+            </div>
+            {feedback && (
+              <p
+                aria-live="polite"
+                className="mt-2 text-[10px] normal-case text-text-muted"
+              >
+                {feedback}
+              </p>
+            )}
+          </div>
+
+          <ol className="grid gap-3">
+            <SetupStep
+              number="1"
+              icon={<NucleoWindowPointerIcon />}
+              title="Keep your Figma design file open"
+            >
+              Use the Figma desktop app and stay in the file you want to
+              import from.
+            </SetupStep>
+            <SetupStep
+              number="2"
+              icon={<NucleoFileContentIcon />}
+              title="Reveal the manifest from Hyper Motion"
+            >
+              Click <strong>Reveal manifest</strong> above. Hyper Motion opens
+              the exact user-specific file; its path stays the same after app
+              updates.
+            </SetupStep>
+            <SetupStep
+              number="3"
+              icon={<NucleoPlugIcon />}
+              title="Import the local plugin once"
+            >
+              In Figma, choose <strong>Plugins → Development → Import new
+              plugin from manifest…</strong>, then select the revealed{' '}
+              <strong>manifest.json</strong>.
+            </SetupStep>
+            <SetupStep
+              number="4"
+              icon={<NucleoClipboardCheckIcon />}
+              title="Copy your selection into Hyper Motion"
+            >
+              Select layers, run <strong>Plugins → Development → Hyper Motion
+              Import</strong>, choose <strong>Copy to Hyper Motion</strong>,
+              then paste here with <strong>⌘ V</strong>.
+            </SetupStep>
+          </ol>
+
+          <p className="mt-4 text-[10px] leading-4 text-text-dim">
+            Setup is required once. Future Hyper Motion updates refresh the
+            same plugin folder automatically; Figma keeps it under Plugins →
+            Development.
+          </p>
+        </div>
+
+        <div className="flex justify-end border-t border-border px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-8 rounded-md border border-border px-4 text-[11px] font-medium text-text-muted hover:bg-panel hover:text-text"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+function SetupStep({
+  number,
+  icon,
+  title,
+  children,
+}: {
+  number: string
+  icon: ReactNode
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <li className="grid grid-cols-[32px_1fr] gap-3">
+      <div className="relative flex h-8 w-8 items-center justify-center rounded-md border border-border bg-panel text-text-muted">
+        {icon}
+        <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[8px] font-semibold text-white">
+          {number}
+        </span>
+      </div>
+      <div className="pt-0.5">
+        <h3 className="text-[11px] font-medium text-text">{title}</h3>
+        <p className="mt-0.5 text-[10px] leading-4 text-text-muted">
+          {children}
+        </p>
+      </div>
+    </li>
+  )
+}

--- a/src/ui/TopBar.tsx
+++ b/src/ui/TopBar.tsx
@@ -4,6 +4,7 @@ import { useUI, type PanelKey, type ThemePreference } from '@/state/ui'
 import { useSceneAPI, useSceneVersion } from '@/scene'
 import { ExportMenu } from '@/ui/ExportMenu'
 import { ExportStatusPill } from '@/ui/ExportStatusPill'
+import { FigmaPluginSetupButton } from '@/ui/FigmaPluginSetup'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
@@ -182,6 +183,7 @@ export function TopBar() {
 
         <ThemeToggle />
         <PreviewButton />
+        <FigmaPluginSetupButton />
         <PanelTogglePopover panels={panels} togglePanel={togglePanel} />
 
         <span className="mx-1 h-4 w-px bg-border" />

--- a/src/ui/icons/NucleoUiIcons.tsx
+++ b/src/ui/icons/NucleoUiIcons.tsx
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SVGProps } from 'react'
+
+/**
+ * Small, local subset of Nucleo UI Essential Outline 18 icons.
+ * Source: https://nucleoapp.com/free-ui-icons
+ * License: https://nucleoapp.com/license
+ */
+type NucleoIconProps = SVGProps<SVGSVGElement> & {
+  size?: number
+  strokeWidth?: number
+}
+
+function NucleoIcon({
+  size = 18,
+  children,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 18 18"
+      fill="none"
+      aria-hidden="true"
+      {...props}
+    >
+      {children}
+    </svg>
+  )
+}
+
+export function NucleoPlugIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="M5.104,8.714l4.182,4.182c.391,.391,.391,1.024,0,1.414l-.28,.28c-1.545,1.545-4.051,1.545-5.596,0s-1.545-4.051,0-5.596l.28-.28c.391-.391,1.024-.391,1.414,0Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1="1.75"
+        y1="16.25"
+        x2="3.409"
+        y2="14.591"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1="5.945"
+        y1="9.555"
+        x2="7.5"
+        y2="8"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1="8.445"
+        y1="12.055"
+        x2="10"
+        y2="10.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="M8.714,5.104l4.182,4.182c.391,.391,1.024,.391,1.414,0l.28-.28c1.545-1.545,1.545-4.051,0-5.596s-4.051-1.545-5.596,0l-.28,.28c-.391,.391-.391,1.024,0,1.414Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1="16.25"
+        y1="1.75"
+        x2="14.591"
+        y2="3.409"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoWindowPointerIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="M4.25 6C4.664 6 5 5.66 5 5.25C5 4.84 4.664 4.5 4.25 4.5C3.836 4.5 3.5 4.84 3.5 5.25C3.5 5.66 3.836 6 4.25 6Z"
+        fill="currentColor"
+      />
+      <path
+        d="M6.75 6C7.164 6 7.5 5.66 7.5 5.25C7.5 4.84 7.164 4.5 6.75 4.5C6.336 4.5 6 4.84 6 5.25C6 5.66 6.336 6 6.75 6Z"
+        fill="currentColor"
+      />
+      <path
+        d="M1.75 7.75H16.25M16.25 9.448V4.75c0-1.1-.895-2-2-2H3.75c-1.105 0-2 .9-2 2v8.5c0 1.1.895 2 2 2h5.328"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M11.126 10.77l5.94 2.17c.25.09.243.45-.011.53l-2.719.87-.87 2.72c-.081.25-.438.26-.529.01l-2.17-5.94c-.082-.23.135-.44.359-.36Z"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoFileContentIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="M5.75 6.75h2M5.75 9.75h6.5M5.75 12.75h6.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="M2.75 14.25V3.75c0-1.105.895-2 2-2h5.586c.265 0 .52.105.707.293l3.914 3.914c.188.188.293.442.293.707v7.586c0 1.105-.895 2-2 2h-8.5c-1.105 0-2-.895-2-2Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="M15.16 6.25h-3.41c-.552 0-1-.448-1-1V1.852"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoClipboardCheckIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="M6.25 2.75h-1c-1.105 0-2 .895-2 2v9.5c0 1.105.895 2 2 2h7.5c1.105 0 2-.895 2-2v-9.5c0-1.105-.895-2-2-2h-1"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <rect
+        x="6.25"
+        y="1.25"
+        width="5.5"
+        height="3"
+        rx="1"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <polyline
+        points="6.25 10.25 8 12.25 11.75 7.25"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoCloseIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <line
+        x1="14"
+        y1="4"
+        x2="4"
+        y2="14"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1="4"
+        y1="4"
+        x2="14"
+        y2="14"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}


### PR DESCRIPTION
## Summary
- bundle the built Figma importer inside desktop releases
- materialize and refresh it at a stable per-user manifest path on app launch
- reduce editor chrome typography while preserving authored canvas text

## Validation
- `pnpm test:figma-plugin-shell`
- `pnpm exec tsc -p tsconfig.electron.json`
- `pnpm --dir figma-plugin typecheck`
- focused ESLint on new files
- `pnpm exec vite build`
- `pnpm build:dir`
- launched packaged app with isolated user data and verified copied manifest/code/UI
- visually checked editor and modal at 1280×720

## Baseline note
- full `pnpm typecheck` still reports existing errors on main in animation tests, export typings, layout, scene, inspector, timeline, and component actions; this PR introduces no additional reported TypeScript errors.
