### PR TITLE
Prepare v0.1.15 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Plus everything you expect from a Jitter-class tool: a real timeline,
 in/out presets, easing curves, 3D camera with depth-of-field, and MP4 /
 WebM / GIF export.
 
-## Status — v0.1.14 research preview
+## Status — v0.1.15 research preview
 
 The semantic-layout-animation bet works end-to-end, with desktop
 editing, Figma import, pixel-correct export, and CLI / MCP workflows for
@@ -34,7 +34,7 @@ copies the app into `/Applications`, strips macOS's download quarantine,
 applies a local ad-hoc signature, and opens it. No drag-to-Applications,
 no "damaged" dialog, no per-version steps.
 
-For a specific version: `curl ... | bash -s -- v0.1.14`.
+For a specific version: `curl ... | bash -s -- v0.1.15`.
 
 ### Manual install
 
@@ -77,26 +77,34 @@ open release/mac-arm64/hyper-motion.app
 ## Figma plugin
 
 Copy frames, text, layout, and vector artwork from Figma straight into
-hyper-motion. Payload v2 imports supported artwork as native vector-backed
-layers and retains the canonical point/segment graph, Bézier controls,
-transforms, ordered paints, gradient metadata, and detailed strokes. Version 1
-payloads remain compatible, while complex constructs keep a sanitized SVG
-fallback for visual fidelity. Direct point editing remains a follow-up. The
-plugin source lives in
-[`figma-plugin/`](./figma-plugin) inside this repo.
+hyper-motion. The desktop app includes the importer—no repository checkout,
+source build, or terminal setup is required. Click the Figma import button in
+the top bar, reveal the manifest from the setup modal, then choose
+**Plugins → Development → Import plugin from manifest…** in Figma Desktop.
+That one-time registration uses a stable per-user location which Hyper Motion
+keeps refreshed across app updates.
 
-```sh
-cd figma-plugin
-pnpm install
-pnpm build
-# Then in Figma: Plugins → Development → Import plugin from manifest…
-# → point at figma-plugin/manifest.json
-```
+Payload v2 imports supported artwork as native vector-backed layers and retains
+the canonical point/segment graph, Bézier controls, transforms, ordered paints,
+gradient metadata, and detailed strokes. Version 1 payloads remain compatible,
+while complex constructs keep a sanitized SVG fallback for visual fidelity.
+Direct point editing remains a follow-up. Contributor source lives in
+[`figma-plugin/`](./figma-plugin).
 
 Full step-by-step at [hypermotion.app/docs#figma-plugin](https://hypermotion.app/docs#figma-plugin).
 Figma Community publish (one-click install) is on the v0.2 roadmap.
 
-## What's in v0.1.14
+## What's in v0.1.15
+
+- **Built-in Figma importer setup.** Open the setup guide from the editor,
+  reveal the exact bundled manifest, and register it once in Figma Desktop—no
+  code download, local build, or terminal commands required.
+- **Stable plugin updates.** Hyper Motion refreshes the importer in its
+  Application Support directory on launch while preserving the same manifest
+  path that Figma already knows.
+- **More compact editor chrome.** Interface text is denser and gives the canvas
+  more breathing room while authored text and exported compositions remain
+  unchanged.
 
 - **Camera-accurate selection and resize.** Selection polygons, hit testing,
   and all eight resize handles now follow workspace zoom, camera XYZ, tilt,

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,52 @@
 Human-friendly release notes. The GitHub Releases page mirrors the matching
 entry below for each corresponding tag.
 
+## v0.1.15 — Built-in Figma importer and compact editor (2026-07-20)
+
+Figma import no longer requires cloning the repository, building plugin source,
+or keeping a release download folder. Hyper Motion now ships the importer inside
+the desktop app, installs it to a stable per-user location, and guides the
+one-time Figma setup directly from the editor. The editor interface is also
+denser while preserving typography inside authored compositions.
+
+### Figma setup from the app
+
+- Add a Figma import button to the editor top bar with a focused setup modal.
+- Reveal the exact manifest users should select in Figma Desktop instead of
+  making them locate an app bundle or copy a path manually.
+- Bundle the manifest, compiled plugin code, and plugin UI with every macOS
+  release; no repository checkout, package install, source build, or terminal
+  command is needed.
+- Keep Figma's registered manifest path stable across Hyper Motion updates and
+  refresh the installed plugin payload whenever the app launches.
+- Explain the one-time **Plugins → Development → Import plugin from manifest…**
+  flow while Community marketplace distribution remains a later option.
+
+### Denser editor chrome
+
+- Reduce oversized interface typography by roughly 12–16 percent with a
+  legible minimum size.
+- Scope the density pass to editor chrome so canvas text, imported designs, and
+  exported media retain their authored sizes.
+- Keep menus, inspectors, dialogs, timeline labels, and the Figma setup modal
+  readable without introducing clipped controls.
+
+### Safe packaging and updates
+
+- Copy bundled plugin files into Application Support atomically and retain the
+  last working copy if a packaged payload is incomplete.
+- Cover first installation, update refresh, and fallback behavior with focused
+  Electron tests.
+- Build the Figma plugin before development and release builds and include its
+  runtime files in the packaged application.
+
+### Install on macOS
+
+Download the Apple Silicon or Intel DMG from this release, or use the one-line
+installer in the [installation guide](https://hypermotion.app/docs#install).
+The v0.1.x builds remain unsigned and macOS-only, so macOS may require the
+first-time setup described in that guide.
+
 ## v0.1.14 — Camera-accurate selection and resize (2026-07-20)
 
 Selection chrome now uses the same world planes and live camera projection as

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 #
 # Or for a specific version:
 #
-#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.14
+#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.15
 #
 # Works for every future release without changes — the script always
 # resolves the latest tag from the GitHub API unless you pass one.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyper-motion-electron",
   "private": true,
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "main": "dist-electron/main.cjs",
   "description": "Native motion design tool with Figma-style structural layout. Auto-layout, 3D camera, semantic keyframes, pixel-correct MP4 / WebM / GIF.",


### PR DESCRIPTION
## Summary

- bump the desktop release to v0.1.15
- document the built-in Figma importer setup and stable manifest path
- document the denser editor chrome and update macOS install examples

## Validation

- `pnpm test:figma-plugin-shell`
- `pnpm exec tsc -p tsconfig.electron.json`
- `pnpm --dir figma-plugin typecheck`
- focused ESLint for the Figma setup implementation
- `pnpm build:dir`
- verified packaged app version and bundled manifest, runtime, and UI