### PR TITLE
Polish compact editor UI and Figma setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,17 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: pnpm run build:win
 
+      - name: Package Figma plugin
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          (
+            cd figma-plugin
+            zip -q -r "../release/hyper-motion-figma-plugin-v${VERSION}.zip" \
+              manifest.json dist/code.js dist/ui.html LICENSE NOTICE README.md
+          )
+
       - name: Upload artifacts (macOS)
         if: matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v4
@@ -80,6 +91,7 @@ jobs:
           path: |
             release/*.dmg
             release/*.dmg.blockmap
+            release/hyper-motion-figma-plugin-v*.zip
             release/latest-mac.yml
           if-no-files-found: error
 
@@ -119,6 +131,7 @@ jobs:
           files: |
             dist-release/*.dmg
             dist-release/*.blockmap
+            dist-release/hyper-motion-figma-plugin-v*.zip
             dist-release/latest-mac.yml
           generate_release_notes: true
           draft: false

--- a/src/index.css
+++ b/src/index.css
@@ -194,7 +194,7 @@ body {
   background: var(--color-app-bg);
   color: var(--color-text);
   font-family: var(--font-sans);
-  font-size: 13px;
+  font-size: 11px;
   line-height: 1.45;
   /* Tabular numerals + SF Pro stylistic sets at body level keep
      timeline readouts and frame counters aligned during scrubbing,
@@ -213,38 +213,38 @@ body {
  * Compact editor typography.
  *
  * Hyper Motion's inspector and timeline deliberately use explicit pixel
- * utilities so dense numeric controls remain aligned. Lowering only body's
- * inherited size would leave most of the interface unchanged, so this layer
- * remaps the larger UI tokens by roughly 12–16% and keeps 10px as the
- * legibility floor. Authored content under the canvas/node markers is excluded:
- * changing editor density must never resize a user's design.
+ * utilities so dense numeric controls remain aligned. The general UI sits at
+ * 11px, supporting copy at 10px, and micro metadata at 9px. Larger legacy
+ * utilities are remapped into that compact scale while authored content under
+ * canvas/node markers is excluded: editor density must never resize a user's
+ * design.
  */
 body[data-hm-ui-density='compact'] {
-  font-size: 11.5px;
+  font-size: 11px;
 }
 
 body[data-hm-ui-density='compact']
   [class~='text-[28px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
-  font-size: 24px;
+  font-size: 22px;
 }
 
 body[data-hm-ui-density='compact']
   [class~='text-[18px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *),
 body[data-hm-ui-density='compact']
   [class~='text-[17px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
-  font-size: 15px;
+  font-size: 14px;
 }
 
 body[data-hm-ui-density='compact']
   [class~='text-[15px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *),
 body[data-hm-ui-density='compact']
   [class~='text-[16px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
-  font-size: 13px;
+  font-size: 12px;
 }
 
 body[data-hm-ui-density='compact']
   [class~='text-[14px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
-  font-size: 12px;
+  font-size: 11.5px;
 }
 
 body[data-hm-ui-density='compact']
@@ -260,6 +260,34 @@ body[data-hm-ui-density='compact']
 body[data-hm-ui-density='compact']
   [class~='text-[11px]']:not([data-canvas-root], [data-canvas-root] *, [data-node-id], [data-node-id] *) {
   font-size: 10px;
+}
+
+/* Semantic editor type scale. Prefer these over adding more one-off pixel
+   values to dense dialogs and inspector surfaces. */
+.hm-type-dialog-title {
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.hm-type-section,
+.hm-type-body {
+  font-size: 11px;
+  line-height: 16px;
+}
+
+.hm-type-support {
+  font-size: 10px;
+  line-height: 14px;
+}
+
+.hm-type-micro {
+  font-size: 9px;
+  line-height: 12px;
+}
+
+[data-hm-figma-plugin-modal],
+[data-hm-figma-plugin-modal] button {
+  text-transform: uppercase;
 }
 
 [data-canvas-root],

--- a/src/ui/FigmaPluginSetup.tsx
+++ b/src/ui/FigmaPluginSetup.tsx
@@ -5,51 +5,51 @@ import {
   useEffect,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from 'react'
 import { createPortal } from 'react-dom'
 import {
   NucleoClipboardCheckIcon,
   NucleoCloseIcon,
+  NucleoDownloadIcon,
   NucleoFileContentIcon,
-  NucleoPlugIcon,
-  NucleoWindowPointerIcon,
+  NucleoPuzzlePieceIcon,
 } from '@/ui/icons/NucleoUiIcons'
 
-interface ManifestStatus {
-  ok: boolean
-  path: string
-  exists: boolean
-  message?: string
-  version?: string
-}
+const RELEASES_URL =
+  'https://github.com/psiddharthdesign/hypermotion/releases/latest'
 
-function isManifestStatus(value: unknown): value is ManifestStatus {
-  if (!value || typeof value !== 'object') return false
-  const status = value as Partial<ManifestStatus>
-  return (
-    typeof status.ok === 'boolean' &&
-    typeof status.path === 'string' &&
-    typeof status.exists === 'boolean'
-  )
-}
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  'a[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
 
 export function FigmaPluginSetupButton() {
   const [open, setOpen] = useState(false)
-  const close = useCallback(() => setOpen(false), [])
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const close = useCallback(() => {
+    setOpen(false)
+    window.requestAnimationFrame(() => triggerRef.current?.focus())
+  }, [])
 
   return (
     <>
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setOpen(true)}
-        title="Set up the Figma import plugin"
+        title="Install the Figma import plugin"
         aria-haspopup="dialog"
         aria-expanded={open}
         className="flex h-8 items-center gap-1.5 rounded-md px-2.5 text-[12px] font-medium text-text-muted hover:bg-panel-raised hover:text-text"
       >
-        <NucleoPlugIcon size={16} />
-        <span>Figma import</span>
+        <NucleoPuzzlePieceIcon size={15} />
+        <span className="uppercase">Figma import</span>
       </button>
       {open && <FigmaPluginSetupModal onClose={close} />}
     </>
@@ -57,246 +57,140 @@ export function FigmaPluginSetupButton() {
 }
 
 function FigmaPluginSetupModal({ onClose }: { onClose: () => void }) {
-  const closeRef = useRef<HTMLButtonElement>(null)
-  const [manifest, setManifest] = useState<ManifestStatus | null>(null)
-  const [feedback, setFeedback] = useState<string | null>(null)
-  const [busy, setBusy] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const downloadRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
-    closeRef.current?.focus()
+    downloadRef.current?.focus()
+  }, [])
 
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return
+  const handleDialogKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
       event.preventDefault()
       onClose()
-    }
-    document.addEventListener('keydown', onKeyDown)
-
-    let cancelled = false
-    const prepareManifest = async () => {
-      if (!window.hypermotion) {
-        if (!cancelled) {
-          setFeedback('Open this screen in the Hyper Motion desktop app.')
-        }
-        return
-      }
-      try {
-        const result = await window.hypermotion.invoke(
-          'figma-plugin:get-manifest-status',
-        )
-        if (!cancelled && isManifestStatus(result)) {
-          setManifest(result)
-          if (!result.ok) setFeedback(result.message ?? 'Plugin setup failed.')
-        }
-      } catch {
-        if (!cancelled) setFeedback('Could not prepare the Figma plugin.')
-      }
-    }
-    void prepareManifest()
-
-    return () => {
-      cancelled = true
-      document.removeEventListener('keydown', onKeyDown)
-    }
-  }, [onClose])
-
-  const copyManifestPath = async () => {
-    if (!manifest?.path) return
-    try {
-      const desktopClipboard = window.hypermotion?.clipboard
-      if (desktopClipboard) {
-        await desktopClipboard.writeText(manifest.path)
-      } else {
-        await navigator.clipboard.writeText(manifest.path)
-      }
-      setFeedback('Manifest path copied.')
-    } catch {
-      setFeedback('Could not copy the path. Select it manually below.')
-    }
-  }
-
-  const revealManifest = async () => {
-    if (!window.hypermotion) {
-      setFeedback('Reveal is available in the Hyper Motion desktop app.')
       return
     }
-    setBusy(true)
-    try {
-      const result = await window.hypermotion.invoke(
-        'figma-plugin:reveal-manifest',
-      )
-      if (isManifestStatus(result)) {
-        setManifest(result)
-        setFeedback(
-          result.exists
-            ? result.ok
-              ? 'Manifest revealed in Finder.'
-              : 'The previous plugin copy was revealed. Restart Hyper Motion to retry the update.'
-            : result.message ?? 'The plugin manifest is unavailable.',
-        )
-      } else {
-        setFeedback('Could not reveal the plugin manifest.')
-      }
-    } catch {
-      setFeedback('Could not reveal the plugin manifest.')
-    } finally {
-      setBusy(false)
+    if (event.key !== 'Tab') return
+
+    const focusable = Array.from(
+      dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? [],
+    )
+    if (focusable.length === 0) {
+      event.preventDefault()
+      dialogRef.current?.focus()
+      return
+    }
+
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    } else if (!focusable.includes(document.activeElement as HTMLElement)) {
+      event.preventDefault()
+      ;(event.shiftKey ? last : first).focus()
     }
   }
 
-  const ready = manifest?.exists === true
+  const openReleases = () => {
+    window.open(RELEASES_URL, '_blank', 'noopener,noreferrer')
+  }
 
   return createPortal(
     <div
       data-hm-editor-ui="1"
+      data-hm-figma-plugin-modal="1"
       role="dialog"
       aria-modal="true"
       aria-labelledby="figma-plugin-setup-title"
+      aria-describedby="figma-plugin-setup-description"
+      tabIndex={-1}
+      ref={dialogRef}
+      onKeyDown={handleDialogKeyDown}
       onPointerDown={(event) => {
         if (event.target === event.currentTarget) onClose()
       }}
-      className="fixed inset-0 z-[120] flex items-center justify-center bg-black/45 px-6 backdrop-blur-[2px]"
+      className="fixed inset-0 z-[120] flex items-center justify-center bg-black/40 p-4 outline-none"
     >
-      <div className="w-full max-w-[600px] overflow-hidden rounded-lg border border-border-strong bg-panel-raised shadow-2xl">
-        <div className="flex items-start justify-between border-b border-border px-5 py-4">
-          <div className="flex min-w-0 items-start gap-3">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent-soft text-accent">
-              <NucleoPlugIcon size={18} />
+      <div className="w-full max-w-[480px] overflow-hidden rounded-[10px] border border-border-strong bg-panel-raised uppercase shadow-[0_24px_70px_rgba(0,0,0,0.34)]">
+        <header className="flex items-start justify-between gap-4 border-b border-border px-4 py-3.5">
+          <div className="flex min-w-0 items-start gap-2.5">
+            <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-panel text-accent">
+              <NucleoPuzzlePieceIcon size={15} />
             </div>
             <div className="min-w-0">
-              <div className="mb-1 flex items-center gap-2">
+              <div className="flex items-center gap-2">
                 <h2
                   id="figma-plugin-setup-title"
-                  className="text-[14px] font-semibold text-text"
+                  className="hm-type-dialog-title font-semibold uppercase text-text"
                 >
-                  Connect Figma to Hyper Motion
+                  Figma import plugin
                 </h2>
-                <span className="rounded border border-border bg-panel px-1.5 py-0.5 text-[9px] font-medium tracking-wider text-text-dim">
-                  Bundled plugin
-                </span>
               </div>
-              <p className="max-w-[460px] text-[11px] leading-5 text-text-muted">
-                No download, source code, or terminal is required. Hyper Motion
-                keeps this local plugin updated inside your Application Support
-                folder.
+              <p
+                id="figma-plugin-setup-description"
+                className="hm-type-support mt-0.5 text-text-muted"
+              >
+                Download the plugin, then import its manifest in Figma Desktop.
               </p>
             </div>
           </div>
           <button
-            ref={closeRef}
             type="button"
             onClick={onClose}
-            aria-label="Close Figma plugin instructions"
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-text-muted outline-none hover:bg-panel hover:text-text focus-visible:ring-2 focus-visible:ring-accent/40"
+            aria-label="Close Figma plugin setup"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-text-muted outline-none hover:bg-panel hover:text-text focus-visible:ring-2 focus-visible:ring-accent/40"
           >
-            <NucleoCloseIcon size={16} />
+            <NucleoCloseIcon size={14} />
           </button>
-        </div>
+        </header>
 
-        <div className="px-5 py-5">
-          <div className="mb-4 rounded-md border border-border bg-panel px-3 py-3">
-            <div className="mb-2 flex items-center justify-between gap-3">
-              <span className="text-[10px] font-medium tracking-wider text-text-dim">
-                Plugin manifest
-              </span>
-              <span
-                className={[
-                  'rounded px-1.5 py-0.5 text-[9px] font-medium tracking-wide',
-                  ready
-                    ? 'bg-[oklch(0.7_0.14_145/0.14)] text-[oklch(0.62_0.14_145)]'
-                    : 'bg-panel-raised text-text-dim',
-                ].join(' ')}
-              >
-                {manifest ? (ready ? 'Ready' : 'Needs attention') : 'Preparing…'}
-              </span>
-            </div>
-            <div className="flex items-center gap-2">
-              <code
-                title={manifest?.path}
-                className="min-w-0 flex-1 truncate rounded border border-border bg-app-bg px-2.5 py-2 text-[11px] normal-case text-text"
-              >
-                {manifest?.path ?? 'Preparing your local plugin…'}
-              </code>
-              <button
-                type="button"
-                disabled={!manifest?.path}
-                onClick={() => void copyManifestPath()}
-                className="h-8 shrink-0 rounded-md border border-border px-2.5 text-[10px] font-medium text-text-muted hover:bg-panel-raised hover:text-text disabled:opacity-40"
-              >
-                Copy path
-              </button>
-              <button
-                type="button"
-                disabled={busy || !ready}
-                onClick={() => void revealManifest()}
-                className="h-8 shrink-0 rounded-md bg-accent px-3 text-[10px] font-medium text-white shadow-sm hover:brightness-110 disabled:cursor-wait disabled:opacity-40"
-              >
-                {busy ? 'Revealing…' : 'Reveal manifest'}
-              </button>
-            </div>
-            {feedback && (
-              <p
-                aria-live="polite"
-                className="mt-2 text-[10px] normal-case text-text-muted"
-              >
-                {feedback}
-              </p>
-            )}
-          </div>
-
+        <div className="grid min-w-0 gap-3 px-4 py-4">
           <ol className="grid gap-3">
             <SetupStep
               number="1"
-              icon={<NucleoWindowPointerIcon />}
-              title="Keep your Figma design file open"
+              icon={<NucleoDownloadIcon size={14} />}
+              title="Download the plugin"
+              action={
+                <button
+                  ref={downloadRef}
+                  type="button"
+                  onClick={openReleases}
+                  className="mt-2 flex h-8 items-center justify-center gap-1.5 rounded-md bg-accent px-3 hm-type-body font-semibold uppercase text-white outline-none hover:brightness-110 focus-visible:ring-2 focus-visible:ring-accent/40"
+                >
+                  <NucleoDownloadIcon size={14} />
+                  Download from releases
+                </button>
+              }
             >
-              Use the Figma desktop app and stay in the file you want to
-              import from.
+              Download the <strong>Figma plugin ZIP</strong> from the latest
+              Hyper Motion release, then unzip it.
             </SetupStep>
             <SetupStep
               number="2"
-              icon={<NucleoFileContentIcon />}
-              title="Reveal the manifest from Hyper Motion"
+              icon={<NucleoFileContentIcon size={14} />}
+              title="Import manifest.json"
             >
-              Click <strong>Reveal manifest</strong> above. Hyper Motion opens
-              the exact user-specific file; its path stays the same after app
-              updates.
+              In Figma Desktop, choose{' '}
+              <strong>
+                Plugins → Development → Import new plugin from manifest…
+              </strong>
+              , then select <strong>manifest.json</strong> from the unzipped
+              folder.
             </SetupStep>
             <SetupStep
               number="3"
-              icon={<NucleoPlugIcon />}
-              title="Import the local plugin once"
+              icon={<NucleoClipboardCheckIcon size={14} />}
+              title="Copy into Hyper Motion"
             >
-              In Figma, choose <strong>Plugins → Development → Import new
-              plugin from manifest…</strong>, then select the revealed{' '}
-              <strong>manifest.json</strong>.
-            </SetupStep>
-            <SetupStep
-              number="4"
-              icon={<NucleoClipboardCheckIcon />}
-              title="Copy your selection into Hyper Motion"
-            >
-              Select layers, run <strong>Plugins → Development → Hyper Motion
-              Import</strong>, choose <strong>Copy to Hyper Motion</strong>,
-              then paste here with <strong>⌘ V</strong>.
+              Run <strong>Hyper Motion Import</strong>, choose{' '}
+              <strong>Copy to Hyper Motion</strong>, return here, and press{' '}
+              <strong>⌘V</strong>.
             </SetupStep>
           </ol>
-
-          <p className="mt-4 text-[10px] leading-4 text-text-dim">
-            Setup is required once. Future Hyper Motion updates refresh the
-            same plugin folder automatically; Figma keeps it under Plugins →
-            Development.
-          </p>
-        </div>
-
-        <div className="flex justify-end border-t border-border px-5 py-3">
-          <button
-            type="button"
-            onClick={onClose}
-            className="h-8 rounded-md border border-border px-4 text-[11px] font-medium text-text-muted hover:bg-panel hover:text-text"
-          >
-            Done
-          </button>
         </div>
       </div>
     </div>,
@@ -309,25 +203,26 @@ function SetupStep({
   icon,
   title,
   children,
+  action,
 }: {
   number: string
   icon: ReactNode
   title: string
   children: ReactNode
+  action?: ReactNode
 }) {
   return (
-    <li className="grid grid-cols-[32px_1fr] gap-3">
-      <div className="relative flex h-8 w-8 items-center justify-center rounded-md border border-border bg-panel text-text-muted">
+    <li className="grid grid-cols-[20px_24px_1fr] items-start gap-2">
+      <span className="hm-type-micro pt-1 text-right tabular-nums text-text-dim">
+        {number}
+      </span>
+      <span className="flex h-6 w-6 items-center justify-center rounded border border-border bg-panel text-text-muted">
         {icon}
-        <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[8px] font-semibold text-white">
-          {number}
-        </span>
-      </div>
-      <div className="pt-0.5">
-        <h3 className="text-[11px] font-medium text-text">{title}</h3>
-        <p className="mt-0.5 text-[10px] leading-4 text-text-muted">
-          {children}
-        </p>
+      </span>
+      <div className="min-w-0 pt-0.5">
+        <h3 className="hm-type-body font-semibold uppercase text-text">{title}</h3>
+        <p className="hm-type-support mt-0.5 text-text-muted">{children}</p>
+        {action}
       </div>
     </li>
   )

--- a/src/ui/FloatingDock.tsx
+++ b/src/ui/FloatingDock.tsx
@@ -5,6 +5,16 @@ import { useUI, type Tool } from '@/state/ui'
 import { useSceneAPI } from '@/scene'
 import { importImageFiles } from '@/ui/importImage'
 import { importMediaFiles } from '@/ui/importMedia'
+import {
+  NucleoEllipseIcon,
+  NucleoFrameIcon,
+  NucleoHandIcon,
+  NucleoImageIcon,
+  NucleoPointerIcon,
+  NucleoRectangleIcon,
+  NucleoTextToolIcon,
+  NucleoVideoIcon,
+} from '@/ui/icons/NucleoUiIcons'
 
 /**
  * FloatingDock — the tool palette as a floating pill at the bottom of
@@ -28,12 +38,12 @@ import { importMediaFiles } from '@/ui/importMedia'
  */
 
 const TOOLS: { id: Tool; shortcut: string; hint: string; icon: ReactNode }[] = [
-  { id: 'select', shortcut: 'V', hint: 'Select', icon: <CursorIcon /> },
-  { id: 'hand', shortcut: 'H', hint: 'Hand (pan)', icon: <HandIcon /> },
-  { id: 'frame', shortcut: 'F', hint: 'Frame', icon: <FrameIcon /> },
-  { id: 'rect', shortcut: 'R', hint: 'Rectangle', icon: <RectIcon /> },
-  { id: 'ellipse', shortcut: 'O', hint: 'Ellipse', icon: <EllipseIcon /> },
-  { id: 'text', shortcut: 'T', hint: 'Text', icon: <TextIcon /> },
+  { id: 'select', shortcut: 'V', hint: 'Select', icon: <NucleoPointerIcon size={18} /> },
+  { id: 'hand', shortcut: 'H', hint: 'Hand (pan)', icon: <NucleoHandIcon size={18} /> },
+  { id: 'frame', shortcut: 'F', hint: 'Frame', icon: <NucleoFrameIcon size={18} /> },
+  { id: 'rect', shortcut: 'R', hint: 'Rectangle', icon: <NucleoRectangleIcon size={18} /> },
+  { id: 'ellipse', shortcut: 'O', hint: 'Ellipse', icon: <NucleoEllipseIcon size={18} /> },
+  { id: 'text', shortcut: 'T', hint: 'Text', icon: <NucleoTextToolIcon size={18} /> },
 ]
 
 // Dock groupings. Each entry is the index in TOOLS where that group
@@ -142,7 +152,7 @@ export function FloatingDock() {
         onClick={() => imageInputRef.current?.click()}
         className="flex h-[34px] w-[34px] items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-white/[0.07] hover:text-text"
       >
-        <ImageIcon />
+        <NucleoImageIcon size={18} />
       </button>
       <input
         ref={imageInputRef}
@@ -161,7 +171,7 @@ export function FloatingDock() {
         onClick={() => mediaInputRef.current?.click()}
         className="flex h-[34px] w-[34px] items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-white/[0.07] hover:text-text"
       >
-        <VideoIcon />
+        <NucleoVideoIcon size={18} />
       </button>
       <input
         ref={mediaInputRef}
@@ -175,92 +185,5 @@ export function FloatingDock() {
         }}
       />
     </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Icons — copied from TopBar (single file ownership, since the dock now
-// owns these). Slightly larger viewBox-internal stroke sized for the
-// 18×18 visual size so they don't look spindly at dock scale.
-// ---------------------------------------------------------------------------
-
-function svgProps() {
-  return {
-    width: 18,
-    height: 18,
-    viewBox: '0 0 16 16',
-    fill: 'none',
-    stroke: 'currentColor',
-    strokeWidth: 1.5,
-    strokeLinecap: 'round' as const,
-    strokeLinejoin: 'round' as const,
-  }
-}
-
-function CursorIcon() {
-  return (
-    <svg {...svgProps()}>
-      <path d="M3 2.5l7.5 11 1.7-4.4 4.4-1.7L3 2.5z" />
-    </svg>
-  )
-}
-
-function FrameIcon() {
-  return (
-    <svg {...svgProps()}>
-      <path d="M5 1.5v13M11 1.5v13M1.5 5h13M1.5 11h13" />
-    </svg>
-  )
-}
-
-function RectIcon() {
-  return (
-    <svg {...svgProps()}>
-      <rect x="2.5" y="3.5" width="11" height="9" rx="1" />
-    </svg>
-  )
-}
-
-function EllipseIcon() {
-  return (
-    <svg {...svgProps()}>
-      <ellipse cx="8" cy="8" rx="5.5" ry="4.5" />
-    </svg>
-  )
-}
-
-function TextIcon() {
-  return (
-    <svg {...svgProps()}>
-      <path d="M3 4V3h10v1M8 3v10M5.5 13h5" />
-    </svg>
-  )
-}
-
-function HandIcon() {
-  return (
-    <svg {...svgProps()}>
-      <path d="M5.5 8V3.5a1 1 0 112 0V8M7.5 8V2.5a1 1 0 112 0V8M9.5 8V3.5a1 1 0 112 0V9M11.5 9V5.5a1 1 0 112 0V11.5c0 2.2-1.8 3-3.5 3h-2c-1 0-1.7-.4-2.3-1L3 10c-.6-.7-.3-1.6.5-1.6.4 0 .8.2 1 .5L5.5 10" />
-    </svg>
-  )
-}
-
-function ImageIcon() {
-  return (
-    <svg {...svgProps()}>
-      <rect x="2" y="3" width="12" height="10" rx="1" />
-      <circle cx="6" cy="6.5" r="1" />
-      <path d="M2.5 11.5l3-3 2.5 2.5 2-2 3.5 3.5" />
-    </svg>
-  )
-}
-
-function VideoIcon() {
-  return (
-    <svg {...svgProps()}>
-      <rect x="2" y="3.5" width="9" height="9" rx="1" />
-      <path d="M11 6.2l3-1.7v7l-3-1.7z" />
-      <path d="M5.5 6.3v3.4L8.4 8z" fill="currentColor" stroke="none" />
-    </svg>
   )
 }

--- a/src/ui/LayersPanel.tsx
+++ b/src/ui/LayersPanel.tsx
@@ -15,6 +15,8 @@ import { buildNodeContextMenu } from '@/ui/contextMenuActions'
 import { instantiateComponent, setLockedRecursive } from '@/ui/actions'
 import { getLastSolvedLayout } from '@/ui/hooks/lastSolvedLayout'
 
+const ASSET_LIBRARY_ENABLED = false
+
 /**
  * Layers panel.
  *
@@ -188,7 +190,7 @@ export function LayersPanel() {
       ) : (
         <ComponentsPanel onViewAll={() => setComponentsModalOpen(true)} />
       )}
-      {componentsModalOpen ? (
+      {ASSET_LIBRARY_ENABLED && componentsModalOpen ? (
         <ComponentsModal onClose={() => setComponentsModalOpen(false)} />
       ) : null}
       {/* Right-edge drag handle. 4px wide, sits half-outside the panel
@@ -232,46 +234,49 @@ function ComponentsPanel({ onViewAll }: { onViewAll: () => void }) {
   useSceneVersion()
   const api = useSceneAPI()
   const components = listComponents(api)
-  const setSelection = useUI((s) => s.setSelection)
-  const setComponentEditId = useUI((s) => s.setComponentEditId)
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex h-9 shrink-0 items-center justify-between border-b border-border px-3">
-        <span className="text-[11px] font-medium text-text-muted">
-          Assets
+        <span className="text-[11px] font-medium uppercase text-text-muted">
+          Asset library
         </span>
-        <button
-          type="button"
-          onClick={onViewAll}
-          className="rounded px-2 py-1 text-[11px] font-medium text-[oklch(0.7_0.24_300)] hover:bg-panel-raised"
-        >
-          View all
-        </button>
+        <div className="flex items-center gap-1">
+          <span
+            role="status"
+            className="rounded border border-border bg-panel-raised px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.04em] text-text-dim"
+          >
+            Coming soon
+          </span>
+          <button
+            type="button"
+            disabled={!ASSET_LIBRARY_ENABLED}
+            onClick={onViewAll}
+            title="Coming soon"
+            className="rounded px-1.5 py-1 text-[9px] font-medium uppercase text-text-dim disabled:cursor-not-allowed disabled:opacity-45"
+          >
+            View all
+          </button>
+        </div>
       </div>
-      <div className="flex-1 overflow-auto py-2">
+      <div
+        aria-disabled="true"
+        className="pointer-events-none flex-1 select-none overflow-auto py-2 opacity-35"
+      >
         {components.length === 0 ? (
-          <p className="px-3 py-4 text-[12px] text-text-dim">
-            No components yet.
+          <p className="px-3 py-4 text-[11px] uppercase text-text-dim">
+            Components
             <br />
-            <span className="text-[11px]">Select layers and press ⌥⌘K.</span>
+            <span className="text-[10px]">Reusable assets will appear here.</span>
           </p>
         ) : (
           components.map((component) => (
             <button
               key={component.id}
               type="button"
-              draggable
-              onDragStart={(e) => {
-                e.dataTransfer.setData('text/hyper-motion-component', component.id)
-                e.dataTransfer.effectAllowed = 'copy'
-              }}
-              onClick={() => setSelection([component.id])}
-              onDoubleClick={() => {
-                setComponentEditId(component.id)
-                setSelection([component.id])
-              }}
-              className="group flex w-full items-center gap-2 px-3 py-2 text-left text-[12px] text-text-muted hover:bg-panel-raised hover:text-text"
+              disabled
+              draggable={false}
+              className="group flex w-full cursor-not-allowed items-center gap-2 px-3 py-2 text-left text-[11px] uppercase text-text-muted"
             >
               <span className="font-mono text-[11px] text-[oklch(0.7_0.24_300)]">
                 ◆
@@ -284,12 +289,15 @@ function ComponentsPanel({ onViewAll }: { onViewAll: () => void }) {
           ))
         )}
       </div>
-      <div className="border-t border-border px-3 py-3">
+      <div
+        aria-disabled="true"
+        className="pointer-events-none select-none border-t border-border px-3 py-3 opacity-35"
+      >
         <div className="text-[10px] font-medium uppercase tracking-wider text-text-dim">
           Imported assets
         </div>
-        <div className="mt-2 rounded-md border border-dashed border-border px-3 py-2 text-[11px] text-text-dim">
-          Images and media can be dropped directly onto the scene canvas.
+        <div className="mt-2 rounded-md border border-dashed border-border px-3 py-2 text-[10px] uppercase text-text-dim">
+          Images and media
         </div>
       </div>
     </div>

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -4114,7 +4114,7 @@ function TimelineTabButton({
       type="button"
       onClick={onClick}
       className={[
-        'h-5 rounded px-1.5 text-[10px] font-semibold uppercase tracking-[0.06em]',
+        'h-5 shrink-0 whitespace-nowrap rounded px-1.5 text-[9px] font-semibold uppercase tracking-[0.04em]',
         active
           ? 'bg-accent-soft text-accent'
           : 'text-text-muted hover:bg-panel-raised hover:text-text',

--- a/src/ui/icons/NucleoUiIcons.tsx
+++ b/src/ui/icons/NucleoUiIcons.tsx
@@ -6,6 +6,7 @@ import type { SVGProps } from 'react'
  * Small, local subset of Nucleo UI Essential Outline 18 icons.
  * Source: https://nucleoapp.com/free-ui-icons
  * License: https://nucleoapp.com/license
+ * Package reference: nucleo-ui-essential-outline-18@1.1.7
  */
 type NucleoIconProps = SVGProps<SVGSVGElement> & {
   size?: number
@@ -92,6 +93,432 @@ export function NucleoPlugIcon({
         strokeLinejoin="round"
         strokeWidth={strokeWidth}
       />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoPuzzlePieceIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="M14.75,8.25c.372,0,.716,.118,1,.317v-2.317c0-1.104-.895-2-2-2h-2.317c.198-.284,.317-.627,.317-1,0-.967-.784-1.75-1.75-1.75s-1.75,.783-1.75,1.75c0,.373,.118,.716,.317,1h-2.317c-1.105,0-2,.896-2,2v2.317c-.284-.198-.628-.317-1-.317-.966,0-1.75,.783-1.75,1.75s.784,1.75,1.75,1.75c.372,0,.716-.118,1-.317v2.317c0,1.104,.895,2,2,2h2.317c-.198-.284-.317-.627-.317-1,0-.967,.784-1.75,1.75-1.75s1.75,.783,1.75,1.75c0,.373-.118,.716-.317,1h2.317c1.105,0,2-.896,2-2v-2.317c-.284,.198-.628,.317-1,.317-.966,0-1.75-.783-1.75-1.75s.784-1.75,1.75-1.75Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoFolderOpenIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="M2.25,7.75v-3c0-1.105,.895-2,2-2h1.951c.607,0,1.18,.275,1.56,.748l.603,.752h5.386c1.105,0,2,.895,2,2v1.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="M2.702,7.75H15.298c.986,0,1.703,.934,1.449,1.886l-1.101,4.129c-.233,.876-1.026,1.485-1.932,1.485H4.287c-.906,0-1.699-.609-1.932-1.485l-1.101-4.129c-.254-.952,.464-1.886,1.449-1.886Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoFilesIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="M6.25,10.75H3.25c-.552,0-1-.448-1-1V2.75c0-.552,.448-1,1-1H7.25l2,2v1"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <polyline
+        points="6.75 1.75 6.75 3.75 8.75 3.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="M15.75,9.25v6c0,.552-.448,1-1,1h-5c-.552,0-1-.448-1-1v-7c0-.552,.448-1,1-1h4l2,2Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <polyline
+        points="13.75 7.25 13.75 9.25 15.75 9.25"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoKeyboardIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <rect
+        x=".75"
+        y="4.75"
+        width="16.5"
+        height="8.5"
+        rx="2"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1="11.75"
+        y1="10.25"
+        x2="6.25"
+        y2="10.25"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      {[
+        [3, 7],
+        [3, 9.5],
+        [5.5, 7],
+        [8.25, 7],
+        [11, 7],
+        [13.5, 7],
+        [13.5, 9.5],
+      ].map(([x, y]) => (
+        <rect key={`${x}-${y}`} x={x} y={y} width="1.5" height="1.5" rx=".5" fill="currentColor" />
+      ))}
+    </NucleoIcon>
+  )
+}
+
+export function NucleoCheckIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <polyline
+        points="2.75 9.25 6.75 14.25 15.25 3.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoWarningIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="M7.638 3.49 2.213 12.89c-.605 1.05.151 2.36 1.362 2.36h10.85c1.211 0 1.967-1.31 1.362-2.36l-5.425-9.4c-.605-1.04-2.119-1.04-2.724 0Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="M9 6.75v3"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <circle cx="9" cy="12.5" r="1" fill="currentColor" />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoDownloadIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <polyline
+        points="11.5 5.75 9 8.25 6.5 5.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1="9"
+        y1="8.25"
+        x2="9"
+        y2="2.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="M16.214,9.75H11.75v1c0,.552-.448,1-1,1h-3.5c-.552,0-1-.448-1-1v-1H1.787"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="M12,2.75h.137c.822,0,1.561,.503,1.862,1.269l2.113,5.379c.092,.233,.138,.481,.138,.731v3.121c0,1.105-.895,2-2,2H3.75c-1.105,0-2-.895-2-2v-3.121c0-.25,.047-.498,.138-.731l2.113-5.379c.301-.765,1.039-1.269,1.862-1.269H6"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoPointerIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="M3.474,2.784 14.897,6.958c.481,.176,.467,.861-.021,1.018L9.648,9.649l-1.673,5.228c-.156,.488-.842,.502-1.018,.021L2.784,3.474c-.157-.43,.26-.847,.69-.69Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoHandIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="M10.75,8.25V2.5c0-.69-.564-1.25-1.25-1.25s-1.25,.56-1.25,1.25v5.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="M13.25,8.25V3.25c0-.69-.564-1.25-1.25-1.25s-1.25,.56-1.25,1.25v5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="M8.25,8.25V3.25c0-.69-.564-1.25-1.25-1.25s-1.25,.56-1.25,1.25V12.053"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <path
+        d="m5.75,11.215-1.768-2.252c-.426-.543-1.215-.635-1.755-.211s-.604,1.131-.211,1.755l2.551,3.924c.738,1.135,2,1.82,3.354,1.82h3.83c2.209,0,4-1.791,4-4V4c0-.69-.564-1.25-1.25-1.25s-1.25,.56-1.25,1.25v4.25"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoFrameIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <rect
+        x="2.75"
+        y="2.75"
+        width="12.5"
+        height="12.5"
+        rx="2"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <polyline
+        points="12.25 8.75 12.25 5.75 9.25 5.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <polyline
+        points="8.75 12.25 5.75 12.25 5.75 9.25"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoRectangleIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <rect
+        x="2.25"
+        y="3.75"
+        width="13.5"
+        height="10.5"
+        rx="1.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoEllipseIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <ellipse
+        cx="9"
+        cy="9"
+        rx="7.25"
+        ry="5.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoTextToolIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="M16.25,12v.75c0,1.105-.895,2-2,2H3.75c-1.105,0-2-.895-2-2V12M1.75,6v-.75c0-1.105,.895-2,2-2h10.5c1.105,0,2,.895,2,2V6"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <polyline
+        points="11.798 12.25 9.068 5.75 8.932 5.75 6.202 12.25"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1="6.832"
+        y1="10.75"
+        x2="11.168"
+        y2="10.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <circle cx="1.75" cy="9" r=".75" fill="currentColor" />
+      <circle cx="16.25" cy="9" r=".75" fill="currentColor" />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoImageIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="m16.329,12.658-4.273-5.812c-.4-.543-1.212-.543-1.611,0l-3.319,4.514-1.444-1.964c-.4-.544-1.212-.544-1.611,0l-2.398,3.262c-.486,.66-.014,1.592,.806,1.592h13.044c.82,0,1.291-.932,.806-1.592Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        cx="5.5"
+        cy="4"
+        r="1.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </NucleoIcon>
+  )
+}
+
+export function NucleoVideoIcon({
+  strokeWidth = 1.5,
+  ...props
+}: NucleoIconProps) {
+  return (
+    <NucleoIcon {...props}>
+      <path
+        d="m12.25,8 4.259-2.342c.333-.183,.741,.058,.741,.438v5.809c0,.38-.408,.621-.741,.438L12.25,10"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <rect
+        x="1.75"
+        y="3.75"
+        width="10.5"
+        height="10.5"
+        rx="2"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <circle cx="4.75" cy="6.75" r=".75" fill="currentColor" />
     </NucleoIcon>
   )
 }


### PR DESCRIPTION
## Summary

- tighten editor typography while preserving authored canvas text and explicit control sizing
- simplify Figma plugin setup to a three-step release download and manifest import flow
- mark the Assets panel as coming soon and disable every asset interaction
- package and attach the standalone Figma plugin ZIP automatically in releases

## Validation

- `pnpm build:dir`
- `pnpm exec vite build`
- `pnpm test:figma-plugin-shell`
- `pnpm --dir figma-plugin typecheck`
- `pnpm exec tsc -p tsconfig.electron.json`
- focused ESLint for all changed TypeScript/TSX files
- `git diff --check`
- generated and integrity-checked the Figma plugin ZIP
