### PR TITLE
Prepare v0.1.16 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Plus everything you expect from a Jitter-class tool: a real timeline,
 in/out presets, easing curves, 3D camera with depth-of-field, and MP4 /
 WebM / GIF export.
 
-## Status — v0.1.15 research preview
+## Status — v0.1.16 research preview
 
 The semantic-layout-animation bet works end-to-end, with desktop
 editing, Figma import, pixel-correct export, and CLI / MCP workflows for
@@ -34,7 +34,7 @@ copies the app into `/Applications`, strips macOS's download quarantine,
 applies a local ad-hoc signature, and opens it. No drag-to-Applications,
 no "damaged" dialog, no per-version steps.
 
-For a specific version: `curl ... | bash -s -- v0.1.15`.
+For a specific version: `curl ... | bash -s -- v0.1.16`.
 
 ### Manual install
 
@@ -77,12 +77,11 @@ open release/mac-arm64/hyper-motion.app
 ## Figma plugin
 
 Copy frames, text, layout, and vector artwork from Figma straight into
-hyper-motion. The desktop app includes the importer—no repository checkout,
-source build, or terminal setup is required. Click the Figma import button in
-the top bar, reveal the manifest from the setup modal, then choose
-**Plugins → Development → Import plugin from manifest…** in Figma Desktop.
-That one-time registration uses a stable per-user location which Hyper Motion
-keeps refreshed across app updates.
+hyper-motion. Click the Figma import button in the top bar, download the plugin
+ZIP from the latest GitHub release, and unzip it. In Figma Desktop, choose
+**Plugins → Development → Import new plugin from manifest…** and select the
+downloaded `manifest.json`. Every release includes the ready-to-use plugin—no
+repository checkout, source build, or terminal setup is required.
 
 Payload v2 imports supported artwork as native vector-backed layers and retains
 the canonical point/segment graph, Bézier controls, transforms, ordered paints,
@@ -94,17 +93,20 @@ Direct point editing remains a follow-up. Contributor source lives in
 Full step-by-step at [hypermotion.app/docs#figma-plugin](https://hypermotion.app/docs#figma-plugin).
 Figma Community publish (one-click install) is on the v0.2 roadmap.
 
-## What's in v0.1.15
+## What's in v0.1.16
 
-- **Built-in Figma importer setup.** Open the setup guide from the editor,
-  reveal the exact bundled manifest, and register it once in Figma Desktop—no
-  code download, local build, or terminal commands required.
-- **Stable plugin updates.** Hyper Motion refreshes the importer in its
-  Application Support directory on launch while preserving the same manifest
-  path that Figma already knows.
-- **More compact editor chrome.** Interface text is denser and gives the canvas
-  more breathing room while authored text and exported compositions remain
-  unchanged.
+- **Direct Figma plugin download.** The setup modal now leads with the release
+  ZIP and the standard three-step Figma manifest import flow.
+- **Standalone plugin release asset.** Every GitHub release automatically
+  includes a versioned, ready-to-import Figma plugin ZIP alongside the app.
+- **More compact editor chrome.** General interface text now uses an 11px base
+  with a tighter semantic scale while authored canvas text remains unchanged.
+- **Consistent editor icons.** The floating tool dock and setup UI now use the
+  Nucleo UI Essential outline set instead of mixed local artwork.
+- **Assets safely gated.** The Assets panel is marked Coming Soon and all of
+  its browsing, editing, dragging, and insertion paths are disabled.
+- **Stable timeline tabs.** Compact timeline labels remain on one line instead
+  of wrapping into the animated-property rows.
 
 - **Camera-accurate selection and resize.** Selection polygons, hit testing,
   and all eight resize handles now follow workspace zoom, camera XYZ, tilt,

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,49 @@
 Human-friendly release notes. The GitHub Releases page mirrors the matching
 entry below for each corresponding tag.
 
+## v0.1.16 — Compact editor polish and downloadable Figma setup (2026-07-20)
+
+Hyper Motion's editor chrome is denser and more consistent, the Figma importer
+now follows the familiar download-and-import flow, and unfinished asset-library
+actions are clearly gated. The release pipeline also publishes the standalone
+Figma plugin automatically alongside every desktop build.
+
+### Clearer Figma setup
+
+- Lead with a direct link to the latest Hyper Motion release instead of a
+  hidden Application Support path.
+- Reduce setup to three steps: download and unzip the plugin, import
+  `manifest.json` in Figma Desktop, then copy the selection into Hyper Motion.
+- Keep every visible modal label and instruction in capitals, with compact
+  spacing, keyboard focus containment, and focus restoration on close.
+- Publish a versioned `hyper-motion-figma-plugin-v*.zip` release asset containing
+  the manifest, compiled plugin runtime, UI, license, notice, and guide.
+
+### Denser, consistent editor chrome
+
+- Move the editor to an 11px general type size with 10px support text and 9px
+  metadata while leaving authored canvas text and exported compositions alone.
+- Preserve explicit control typography instead of globally overriding form
+  sizes, so compact mode does not collapse intentionally larger controls.
+- Replace the floating tool dock artwork and Figma setup icons with a consistent
+  Nucleo UI Essential outline set.
+- Keep the Animated Layers timeline tab on one line at narrow panel widths.
+
+### Assets safely gated
+
+- Mark the Assets panel as **Coming Soon** without changing the Layers panel.
+- Disable View All, component selection, double-click editing, dragging, and
+  imported-media interactions until the asset library is ready.
+- Block the legacy component browser modal from opening through any Assets
+  panel path.
+
+### Install on macOS
+
+Download the Apple Silicon or Intel DMG from this release, or use the one-line
+installer in the [installation guide](https://hypermotion.app/docs#install).
+The v0.1.x builds remain unsigned and macOS-only, so macOS may require the
+first-time setup described in that guide.
+
 ## v0.1.15 — Built-in Figma importer and compact editor (2026-07-20)
 
 Figma import no longer requires cloning the repository, building plugin source,

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 #
 # Or for a specific version:
 #
-#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.15
+#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.16
 #
 # Works for every future release without changes — the script always
 # resolves the latest tag from the GitHub API unless you pass one.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyper-motion-electron",
   "private": true,
-  "version": "0.1.15",
+  "version": "0.1.16",
   "type": "module",
   "main": "dist-electron/main.cjs",
   "description": "Native motion design tool with Figma-style structural layout. Auto-layout, 3D camera, semantic keyframes, pixel-correct MP4 / WebM / GIF.",


### PR DESCRIPTION
## Summary

- bump the desktop release to v0.1.16
- document the simplified three-step Figma plugin installation flow
- document the standalone plugin ZIP now attached automatically to every release
- update the macOS installer examples

## Validation

- `pnpm build:dir`
- packaged app reports version `0.1.16`
- `pnpm test:figma-plugin-shell`
- `pnpm --dir figma-plugin typecheck`
- `pnpm exec tsc -p tsconfig.electron.json`
- `bash -n install.sh`
- parsed `.github/workflows/release.yml`
- generated and integrity-checked `hyper-motion-figma-plugin-v0.1.16.zip`
- `git diff --check`
