### PR TITLE
Prepare v0.1.17 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Plus everything you expect from a Jitter-class tool: a real timeline,
 in/out presets, easing curves, 3D camera with depth-of-field, and MP4 /
 WebM / GIF export.
 
-## Status — v0.1.16 research preview
+## Status — v0.1.17 research preview
 
 The semantic-layout-animation bet works end-to-end, with desktop
 editing, Figma import, pixel-correct export, and CLI / MCP workflows for
@@ -34,7 +34,7 @@ copies the app into `/Applications`, strips macOS's download quarantine,
 applies a local ad-hoc signature, and opens it. No drag-to-Applications,
 no "damaged" dialog, no per-version steps.
 
-For a specific version: `curl ... | bash -s -- v0.1.16`.
+For a specific version: `curl ... | bash -s -- v0.1.17`.
 
 ### Manual install
 
@@ -93,7 +93,7 @@ Direct point editing remains a follow-up. Contributor source lives in
 Full step-by-step at [hypermotion.app/docs#figma-plugin](https://hypermotion.app/docs#figma-plugin).
 Figma Community publish (one-click install) is on the v0.2 roadmap.
 
-## What's in v0.1.16
+## What's in v0.1.17
 
 - **Direct Figma plugin download.** The setup modal now leads with the release
   ZIP and the standard three-step Figma manifest import flow.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,24 @@
 Human-friendly release notes. The GitHub Releases page mirrors the matching
 entry below for each corresponding tag.
 
+## v0.1.17 — Editor and Figma setup maintenance (2026-07-21)
+
+This maintenance release keeps the current editor and Figma setup aligned with
+the latest source on `main` while removing obsolete public and source references.
+
+### Included
+
+- Keep the direct Figma plugin download and three-step manifest import flow.
+- Keep the compact editor typography, gated Assets panel, and stable timeline tabs.
+- Remove obsolete product-copy and source references.
+
+### Install on macOS
+
+Download the Apple Silicon or Intel DMG from this release, or use the one-line
+installer in the [installation guide](https://hypermotion.app/docs#install).
+The v0.1.x builds remain unsigned and macOS-only, so macOS may require the
+first-time setup described in that guide.
+
 ## v0.1.16 — Compact editor polish and downloadable Figma setup (2026-07-20)
 
 Hyper Motion's editor chrome is denser and more consistent, the Figma importer

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 #
 # Or for a specific version:
 #
-#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.16
+#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.17
 #
 # Works for every future release without changes — the script always
 # resolves the latest tag from the GitHub API unless you pass one.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyper-motion-electron",
   "private": true,
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "main": "dist-electron/main.cjs",
   "description": "Native motion design tool with Figma-style structural layout. Auto-layout, 3D camera, semantic keyframes, pixel-correct MP4 / WebM / GIF.",


### PR DESCRIPTION
## Summary

- bump the desktop app to v0.1.17
- update installation examples and current-version documentation
- add maintenance release notes without obsolete product copy

## Validation

- `pnpm build:dir`
- packaged app reports version `0.1.17`
- `pnpm test:figma-plugin-shell`
- `pnpm --dir figma-plugin typecheck`
- `pnpm exec tsc -p tsconfig.electron.json`
- `bash -n install.sh`
- verified removed references are absent from source and the packaged app
- `git diff --check`
