### PR TITLE
Fix text editing camera stability

### DIFF
--- a/src/render/RenderWindowApp.tsx
+++ b/src/render/RenderWindowApp.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/ui/Canvas'
 import { ThreeSceneViewport } from '@/render3d/ThreeSceneViewport'
 import { resolveFallbackCameraPostEffects } from '@/render/cameraPostEffectsFallbackState'
+import { resolveCameraDomProjection } from '@/render/cameraDomProjection'
 import { getAnimEngine } from '@/anim'
 import {
   createElectronCapture,
@@ -349,37 +350,18 @@ function RenderCanvas({ job }: { job: RenderJob }) {
     ? fillBackgroundStyle(cameraBackgroundFill)
     : null
 
-  const cameraFocalLength =
-    camera && camera.kind === 'camera'
-      ? Math.max(50, camera.focalLength ?? 1000)
-      : 1000
-  const cameraZ =
-    camera && camera.kind === 'camera'
-      ? cameraAnim?.z ?? camera.transform.z
-      : 0
-  const cameraDollyZ = cameraZ / 100
-  const cameraScaleFromZ = useMemo(() => {
-    const denom = Math.max(1, cameraFocalLength - cameraDollyZ)
-    return cameraFocalLength / denom
-  }, [cameraDollyZ, cameraFocalLength])
-
-  const cameraTransform = useMemo(() => {
-    if (!camera || camera.kind !== 'camera') return null
-    const cx = cameraAnim?.x ?? camera.transform.x
-    const cy = cameraAnim?.y ?? camera.transform.y
-    const rZ = cameraAnim?.rotation ?? camera.transform.rotation
-    const rX = cameraAnim?.rotationX ?? camera.transform.rotationX
-    const rY = cameraAnim?.rotationY ?? camera.transform.rotationY
-    const s = cameraScaleFromZ
-    const w = canvasWidth
-    const h = canvasHeight
-    return (
-      `translate(${w / 2}px, ${h / 2}px) ` +
-      `scale(${s}, ${s}) ` +
-      `rotateX(${-rX}deg) rotateY(${rY}deg) rotateZ(${-rZ}deg) ` +
-      `translate(${-cx}px, ${-cy}px)`
-    )
-  }, [camera, cameraAnim, cameraScaleFromZ, canvasWidth, canvasHeight])
+  const cameraDomProjection = useMemo(
+    () =>
+      resolveCameraDomProjection(
+        camera && camera.kind === 'camera' ? camera : null,
+        cameraAnim,
+        { width: canvasWidth, height: canvasHeight },
+      ),
+    [camera, cameraAnim, canvasWidth, canvasHeight],
+  )
+  const cameraFocalLength = cameraDomProjection.focalLength
+  const cameraScaleFromZ = cameraDomProjection.scale
+  const cameraTransform = cameraDomProjection.transform
 
   const cameraDepthOfField = useMemo(
     () => {
@@ -489,7 +471,10 @@ function RenderCanvas({ job }: { job: RenderJob }) {
           >
             <div
               className="absolute inset-0"
-              style={{ opacity: threeCameraAvailable ? 0 : 1 }}
+              style={{
+                opacity: threeCameraAvailable ? 0 : 1,
+                transformStyle: 'preserve-3d',
+              }}
             >
               <ScenePostProcessLayer
                 rootId={rootId}
@@ -908,11 +893,11 @@ function resolveRenderWindowFocusEffect(
   const camera = cameraId ? api.getNode(cameraId) : null
   if (!camera || camera.kind !== 'camera' || !camera.depthOfField) return null
   const cameraAnim = animated[camera.id]
-  const cameraFocalLength = Math.max(50, camera.focalLength ?? 1000)
-  const cameraZ = cameraAnim?.z ?? camera.transform.z
-  const cameraDollyZ = cameraZ / 100
-  const cameraScale =
-    cameraFocalLength / Math.max(1, cameraFocalLength - cameraDollyZ)
+  const cameraScale = resolveCameraDomProjection(
+    camera,
+    cameraAnim,
+    sceneCanvas,
+  ).scale
   const dof = computeCameraDepthOfField(
     camera,
     cameraAnim,

--- a/src/render/cameraDomProjection.ts
+++ b/src/render/cameraDomProjection.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AnimatedValue } from '@/anim'
+import type { CameraNode } from '@/scene'
+import {
+  resolveCamera3D,
+  worldToCamera,
+  type ViewportSize,
+} from '@/render3d/scene3d'
+import type { Vec3 } from '@/render3d/math'
+
+export type CameraDomMatrix = readonly [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+]
+
+export interface CameraDomProjection {
+  focalLength: number
+  z: number
+  scale: number
+  matrix: CameraDomMatrix
+  transform: string | null
+}
+
+const IDENTITY_MATRIX: CameraDomMatrix = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+]
+
+function subtract(a: Vec3, b: Vec3): Vec3 {
+  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z }
+}
+
+/**
+ * Mirrors the canonical WebGL camera projection for DOM-backed scene renders.
+ *
+ * Text editing temporarily reveals the DOM scene so contenteditable can own
+ * the glyphs. The returned matrix maps world coordinates into the exact
+ * pre-perspective CSS coordinates which project to the same pixels as WebGL.
+ * This remains camera-accurate for dolly, FOV, pitch, yaw, roll, and layer Z.
+ */
+export function resolveCameraDomProjection(
+  camera: CameraNode | null | undefined,
+  animated: AnimatedValue | undefined,
+  viewport: ViewportSize,
+): CameraDomProjection {
+  if (!camera) {
+    return {
+      focalLength: 1000,
+      z: 0,
+      scale: 1,
+      matrix: IDENTITY_MATRIX,
+      transform: null,
+    }
+  }
+
+  const resolved = resolveCamera3D(camera, animated, viewport)
+  const z = animated?.z ?? camera.transform.z
+  const focalLength = resolved.focalLength
+  const origin = { x: viewport.width / 2, y: viewport.height / 2 }
+
+  // CSS perspective projects a transformed point q with
+  //   screen = origin + (q.xy - origin) * f / (f - q.z)
+  // while the WebGL camera projects camera-space c with
+  //   screen = origin + c.xy * f / c.z.
+  // Therefore q=(origin.x+c.x, origin.y+c.y, f-c.z) is an exact bridge.
+  // worldToCamera is affine, so sampling its origin and unit axes gives the
+  // single matrix3d that applies that bridge to every DOM scene point.
+  const cameraOrigin = worldToCamera({ x: 0, y: 0, z: 0 }, resolved)
+  const cameraX = subtract(
+    worldToCamera({ x: 1, y: 0, z: 0 }, resolved),
+    cameraOrigin,
+  )
+  const cameraY = subtract(
+    worldToCamera({ x: 0, y: 1, z: 0 }, resolved),
+    cameraOrigin,
+  )
+  const cameraZ = subtract(
+    worldToCamera({ x: 0, y: 0, z: 1 }, resolved),
+    cameraOrigin,
+  )
+  const matrix: CameraDomMatrix = [
+    cameraX.x,
+    cameraX.y,
+    -cameraX.z,
+    0,
+    cameraY.x,
+    cameraY.y,
+    -cameraY.z,
+    0,
+    cameraZ.x,
+    cameraZ.y,
+    -cameraZ.z,
+    0,
+    origin.x + cameraOrigin.x,
+    origin.y + cameraOrigin.y,
+    focalLength - cameraOrigin.z,
+    1,
+  ]
+  const targetDepth = worldToCamera(resolved.pointOfInterest, resolved).z
+
+  return {
+    focalLength,
+    z,
+    scale: focalLength / Math.max(1, targetDepth),
+    matrix,
+    transform: `matrix3d(${matrix.join(',')})`,
+  }
+}

--- a/src/render3d/scene3d.focus.test.ts
+++ b/src/render3d/scene3d.focus.test.ts
@@ -1,12 +1,74 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from 'vitest'
+import * as THREE from 'three'
 import { createSceneAPI } from '@/scene/doc'
+import {
+  resolveCameraDomProjection,
+  type CameraDomProjection,
+} from '@/render/cameraDomProjection'
 import {
   depthBlurAmount,
   effectiveApertureStrength,
+  projectWorldPoint,
   resolveCamera3D,
+  type ResolvedCamera3D,
 } from './scene3d'
+import type { Vec3 } from './math'
+
+function projectWithDomCamera(
+  point: Vec3,
+  projection: CameraDomProjection,
+  viewport: { width: number; height: number },
+) {
+  const m = projection.matrix
+  const transformed = {
+    x: m[0] * point.x + m[4] * point.y + m[8] * point.z + m[12],
+    y: m[1] * point.x + m[5] * point.y + m[9] * point.z + m[13],
+    z: m[2] * point.x + m[6] * point.y + m[10] * point.z + m[14],
+  }
+  const origin = { x: viewport.width / 2, y: viewport.height / 2 }
+  const perspectiveScale =
+    projection.focalLength /
+    (projection.focalLength - transformed.z)
+  return {
+    x: origin.x + (transformed.x - origin.x) * perspectiveScale,
+    y: origin.y + (transformed.y - origin.y) * perspectiveScale,
+  }
+}
+
+function projectWithThreeCamera(
+  point: Vec3,
+  resolved: ResolvedCamera3D,
+  viewport: { width: number; height: number },
+) {
+  const camera = new THREE.PerspectiveCamera(
+    resolved.fieldOfView,
+    viewport.width / viewport.height,
+    resolved.nearClip,
+    resolved.farClip,
+  )
+  camera.position.set(
+    resolved.position.x,
+    resolved.position.y,
+    resolved.position.z,
+  )
+  camera.up.set(0, -1, 0)
+  camera.lookAt(
+    resolved.pointOfInterest.x,
+    resolved.pointOfInterest.y,
+    resolved.pointOfInterest.z,
+  )
+  camera.rotateZ(THREE.MathUtils.degToRad(-resolved.rotation.z))
+  camera.updateProjectionMatrix()
+  camera.updateMatrixWorld(true)
+
+  const projected = new THREE.Vector3(point.x, point.y, point.z).project(camera)
+  return {
+    x: ((projected.x + 1) / 2) * viewport.width,
+    y: ((1 - projected.y) / 2) * viewport.height,
+  }
+}
 
 describe('physical camera focus resolution', () => {
   it('keeps the animated point-focus center in composition screen space', () => {
@@ -94,5 +156,145 @@ describe('physical camera focus resolution', () => {
 
     expect(blur).toBeLessThanOrEqual(maxBlur)
     expect(blur).toBeCloseTo(maxBlur)
+  })
+})
+
+describe('DOM camera projection parity', () => {
+  it('matches WebGL field of view and direct Z during text-edit handoff', () => {
+    const api = createSceneAPI()
+    const camera = api.getActiveCamera()
+    if (!camera) throw new Error('Expected the default camera')
+    const viewport = { width: 960, height: 540 }
+    const authored = {
+      ...camera,
+      fieldOfView: 35,
+      transform: { ...camera.transform, z: 400 },
+    }
+
+    const webgl = resolveCamera3D(authored, undefined, viewport)
+    const dom = resolveCameraDomProjection(authored, undefined, viewport)
+    const webglTargetDepth = Math.hypot(
+      webgl.position.x - webgl.pointOfInterest.x,
+      webgl.position.y - webgl.pointOfInterest.y,
+      webgl.position.z - webgl.pointOfInterest.z,
+    )
+
+    expect(dom.focalLength).toBeCloseTo(webgl.focalLength)
+    expect(dom.z).toBe(400)
+    expect(dom.scale).toBeCloseTo(webgl.focalLength / webglTargetDepth)
+    expect(dom.scale).toBeGreaterThan(1.8)
+  })
+
+  it('tracks animated field of view and Z instead of static camera values', () => {
+    const api = createSceneAPI()
+    const camera = api.getActiveCamera()
+    if (!camera) throw new Error('Expected the default camera')
+    const viewport = { width: 960, height: 540 }
+    const animated = { fieldOfView: 70, z: -250 }
+
+    const webgl = resolveCamera3D(camera, animated, viewport)
+    const dom = resolveCameraDomProjection(camera, animated, viewport)
+
+    expect(dom.focalLength).toBeCloseTo(webgl.focalLength)
+    expect(dom.z).toBe(-250)
+    expect(dom.scale).toBeCloseTo(
+      webgl.focalLength / (webgl.focalLength + 250),
+    )
+  })
+
+  it('projects DOM pixels exactly like WebGL for every camera axis and layer depth', () => {
+    const api = createSceneAPI()
+    const camera = api.getActiveCamera()
+    if (!camera) throw new Error('Expected the default camera')
+    const viewport = { width: 960, height: 540 }
+    const authored = {
+      ...camera,
+      fieldOfView: 46,
+      transform: {
+        ...camera.transform,
+        x: 510,
+        y: 248,
+        z: 210,
+        rotationX: 18,
+        rotationY: -27,
+        rotation: 13,
+      },
+    }
+    const animated = {
+      fieldOfView: 58,
+      x: 472,
+      y: 292,
+      z: -135,
+      rotationX: -16,
+      rotationY: 31,
+      rotation: -21,
+    }
+    const points: Vec3[] = [
+      { x: 0, y: 0, z: 0 },
+      { x: 960, y: 0, z: 0 },
+      { x: 960, y: 540, z: 0 },
+      { x: 0, y: 540, z: 0 },
+      { x: 480, y: 270, z: 140 },
+      { x: 315, y: 184, z: -90 },
+    ]
+
+    for (const values of [undefined, animated]) {
+      const webgl = resolveCamera3D(authored, values, viewport)
+      const dom = resolveCameraDomProjection(authored, values, viewport)
+      for (const point of points) {
+        const expected = projectWorldPoint(point, webgl, viewport)
+        const actual = projectWithDomCamera(point, dom, viewport)
+        for (const workspaceZoom of [0.17, 1, 2]) {
+          expect(actual.x * workspaceZoom).toBeCloseTo(
+            expected.x * workspaceZoom,
+            7,
+          )
+          expect(actual.y * workspaceZoom).toBeCloseTo(
+            expected.y * workspaceZoom,
+            7,
+          )
+        }
+      }
+    }
+  })
+
+  it('matches the real Three.js camera for positive and negative roll', () => {
+    const api = createSceneAPI()
+    const camera = api.getActiveCamera()
+    if (!camera) throw new Error('Expected the default camera')
+    const viewport = { width: 960, height: 540 }
+    const points: Vec3[] = [
+      { x: 120, y: 80, z: 0 },
+      { x: 840, y: 460, z: 0 },
+      { x: 520, y: 210, z: 175 },
+    ]
+
+    for (const roll of [-30, 30]) {
+      const authored = {
+        ...camera,
+        fieldOfView: 44,
+        transform: {
+          ...camera.transform,
+          x: 480,
+          y: 270,
+          z: 185,
+          rotationX: 17,
+          rotationY: -24,
+          rotation: roll,
+        },
+      }
+      const resolved = resolveCamera3D(authored, undefined, viewport)
+      const dom = resolveCameraDomProjection(authored, undefined, viewport)
+
+      for (const point of points) {
+        const three = projectWithThreeCamera(point, resolved, viewport)
+        const analytic = projectWorldPoint(point, resolved, viewport)
+        const css = projectWithDomCamera(point, dom, viewport)
+        expect(analytic.x).toBeCloseTo(three.x, 7)
+        expect(analytic.y).toBeCloseTo(three.y, 7)
+        expect(css.x).toBeCloseTo(three.x, 7)
+        expect(css.y).toBeCloseTo(three.y, 7)
+      }
+    }
   })
 })

--- a/src/render3d/scene3d.ts
+++ b/src/render3d/scene3d.ts
@@ -363,7 +363,7 @@ export function resolveCamera3D(
   }
   const orbitOffset = rotateEuler(sub3(basePosition, pointOfInterest), -rotation.x, rotation.y, 0)
   const position = add3(pointOfInterest, orbitOffset)
-  const basis = cameraBasisFromPosition(position, pointOfInterest, -rotation.z)
+  const basis = cameraBasisFromPosition(position, pointOfInterest, rotation.z)
   const targetDepth = Math.max(1, dot3(sub3(pointOfInterest, position), basis.forward))
   const focusMode = camera.focusMode ?? 'screen'
   const focusScreen = {
@@ -493,7 +493,7 @@ function cameraBasisFromPosition(
 }
 
 function cameraBasis(camera: ResolvedCamera3D): { right: Vec3; down: Vec3; forward: Vec3 } {
-  return cameraBasisFromPosition(camera.position, camera.pointOfInterest, -camera.rotation.z)
+  return cameraBasisFromPosition(camera.position, camera.pointOfInterest, camera.rotation.z)
 }
 
 export function viewportPointToRay(

--- a/src/ui/Canvas.tsx
+++ b/src/ui/Canvas.tsx
@@ -65,6 +65,7 @@ import { FloatingDock } from '@/ui/FloatingDock'
 import { SnapshotCompositor } from '@/render/SnapshotCompositor'
 import { CameraPostEffectsFallback } from '@/render/CameraPostEffectsFallback'
 import { resolveFallbackCameraPostEffects } from '@/render/cameraPostEffectsFallbackState'
+import { resolveCameraDomProjection } from '@/render/cameraDomProjection'
 import type { CameraPostEffectsState } from '@/render3d/postEffects'
 import { ThreeSceneViewport } from '@/render3d/ThreeSceneViewport'
 import {
@@ -81,6 +82,7 @@ import {
   buildWorldPlanes,
   effectiveApertureStrength,
   hitTestPlanes,
+  projectWorldPoint,
   resolveCamera3D,
   viewportPointToRay,
 } from '@/render3d/scene3d'
@@ -128,6 +130,7 @@ type AnimatedThreeSceneViewportProps = Omit<
 const EMPTY_CAMERA_ANIMATION_IDS: NodeId[] = []
 const EMPTY_SCENE_ANIMATION_IDS: NodeId[] = []
 const EMPTY_THREE_SELECTION_IDS: NodeId[] = []
+const CAMERA_CONTROL_DRAG_THRESHOLD_PX = 6
 const subscribeToNothing = () => () => {}
 const getNoCameraPreview = () => undefined
 
@@ -365,35 +368,6 @@ function degToRad(deg: number): number {
   return (deg * Math.PI) / 180
 }
 
-function sub3(a: Vec3, b: Vec3): Vec3 {
-  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z }
-}
-
-function rotateX(v: Vec3, deg: number): Vec3 {
-  const r = degToRad(deg)
-  const c = Math.cos(r)
-  const s = Math.sin(r)
-  return { x: v.x, y: v.y * c - v.z * s, z: v.y * s + v.z * c }
-}
-
-function rotateY(v: Vec3, deg: number): Vec3 {
-  const r = degToRad(deg)
-  const c = Math.cos(r)
-  const s = Math.sin(r)
-  return { x: v.x * c + v.z * s, y: v.y, z: -v.x * s + v.z * c }
-}
-
-function rotateZ(v: Vec3, deg: number): Vec3 {
-  const r = degToRad(deg)
-  const c = Math.cos(r)
-  const s = Math.sin(r)
-  return { x: v.x * c - v.y * s, y: v.x * s + v.y * c, z: v.z }
-}
-
-function inverseRotateEuler(v: Vec3, rotX: number, rotY: number, rotZ: number): Vec3 {
-  return rotateX(rotateY(rotateZ(v, -rotZ), -rotY), -rotX)
-}
-
 function cornerRadiusCss(
   cornerRadius: number,
   cornerRadii?: CornerRadii,
@@ -573,7 +547,11 @@ export function computeCameraDepthOfField(
   const fStop = Math.max(0.1, cameraAnim?.fStop ?? camera.fStop ?? 2.8)
   const focusZ = cameraAnim?.focusWorldZ ?? camera.focusWorldZ ?? focusDistance
   const maxBlur = Math.max(0, Math.min(128, cameraAnim?.blurLevel ?? camera.blurLevel ?? 1))
-  const focalLength = Math.max(50, camera.focalLength ?? 1000)
+  const focalLength = resolveCameraDomProjection(
+    camera,
+    cameraAnim,
+    { width: canvasWidth, height: canvasHeight },
+  ).focalLength
   const cameraZ = cameraAnim?.z ?? camera.transform.z
   const rotationX = cameraAnim?.rotationX ?? camera.transform.rotationX
   const rotationY = cameraAnim?.rotationY ?? camera.transform.rotationY
@@ -681,21 +659,12 @@ function projectWorldPointThroughCamera(
   canvasWidth: number,
   canvasHeight: number,
 ): { x: number; y: number } {
-  const focalLength = Math.max(50, camera.focalLength ?? 1000)
-  const cx = cameraAnim?.x ?? camera.transform.x
-  const cy = cameraAnim?.y ?? camera.transform.y
-  const cz = cameraAnim?.z ?? camera.transform.z
-  const rX = cameraAnim?.rotationX ?? camera.transform.rotationX
-  const rY = cameraAnim?.rotationY ?? camera.transform.rotationY
-  const rZ = cameraAnim?.rotation ?? camera.transform.rotation
-  const cameraOrigin: Vec3 = { x: cx, y: cy, z: -focalLength + cz }
-  const cameraSpace = inverseRotateEuler(sub3(point, cameraOrigin), rX, rY, rZ)
-  const denom = Math.max(1, cameraSpace.z)
-  const scale = focalLength / denom
-  return {
-    x: canvasWidth / 2 + cameraSpace.x * scale,
-    y: canvasHeight / 2 + cameraSpace.y * scale,
-  }
+  const viewport = { width: canvasWidth, height: canvasHeight }
+  return projectWorldPoint(
+    point,
+    resolveCamera3D(camera, cameraAnim, viewport),
+    viewport,
+  )
 }
 
 export function resolveCameraFocusTargetPoint(
@@ -973,58 +942,21 @@ export function Canvas() {
   // Apparent scale uses a textbook pinhole model:
   //   apparentScale = focalLength / (focalLength - z)
   //
-  // Focal length now lives on the camera node so users can dial it
-  // per-scene. Default 1000 matches the historical hardcoded value.
-  // Larger = more telephoto (subtler rotations, less Z-driven scale).
-  // Smaller = wide-angle (dramatic rotations, big Z scale).
-  const cameraFocalLength =
-    camera && camera.kind === 'camera'
-      ? Math.max(50, camera.focalLength ?? 1000)
-      : 1000
-  const cameraZ =
-    camera && camera.kind === 'camera'
-      ? liveCameraAnim?.z ?? camera.transform.z
-      : 0
-  const cameraDollyZ = cameraZ / 100
-  // Clamp the denominator so an animation through z = focal length
-  // (singularity) doesn't blow the scale up to infinity.
-  const cameraScaleFromZ = useMemo(() => {
-    const denom = Math.max(1, cameraFocalLength - cameraDollyZ)
-    return cameraFocalLength / denom
-  }, [cameraDollyZ, cameraFocalLength])
-
-  const cameraTransform = useMemo(() => {
-    if (!camera || camera.kind !== 'camera') return null
-    const cx = liveCameraAnim?.x ?? camera.transform.x
-    const cy = liveCameraAnim?.y ?? camera.transform.y
-    const rX =
-      liveCameraAnim?.rotationX ?? camera.transform.rotationX
-    const rY =
-      liveCameraAnim?.rotationY ?? camera.transform.rotationY
-    const rZ =
-      liveCameraAnim?.rotation ?? camera.transform.rotation
-    const s = cameraScaleFromZ
-    const w = canvasWidth
-    const h = canvasHeight
-    // Keep the editor preview faithful to the actual design DOM/Yoga
-    // renderer. WebGL remains the long-term 3D compositor, but until its
-    // texture pipeline can rasterize full design fidelity, the visible
-    // camera view should use the real DOM tree and CSS 3D camera tilt.
-    return (
-      `translate(${w / 2}px, ${h / 2}px) ` +
-      `scale(${s}, ${s}) ` +
-      `rotateX(${-rX}deg) ` +
-      `rotateY(${rY}deg) ` +
-      `rotateZ(${-rZ}deg) ` +
-      `translate(${-cx}px, ${-cy}px)`
-    )
-  }, [
-    camera,
-    liveCameraAnim,
-    cameraScaleFromZ,
-    canvasWidth,
-    canvasHeight,
-  ])
+  // Text editing reveals the DOM scene while the WebGL scene stays mounted.
+  // Resolve both renderers from the same FOV and direct-Z projection so that
+  // entering contenteditable never looks like a lens or camera jump.
+  const cameraDomProjection = useMemo(
+    () =>
+      resolveCameraDomProjection(
+        camera && camera.kind === 'camera' ? camera : null,
+        liveCameraAnim,
+        { width: canvasWidth, height: canvasHeight },
+      ),
+    [camera, liveCameraAnim, canvasWidth, canvasHeight],
+  )
+  const cameraFocalLength = cameraDomProjection.focalLength
+  const cameraScaleFromZ = cameraDomProjection.scale
+  const cameraTransform = cameraDomProjection.transform
   const cameraSceneContentStyle = useMemo<CSSProperties | undefined>(
     () =>
       cameraTransform
@@ -1609,40 +1541,6 @@ export function Canvas() {
         e.stopPropagation()
         return
       }
-      if (
-        !focusPickingCameraId &&
-        tool === 'select' &&
-        !e.metaKey &&
-        !e.ctrlKey &&
-        camera &&
-        camera.kind === 'camera' &&
-        selection.includes(camera.id)
-      ) {
-        const target = e.target as HTMLElement
-        if (target.closest('[data-export-hide="1"]')) return
-        const startTransform = displayedCameraTransform(camera)
-        cameraControlRef.current = {
-          pointerId: e.pointerId,
-          cameraId: camera.id,
-          mode: e.shiftKey ? 'pan' : 'rotate',
-          startX: e.clientX,
-          startY: e.clientY,
-          transform: startTransform,
-          latestTransform: startTransform,
-          startPlayhead: currentAnimationAuthorTime(),
-          startPerfTime: performance.now(),
-          lastSampleTime: currentAnimationAuthorTime(),
-          didStampStart: false,
-          moved: false,
-          samples: [],
-        }
-        cameraPreviewStore.set(camera.id, cameraTransformPreview(startTransform))
-        setIsCameraManipulating(true)
-        ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
-        e.preventDefault()
-        e.stopPropagation()
-        return
-      }
       if (!focusPickingCameraId) return
       const point = clientToViewport(e.clientX, e.clientY)
       const canvasPoint = clientToCanvas(e.clientX, e.clientY)
@@ -1683,17 +1581,11 @@ export function Canvas() {
       api,
       clientToViewport,
       clientToCanvas,
-      solved,
       focusPickingCameraId,
       setFocusPickingCameraId,
       setSelection,
       stampCanvasCameraPatch,
-      currentAnimationAuthorTime,
-      camera,
-      displayedCameraTransform,
-      selection,
       spacePanning,
-      tool,
       view.panX,
       view.panY,
     ],
@@ -2001,6 +1893,33 @@ export function Canvas() {
             e.preventDefault()
 	            return
 	          }
+	          // A flattened camera plane can miss a nested text node even
+	          // though the independent-node hit test used by double-click
+	          // finds it. When the camera itself is selected, check for that
+	          // content before arming a camera drag; otherwise the first press
+	          // can rotate the camera and the second press enters text editing.
+	          if (
+	            !directSelect &&
+	            camera &&
+	            camera.kind === 'camera' &&
+	            selection.includes(camera.id)
+	          ) {
+	            const contentHit = hitTestCanvas3D(
+	              e.clientX,
+	              e.clientY,
+	              true,
+	            )
+	            if (contentHit) {
+	              if (e.shiftKey) {
+	                useUI.getState().toggleInSelection(contentHit.nodeId, true)
+	              } else {
+	                setSelection([contentHit.nodeId])
+	              }
+	              e.preventDefault()
+	              e.stopPropagation()
+	              return
+	            }
+	          }
 	        }
 	        if (
 	          tool === 'select' &&
@@ -2104,7 +2023,10 @@ export function Canvas() {
 	        if (!current || current.kind !== 'camera') return
 	        const dx = e.clientX - cameraControl.startX
 	        const dy = e.clientY - cameraControl.startY
-	        if (!cameraControl.moved && Math.hypot(dx, dy) < 2) return
+	        if (
+	          !cameraControl.moved &&
+	          Math.hypot(dx, dy) < CAMERA_CONTROL_DRAG_THRESHOLD_PX
+	        ) return
 	        cameraControl.moved = true
 	        let nextTransform: CameraNode['transform']
 	        if (cameraControl.mode === 'rotate') {
@@ -2455,42 +2377,63 @@ export function Canvas() {
     cameraCommitTimer: null as number | null,
   })
 
+  const flushPendingCameraWheel = useCallback(() => {
+    const pending = pendingWheelRef.current
+    const cameraId = pending.cameraId
+    const cameraZ = pending.cameraZ
+    if (pending.cameraCommitTimer !== null) {
+      window.clearTimeout(pending.cameraCommitTimer)
+      pending.cameraCommitTimer = null
+    }
+    if (!cameraId || cameraZ === null) return
+    const authorTime =
+      pending.cameraAuthorTime ?? currentAnimationAuthorTime()
+    pending.cameraId = null
+    pending.cameraZ = null
+    pending.cameraAuthorTime = null
+    const current = api.getNode(cameraId)
+    if (!current || current.kind !== 'camera') {
+      cameraPreviewStore.clear(cameraId)
+      return
+    }
+    // A trackpad dolly can emit dozens of packets. Keep those packets in
+    // the shared rAF preview and author one scene/track mutation after the
+    // gesture goes idle, just like pointer-based camera movement.
+    api.doc.transact(() => {
+      api.setNodeProperty(current.id, 'transform', {
+        ...current.transform,
+        z: cameraZ,
+      })
+      stampCanvasTransformPatch(current.id, { z: cameraZ }, authorTime)
+    })
+    // Keep the final transient Z for one paint while the scene update and
+    // newly-authored track reach the WebGL leaf. Clearing synchronously can
+    // reveal its previous engine snapshot for one frame and looks like the
+    // zoom jumped backwards at the end of every wheel burst.
+    cameraPreviewStore.finish(cameraId)
+  }, [api, currentAnimationAuthorTime, stampCanvasTransformPatch])
+
+  useEffect(() => {
+    if (!editingTextId) return
+    const pending = pendingWheelRef.current
+    if (wheelFrameRef.current !== null) {
+      cancelAnimationFrame(wheelFrameRef.current)
+      wheelFrameRef.current = null
+    }
+    // Preserve the exact camera pose visible before contenteditable takes
+    // over. Dropping this pending preview made entering edit mode look like
+    // a sudden FOV/dolly change.
+    flushPendingCameraWheel()
+    pending.zoomDeltaY = 0
+    pending.panDeltaX = 0
+    pending.panDeltaY = 0
+  }, [editingTextId, flushPendingCameraWheel])
+
   // --- wheel: cmd/ctrl + wheel = zoom, otherwise pan -------------------
   useEffect(() => {
     const el = workspaceRef.current
     if (!el) return
     const pendingWheel = pendingWheelRef.current
-    const commitCameraWheel = () => {
-      const cameraId = pendingWheel.cameraId
-      const cameraZ = pendingWheel.cameraZ
-      if (!cameraId || cameraZ === null) return
-      const authorTime =
-        pendingWheel.cameraAuthorTime ?? currentAnimationAuthorTime()
-      pendingWheel.cameraId = null
-      pendingWheel.cameraZ = null
-      pendingWheel.cameraAuthorTime = null
-      pendingWheel.cameraCommitTimer = null
-      const current = api.getNode(cameraId)
-      if (!current || current.kind !== 'camera') {
-        cameraPreviewStore.clear(cameraId)
-        return
-      }
-      // A trackpad dolly can emit dozens of packets. Keep those packets in
-      // the shared rAF preview and author one scene/track mutation after the
-      // gesture goes idle, just like pointer-based camera movement.
-      api.doc.transact(() => {
-        api.setNodeProperty(current.id, 'transform', {
-          ...current.transform,
-          z: cameraZ,
-        })
-        stampCanvasTransformPatch(current.id, { z: cameraZ }, authorTime)
-      })
-      // Keep the final transient Z for one paint while the scene update and
-      // newly-authored track reach the WebGL leaf. Clearing synchronously can
-      // reveal its previous engine snapshot for one frame and looks like the
-      // zoom jumped backwards at the end of every wheel burst.
-      cameraPreviewStore.finish(cameraId)
-    }
     const scheduleViewCommit = () => {
       if (wheelFrameRef.current !== null) return
       wheelFrameRef.current = requestAnimationFrame(() => {
@@ -2527,6 +2470,14 @@ export function Canvas() {
     }
     const onWheel = (e: WheelEvent) => {
       if (!el.contains(e.target as Node)) return
+      const target = e.target as HTMLElement | null
+      if (
+        editingTextId ||
+        target?.isContentEditable ||
+        target?.closest('input, textarea, select, [contenteditable="true"]')
+      ) {
+        return
+      }
       e.preventDefault()
       const deltaScale =
         e.deltaMode === 1
@@ -2598,7 +2549,7 @@ export function Canvas() {
           window.clearTimeout(pendingWheel.cameraCommitTimer)
         }
         pendingWheel.cameraCommitTimer = window.setTimeout(
-          commitCameraWheel,
+          flushPendingCameraWheel,
           180,
         )
       } else {
@@ -2617,11 +2568,7 @@ export function Canvas() {
         cancelAnimationFrame(wheelFrameRef.current)
         wheelFrameRef.current = null
       }
-      if (pendingWheel.cameraCommitTimer !== null) {
-        window.clearTimeout(pendingWheel.cameraCommitTimer)
-        pendingWheel.cameraCommitTimer = null
-      }
-      commitCameraWheel()
+      flushPendingCameraWheel()
       pendingWheel.zoomDeltaY = 0
       pendingWheel.panDeltaX = 0
       pendingWheel.panDeltaY = 0
@@ -2632,6 +2579,8 @@ export function Canvas() {
     canvasHeight,
     canvasWidth,
     currentAnimationAuthorTime,
+    editingTextId,
+    flushPendingCameraWheel,
     selection,
     stampCanvasTransformPatch,
     tool,
@@ -2908,7 +2857,10 @@ export function Canvas() {
               {camera && camera.kind === 'camera' ? (
                 <>
                   {textEditPresentation.showDomScene ? (
-                    <div className="absolute inset-0 z-[1]">
+                    <div
+                      className="absolute inset-0 z-[1]"
+                      style={{ transformStyle: 'preserve-3d' }}
+                    >
                       <ScenePostProcessLayer
                         rootId={rootId}
                         solved={solved}
@@ -3092,6 +3044,8 @@ export function Canvas() {
             width: canvasWidth,
             height: canvasHeight,
             borderRadius: Math.max(0, sceneCorner),
+            perspective: cameraFocalLength,
+            perspectiveOrigin: 'center center',
           }}
         >
           {/* Camera viewfinder gizmo. Drawn OUTSIDE the camera-transform
@@ -3919,12 +3873,14 @@ const AnimatedCameraFocusMaskOverlay = memo(
     onHandlePointerCancel: (e: React.PointerEvent<HTMLElement>) => void
   }) {
     const { cameraAnim } = useLiveCameraAnimatedValue(camera.id)
-    const cameraScale = useMemo(() => {
-      const focalLength = Math.max(50, camera.focalLength ?? 1000)
-      const cameraDollyZ =
-        (cameraAnim?.z ?? camera.transform.z) / 100
-      return focalLength / Math.max(1, focalLength - cameraDollyZ)
-    }, [camera, cameraAnim?.z])
+    const cameraScale = useMemo(
+      () =>
+        resolveCameraDomProjection(camera, cameraAnim, {
+          width: canvasWidth,
+          height: canvasHeight,
+        }).scale,
+      [camera, cameraAnim, canvasWidth, canvasHeight],
+    )
     const depthOfField = useMemo(
       () =>
         computeCameraDepthOfField(


### PR DESCRIPTION
## What changed

- Keep DOM text editing aligned with the exact WebGL camera projection across FOV, dolly, XYZ position, tilt, yaw, roll, and layer depth.
- Preserve pending camera wheel state before entering text edit mode.
- Prevent text clicks from accidentally arming camera movement.
- Keep Shift-click selection behavior consistent for nested layers.

## Why

Double-clicking text could switch from the WebGL scene to a flattened DOM plane, visually changing the camera and sometimes mutating camera controls before editing began.

## Impact

Text can now be entered without a camera jump or field-of-view change, including under animated and angled cameras.

## Validation

- `pnpm test:canvas` — 43 files, 310 tests passed.
- `pnpm build:figma-plugin && pnpm exec vite build` — passed.
- Live reproduction verified on the reported scene with camera state unchanged before and after text entry.