### PR TITLE
Prepare v0.1.18 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Plus everything you expect from a Jitter-class tool: a real timeline,
 in/out presets, easing curves, 3D camera with depth-of-field, and MP4 /
 WebM / GIF export.
 
-## Status — v0.1.17 research preview
+## Status — v0.1.18 research preview
 
 The semantic-layout-animation bet works end-to-end, with desktop
 editing, Figma import, pixel-correct export, and CLI / MCP workflows for
@@ -34,7 +34,7 @@ copies the app into `/Applications`, strips macOS's download quarantine,
 applies a local ad-hoc signature, and opens it. No drag-to-Applications,
 no "damaged" dialog, no per-version steps.
 
-For a specific version: `curl ... | bash -s -- v0.1.17`.
+For a specific version: `curl ... | bash -s -- v0.1.18`.
 
 ### Manual install
 
@@ -93,7 +93,14 @@ Direct point editing remains a follow-up. Contributor source lives in
 Full step-by-step at [hypermotion.app/docs#figma-plugin](https://hypermotion.app/docs#figma-plugin).
 Figma Community publish (one-click install) is on the v0.2 roadmap.
 
-## What's in v0.1.17
+## What's in v0.1.18
+
+- **Camera-stable text editing.** Double-clicking text now preserves the exact
+  camera view across FOV, dolly, XYZ movement, tilt, yaw, roll, layer depth,
+  and animated camera values instead of jumping or changing the lens view.
+- **Safer canvas interaction.** Pending trackpad camera movement is committed
+  before text editing begins, and text clicks no longer accidentally arm a
+  camera drag.
 
 - **Direct Figma plugin download.** The setup modal now leads with the release
   ZIP and the standard three-step Figma manifest import flow.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,28 @@
 Human-friendly release notes. The GitHub Releases page mirrors the matching
 entry below for each corresponding tag.
 
+## v0.1.18 — Camera-stable text editing (2026-07-21)
+
+Text editing now stays visually locked to the active camera, so entering text
+does not change the field of view, zoom, angle, or animated camera state.
+
+### Camera-stable text editing
+
+- Match the editable DOM scene to the WebGL camera across FOV, dolly, XYZ
+  movement, tilt, yaw, roll, layer depth, and animated camera values.
+- Commit pending trackpad camera movement before text editing begins instead of
+  dropping the visible camera preview.
+- Prevent text clicks from accidentally arming camera movement before a
+  double-click enters editing.
+- Preserve Shift-click selection behavior for nested layers.
+
+### Install on macOS
+
+Download the Apple Silicon or Intel DMG from this release, or use the one-line
+installer in the [installation guide](https://hypermotion.app/docs#install).
+The v0.1.x builds remain unsigned and macOS-only, so macOS may require the
+first-time setup described in that guide.
+
 ## v0.1.17 — Editor and Figma setup maintenance (2026-07-21)
 
 This maintenance release keeps the current editor and Figma setup aligned with

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 #
 # Or for a specific version:
 #
-#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.17
+#   curl -fsSL https://raw.githubusercontent.com/psiddharthdesign/hypermotion/main/install.sh | bash -s -- v0.1.18
 #
 # Works for every future release without changes — the script always
 # resolves the latest tag from the GitHub API unless you pass one.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyper-motion-electron",
   "private": true,
-  "version": "0.1.17",
+  "version": "0.1.18",
   "type": "module",
   "main": "dist-electron/main.cjs",
   "description": "Native motion design tool with Figma-style structural layout. Auto-layout, 3D camera, semantic keyframes, pixel-correct MP4 / WebM / GIF.",


### PR DESCRIPTION
## What changed

- Bump the desktop app release version to v0.1.18.
- Add curated camera-stable text editing release notes.
- Update README status and pinned installer example.
- Keep the required macOS installation guidance and release artifacts workflow.

## Validation

- `pnpm test:canvas` — 43 files, 310 tests passed.
- `pnpm --dir cli test` — 461 tests passed.
- `pnpm test:figma-plugin-shell` — 3 tests passed.
- Figma plugin and Electron type checks passed.
- `pnpm build:dir` packaged Hyper Motion 0.1.18 with the bundled Figma plugin.
- Installer syntax and diff checks passed.