### PR TITLE
feat(editor): add timeline-driven Paper shaders and camera controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,8 +325,38 @@ A single-frame artboard with a title:
 | `ellipse`   | `size`                                                                             |
 | `text`      | `text`, `fontFamily`, `fontSize` (default Inter / 16 / weight 400)                 |
 | `image`     | `src` (data URL or absolute path), `size`, `fit`                                   |
+| `shader`    | `size`, `shaderType`, `colors`, `speed`, `scale`, `params`; optional `sourceNodeId` / `sourceImage`; legacy Mesh Gradient `distortion`, `swirl`, `grain` |
 | `camera`    | `transform` (one scene-level camera only; `parent: null`, referenced by `activeCameraId`) |
 | `video` / `audio` | `src`, `duration`, `volume` — for sequences with media; rarely used by agents |
+
+Shader nodes use the pinned Apache-2.0 Paper Shaders runtime. Supported
+`shaderType` ids are:
+
+```
+mesh-gradient, smoke-ring, neuro-noise, dot-orbit, dot-grid,
+simplex-noise, metaballs, waves, perlin-noise, voronoi, warp, god-rays,
+spiral, swirl, dithering, grain-gradient, pulsing-border, color-panels,
+static-mesh-gradient, static-radial-gradient, paper-texture, fluted-glass,
+water, image-dithering, halftone-dots, halftone-cmyk, heatmap,
+liquid-metal, gem-smoke
+```
+
+Put shader-specific Paper props in the JSON-serializable `params` object.
+Common `colors`, `speed`, and `scale` fields stay at the node level.
+Animation is driven by the scene playhead rather than wall-clock time, so
+preview, seeks, and frame-by-frame exports stay deterministic. `speed: 0`
+freezes the shader; `speed: 1` advances at normal timeline speed. Keep
+`speed` in `0..2` and `scale` in `0.1..4`. Colors use `#RGB`, `#RRGGBB`,
+or `#RRGGBBAA`; individual shader color-count limits are applied.
+
+Image-consuming shaders can use `sourceNodeId` to sample another scene layer
+or `sourceImage` for a data URL, URL, or absolute path. Fluted Glass, Image
+Dithering, Halftone Dots, Halftone CMYK, and Heatmap require a source. Paper
+Texture, Water, Liquid Metal, and Gem Smoke accept a source optionally.
+
+Older Mesh Gradient scenes remain compatible. Their top-level `distortion`,
+`swirl`, and `grain` fields are still supported and stay in `0..1`; `grain`
+maps to Paper's `grainOverlay`.
 
 Use Lucide or Phosphor assets for UI icons. Prefer placing them as
 image/vector assets inside auto-layout frames, sized consistently with
@@ -403,6 +433,8 @@ camera.aperture, camera.fStop, camera.bladeCount, camera.bladeRotation,
 camera.bokehRatio, camera.iso, camera.blurLevel, camera.blurQuality,
 camera.chromaticAberrationAmount, camera.chromaticAberrationAngle,
 camera.bloomStrength, camera.bloomRadius, camera.bloomThreshold,
+camera.vhsIntensity, camera.vhsNoise, camera.vhsScanlines,
+camera.vhsColorBleed,
 appearance.opacity, appearance.cornerRadius, appearance.cornerRadii,
 appearance.cornerRadii.tl, appearance.cornerRadii.tr,
 appearance.cornerRadii.br, appearance.cornerRadii.bl, appearance.fill,
@@ -422,7 +454,11 @@ green channel; `chromaticAberrationAmount` is each channel's offset in
 composition pixels (0-64) and `chromaticAberrationAngle` sets its direction in
 degrees. Set `bloomEnabled: true` to glow bright pixels, then tune
 `bloomStrength` (0-4), `bloomRadius` (0-1), and `bloomThreshold` (0-1). The five
-numeric fields are keyframeable; the enable flags are static scene settings.
+numeric fields are keyframeable. Set `vhsEnabled: true` for an analog tape
+treatment driven deterministically by scene time, then tune `vhsIntensity`,
+`vhsNoise`, and `vhsScanlines` (each 0-1), plus `vhsColorBleed` in composition
+pixels (0-32). All nine numeric fields are keyframeable; the enable flags are
+static scene settings.
 
 EasingKind: `'linear' | 'ease-in' | 'ease-out' | 'ease-in-out' | { bezier: [x1, y1, x2, y2] } | { spring: { stiffness, damping, mass } }`.
 

--- a/NOTICE
+++ b/NOTICE
@@ -17,6 +17,7 @@ node_modules/<package>/ after `pnpm install`.
 
 Runtime dependencies:
   - React, React-DOM (MIT)              https://github.com/facebook/react
+  - Paper Shaders (Apache-2.0)          https://github.com/paper-design/shaders
   - Yjs (MIT)                           https://github.com/yjs/yjs
   - y-indexeddb (MIT)                   https://github.com/yjs/y-indexeddb
   - Yoga Layout (MIT)                   https://github.com/facebook/yoga
@@ -48,3 +49,11 @@ versions is maintained in pnpm-lock.yaml.
 The Apache 2.0 license requires that any redistribution of this work
 (or derivative works) preserve the LICENSE and NOTICE files. See
 §4(a)–(d) of LICENSE for the full conditions.
+
+---
+
+Paper Shaders
+Copyright 2026 Paper
+
+Powered by Paper Shaders:
+https://shaders.paper.design

--- a/cli/src/mcp/createScene.test.ts
+++ b/cli/src/mcp/createScene.test.ts
@@ -81,6 +81,10 @@ test('create_scene description lists supported camera property ids', () => {
     'camera.bloomStrength',
     'camera.bloomRadius',
     'camera.bloomThreshold',
+    'camera.vhsIntensity',
+    'camera.vhsNoise',
+    'camera.vhsScanlines',
+    'camera.vhsColorBleed',
   ]) {
     const escapedPropertyId = propertyId.replaceAll('.', '\\.')
     assert.match(description, new RegExp(`${escapedPropertyId}(?:,|\\.)`))
@@ -141,6 +145,43 @@ test('create_scene description lists supported layout property ids', () => {
     const escapedPropertyId = propertyId.replaceAll('.', '\\.')
     assert.match(description, new RegExp(`${escapedPropertyId}(?:,|\\.)`))
   }
+})
+
+test('create_scene description documents all Paper shader nodes', () => {
+  const description = createSceneTool.description
+  if (typeof description !== 'string') {
+    throw new Error('create_scene description is missing')
+  }
+
+  assert.match(description, /'shader'/)
+  assert.match(description, /all 29 Paper Shaders/)
+  for (const field of [
+    'shaderType',
+    'colors',
+    'params',
+    'sourceNodeId',
+    'sourceImage',
+    'speed',
+    'scale',
+    'distortion',
+    'swirl',
+    'grain',
+  ]) {
+    assert.match(description, new RegExp(field))
+  }
+  for (const shaderType of [
+    'mesh-gradient',
+    'paper-texture',
+    'halftone-cmyk',
+    'liquid-metal',
+    'gem-smoke',
+  ]) {
+    assert.match(description, new RegExp(shaderType))
+  }
+  assert.match(description, /require a source/)
+  assert.match(description, /size 640x360/)
+  assert.match(description, /Shader parameters are static node fields/)
+  assert.doesNotMatch(description, /primitive3d/i)
 })
 
 test('create_scene description mentions text animation track fields', () => {

--- a/cli/src/mcp/tools/createScene.ts
+++ b/cli/src/mcp/tools/createScene.ts
@@ -28,6 +28,7 @@ import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import fs from 'node:fs'
 import path from 'node:path'
 import {
+  PAPER_SHADER_TYPES,
   PROPERTY_IDS,
   buildSceneBytes,
   readSceneSummary,
@@ -93,7 +94,7 @@ export const createSceneTool: Tool = {
     "tracks with keyframes), passes it here, and gets a .hype file the desktop app " +
     "can open. Use this BEFORE render_scene when the scene doesn't already exist.\n\n" +
     "SceneJson shape (top level): { meta?, root?, activeCameraId?, nodes, tracks?, sections? }\n" +
-    "Each node: { id, kind: 'frame'|'rect'|'ellipse'|'text'|'image'|'video'|'audio'|'component'|'instance'|'camera', " +
+    "Each node: { id, kind: 'frame'|'rect'|'ellipse'|'text'|'image'|'shader'|'video'|'audio'|'component'|'instance'|'camera', " +
     "parent: id|null, children?: id[], transform?, appearance?, size?, layout?, ...kind-specific }\n" +
     "Design scenes with auto-layout by default from the first frame onward. Prefer layout.mode: 'flex' for rows/columns " +
     "and layout.mode: 'grid' for grids; use fixed transforms or layout.mode: 'none' only when the user explicitly asks " +
@@ -107,12 +108,22 @@ export const createSceneTool: Tool = {
     "Components can define variants, defaultSelection, variantOverrides, timelines, and interactions. " +
     "Instances point at componentId and carry selection, overrides, and instance-local interaction additions. " +
     "Component timelines are local tracks triggered by interactions, e.g. onClick -> playTimeline, and are scoped per instance.\n" +
+    `Shader nodes support all 29 Paper Shaders. shaderType is one of: ${PAPER_SHADER_TYPES.join(', ')}. ` +
+    "Use colors for a shader's color array, speed in 0..2, scale in 0.1..4, and params for shader-specific JSON-serializable Paper props. " +
+    "Image-consuming shaders accept sourceNodeId (another scene layer) or sourceImage (a data URL, URL, or absolute path). " +
+    "Fluted Glass, Image Dithering, Halftone Dots, Halftone CMYK, and Heatmap require a source; Paper Texture, Water, Liquid Metal, and Gem Smoke accept one optionally. " +
+    "Mesh Gradient remains backward-compatible with top-level distortion, swirl, and grain (Paper's grainOverlay), each in 0..1. " +
+    "Its omitted values default to size 640x360, colors ['#e0eaff','#241d9a','#f75092','#9f50d3'], speed 0.6, scale 1, distortion 0.8, swirl 0.1, and grain 0.08. " +
+    "Shader parameters are static node fields; " +
+    "size, transform, and appearance properties remain animatable through ordinary tracks.\n" +
     "Tracks: { id, nodeId, propertyId, keyframes?: [{ id, time, value, easingOut?, easingPreset?: { presetId, strength } }], defaultEasing?, textAnimation? } — omitted keyframes default to [].\n" +
     "Text animation tracks can include textAnimation with mode, applyTo ('layer'|'letters'|'words'|'lines'), order, delay, smoothing ('none'|'soft'|'smooth' blends neighbouring profile samples), optional staggerCurve ({ version: 1, points: [{ id, x, y, inX, inY, outX, outY }] } defining a monotonic initial-to-final trail profile sampled by every segment as it travels across text), duration, startTime, acceleration, easingPresetId, easingStrength, direction, travelDistance, optional motionVector ({ x, y, z } per segment in line-height multiples; +X right, +Y down, +Z toward the viewer; null or omitted uses direction/travelDistance), optional motionPath ({ version: 1, points: [{ id, t, x, y, z, inX, inY, inZ, outX, outY, outZ }] } defining an editable cubic spatial route in line-height units; t=0 is the settled origin, t=1 is the authored start, +X right, +Y down, +Z toward the viewer; motionPath takes precedence over motionVector), and blurRadius.\n" +
     "Camera nodes can include focalLength, scrollSensitivity (0.1-2, default 1), fieldOfView, pointOfInterestX/Y/Z, nearClip, farClip, " +
     "depthOfField, focusMode, focusWorldX/Y/Z, focusTargetNodeId, focusDistance, focusRadius, focusFalloff, aperture (legacy strength), " +
     "fStop (default 2.8; lower values create more blur), bladeCount (3-16), bladeRotation, bokehRatio (0.25-4), " +
-    "dofPreviewQuality ('draft'|'balanced'|'high'), iso, blurLevel, blurQuality (24-48 effective final export samples; default/minimum 24), and showFocusPlane. " +
+    "dofPreviewQuality ('draft'|'balanced'|'high'), iso, blurLevel, blurQuality (24-48 effective final export samples; default/minimum 24), " +
+    "chromaticAberrationEnabled/Amount/Angle, bloomEnabled/Strength/Radius/Threshold, " +
+    "vhsEnabled, vhsIntensity, vhsNoise, vhsScanlines, vhsColorBleed, and showFocusPlane. " +
     "Hyper Motion currently supports only one camera node per scene; " +
     "keep it scene-level with parent: null, set activeCameraId to that camera id, do not list it in any frame/artboard children, " +
     "and default focalLength to 1000 unless the user explicitly requests a different camera/lens feel.\n" +

--- a/cli/src/scene/build.test.ts
+++ b/cli/src/scene/build.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import * as Y from 'yjs'
 import {
+  PAPER_SHADER_TYPES,
   applyScenePatch,
   buildSceneBytes,
   readSceneSummary,
@@ -584,6 +585,155 @@ test('buildSceneBytes preserves image fit none', () => {
   assert.equal(nodes.image.fit, 'none')
 })
 
+test('buildSceneBytes preserves explicit Mesh Gradient shader fields', () => {
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  if (!root) throw new Error('missing sample root')
+  root.children = [...(root.children ?? []), 'gradient']
+  scene.nodes = {
+    ...scene.nodes,
+    gradient: {
+      id: 'gradient',
+      kind: 'shader',
+      parent: 'root',
+      size: { width: 800, height: 450 },
+      shaderType: 'mesh-gradient',
+      colors: ['#001122', '#aabbcc', '#ff00aa'],
+      speed: 1.2,
+      scale: 1.5,
+      distortion: 0.35,
+      swirl: 0.4,
+      grain: 0.22,
+    },
+  }
+
+  const data = inspectScene(buildSceneBytes(scene))
+  const nodes = data.nodes as PlainSceneMap
+
+  assert.deepEqual(nodes.gradient.size, { width: 800, height: 450 })
+  assert.equal(nodes.gradient.shaderType, 'mesh-gradient')
+  assert.deepEqual(nodes.gradient.colors, ['#001122', '#aabbcc', '#ff00aa'])
+  assert.equal(nodes.gradient.speed, 1.2)
+  assert.equal(nodes.gradient.scale, 1.5)
+  assert.equal(nodes.gradient.distortion, 0.35)
+  assert.equal(nodes.gradient.swirl, 0.4)
+  assert.equal(nodes.gradient.grain, 0.22)
+  assert.equal(validateScene(buildSceneBytes(scene)).ok, true)
+})
+
+test('buildSceneBytes supports all 29 Paper shader ids and generic params', () => {
+  assert.equal(PAPER_SHADER_TYPES.length, 29)
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  if (!root || !scene.nodes) throw new Error('missing sample root')
+  const requiredSourceTypes = new Set([
+    'fluted-glass',
+    'image-dithering',
+    'halftone-dots',
+    'halftone-cmyk',
+    'heatmap',
+  ])
+
+  for (const shaderType of PAPER_SHADER_TYPES) {
+    const id = `shader-${shaderType}`
+    root.children = [...(root.children ?? []), id]
+    scene.nodes[id] = {
+      id,
+      kind: 'shader',
+      parent: 'root',
+      shaderType,
+      params: { intensity: 0.4, nested: { enabled: true } },
+      ...(requiredSourceTypes.has(shaderType)
+        ? { sourceImage: 'data:image/png;base64,AA==' }
+        : {}),
+    }
+  }
+
+  const bytes = buildSceneBytes(scene)
+  const result = validateScene(bytes)
+  const data = inspectScene(bytes)
+  const nodes = data.nodes as PlainSceneMap
+
+  assert.deepEqual(result.errors, [])
+  for (const shaderType of PAPER_SHADER_TYPES) {
+    const node = nodes[`shader-${shaderType}`]
+    assert.equal(node.shaderType, shaderType)
+    assert.deepEqual(node.params, {
+      intensity: 0.4,
+      nested: { enabled: true },
+    })
+    assert.equal(typeof node.name, 'string')
+  }
+})
+
+test('buildSceneBytes preserves shader source layer and image fields', () => {
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  if (!root || !scene.nodes) throw new Error('missing sample root')
+  root.children = [...(root.children ?? []), 'source', 'glass']
+  scene.nodes.source = {
+    id: 'source',
+    kind: 'image',
+    parent: 'root',
+    src: '/tmp/source.png',
+  }
+  scene.nodes.glass = {
+    id: 'glass',
+    kind: 'shader',
+    parent: 'root',
+    shaderType: 'fluted-glass',
+    sourceNodeId: 'source',
+    sourceImage: '/tmp/fallback.png',
+  }
+
+  const bytes = buildSceneBytes(scene)
+  const nodes = inspectScene(bytes).nodes as PlainSceneMap
+
+  assert.equal(nodes.glass.sourceNodeId, 'source')
+  assert.equal(nodes.glass.sourceImage, '/tmp/fallback.png')
+  assert.equal(validateScene(bytes).ok, true)
+})
+
+test('authoring rejects retired primitive3d nodes at runtime', () => {
+  const retiredNode = {
+    id: 'legacy-mesh',
+    kind: 'primitive3d',
+    parent: 'root',
+  }
+  const scene = sampleScene()
+  if (!scene.nodes) throw new Error('missing sample nodes')
+  scene.nodes[retiredNode.id] = retiredNode as never
+
+  assert.throws(
+    () => buildSceneBytes(scene),
+    /node legacy-mesh has unsupported kind: primitive3d/,
+  )
+
+  const bytes = buildSceneBytes(sampleScene())
+  assert.throws(
+    () =>
+      applyScenePatch(bytes, [
+        {
+          op: 'createNode',
+          node: retiredNode,
+        } as never,
+      ]),
+    /node legacy-mesh has unsupported kind: primitive3d/,
+  )
+  assert.throws(
+    () =>
+      applyScenePatch(bytes, [
+        {
+          op: 'setNodeProperty',
+          nodeId: 'title',
+          key: 'kind',
+          value: 'primitive3d',
+        },
+      ]),
+    /node title has unsupported kind: primitive3d/,
+  )
+})
+
 test('buildSceneBytes writes text defaults expected by the desktop app', () => {
   const scene = sampleScene()
   scene.nodes = {
@@ -877,6 +1027,76 @@ test('applyScenePatch fills image defaults for created nodes', () => {
   assert.deepEqual(nodes.thumbnail.size, { width: 100, height: 100 })
   assert.equal(nodes.thumbnail.src, '')
   assert.equal(nodes.thumbnail.fit, 'cover')
+})
+
+test('applyScenePatch fills shader defaults and accepts shader property edits', () => {
+  const bytes = buildSceneBytes(sampleScene())
+  const patched = applyScenePatch(bytes, [
+    {
+      op: 'createNode',
+      node: {
+        id: 'gradient',
+        kind: 'shader',
+        parent: 'root',
+      },
+    },
+    {
+      op: 'setNodeProperty',
+      nodeId: 'gradient',
+      key: 'grain',
+      value: 0.2,
+    },
+  ])
+  const data = inspectScene(patched)
+  const nodes = data.nodes as PlainSceneMap
+
+  assert.deepEqual(nodes.gradient, {
+    id: 'gradient',
+    kind: 'shader',
+    name: 'Mesh Gradient',
+    parent: 'root',
+    children: [],
+    transform: {
+      x: 0,
+      y: 0,
+      z: 0,
+      rotation: 0,
+      rotationX: 0,
+      rotationY: 0,
+      scaleX: 1,
+      scaleY: 1,
+      anchorX: 0.5,
+      anchorY: 0.5,
+      anchorZ: 0,
+      space: 'local',
+      renderMode: 'flat',
+    },
+    appearance: {
+      opacity: 1,
+      fill: null,
+      stroke: null,
+      cornerRadius: 0,
+      blendMode: 'normal',
+      effects: [],
+    },
+    visible: true,
+    locked: false,
+    position: 'flow',
+    isMask: false,
+    componentSourceId: null,
+    workspaceOnly: false,
+    size: { width: 640, height: 360 },
+    shaderType: 'mesh-gradient',
+    colors: ['#e0eaff', '#241d9a', '#f75092', '#9f50d3'],
+    params: {},
+    speed: 0.6,
+    scale: 1,
+    distortion: 0.8,
+    swirl: 0.1,
+    grain: 0.2,
+  })
+  assert.deepEqual(nodes.root.children, ['title', 'gradient'])
+  assert.equal(validateScene(patched).ok, true)
 })
 
 test('applyScenePatch fills layout defaults for created frame nodes', () => {
@@ -1267,6 +1487,128 @@ test('validateScene rejects unsupported node kinds', () => {
 
   assert.equal(result.ok, false)
   assert.deepEqual(result.errors, ['node title has unsupported kind: shape'])
+})
+
+test('validateScene rejects malformed Mesh Gradient shader fields', () => {
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  if (!root) throw new Error('missing sample root')
+  root.children = [...(root.children ?? []), 'gradient']
+  scene.nodes = {
+    ...scene.nodes,
+    gradient: {
+      id: 'gradient',
+      kind: 'shader',
+      parent: 'root',
+    },
+  }
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(scene))
+  const sceneMap = doc.getMap<unknown>('scene')
+  const nodes = sceneMap.get('nodes') as Y.Map<Y.Map<unknown>>
+  const shader = nodes.get('gradient')
+  if (!shader) throw new Error('missing shader node')
+  shader.set('shaderType', 'noise')
+  shader.set('colors', ['#ffffff', 'bogus', 42])
+  shader.set('speed', 'fast')
+  shader.set('scale', 8)
+  shader.set('distortion', -0.1)
+  shader.set('swirl', 2)
+  shader.set('grain', 1.5)
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(result.errors, [
+    'shader node gradient has unsupported shaderType: noise',
+    'shader node gradient colors must contain 1-10 hex colors (#RGB, #RRGGBB, or #RRGGBBAA)',
+    'shader node gradient speed must be a finite number',
+    'shader node gradient scale must be between 0.1 and 4',
+    'shader node gradient distortion must be between 0 and 1',
+    'shader node gradient swirl must be between 0 and 1',
+    'shader node gradient grain must be between 0 and 1',
+  ])
+})
+
+test('validateScene requires sources for the five image-only shaders', () => {
+  const requiredSourceTypes = [
+    'fluted-glass',
+    'image-dithering',
+    'halftone-dots',
+    'halftone-cmyk',
+    'heatmap',
+  ] as const
+
+  for (const shaderType of requiredSourceTypes) {
+    const scene = sampleScene()
+    const root = scene.nodes?.root
+    if (!root || !scene.nodes) throw new Error('missing sample root')
+    root.children = [...(root.children ?? []), 'shader']
+    scene.nodes.shader = {
+      id: 'shader',
+      kind: 'shader',
+      parent: 'root',
+      shaderType,
+    }
+
+    const result = validateScene(buildSceneBytes(scene))
+
+    assert.ok(
+      result.errors.includes(
+        `shader node shader ${shaderType} requires sourceNodeId or sourceImage`,
+      ),
+    )
+  }
+})
+
+test('validateScene rejects missing shader source layers and unsafe params', () => {
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  if (!root || !scene.nodes) throw new Error('missing sample root')
+  root.children = [...(root.children ?? []), 'shader']
+  scene.nodes.shader = {
+    id: 'shader',
+    kind: 'shader',
+    parent: 'root',
+    shaderType: 'water',
+    sourceNodeId: 'missing',
+  }
+  const doc = new Y.Doc()
+  Y.applyUpdate(doc, buildSceneBytes(scene))
+  const sceneMap = doc.getMap<unknown>('scene')
+  const nodes = sceneMap.get('nodes') as Y.Map<Y.Map<unknown>>
+  nodes.get('shader')?.set('params', {
+    amount: Number.POSITIVE_INFINITY,
+  })
+
+  const result = validateScene(Y.encodeStateAsUpdate(doc))
+
+  assert.deepEqual(result.errors, [
+    'shader node shader params must be a bounded JSON object with finite numbers',
+    'shader node shader sourceNodeId points to missing node: missing',
+  ])
+})
+
+test('validateScene rejects image sources on generated shaders', () => {
+  const scene = sampleScene()
+  const root = scene.nodes?.root
+  if (!root || !scene.nodes) throw new Error('missing sample root')
+  root.children = [...(root.children ?? []), 'shader']
+  scene.nodes.shader = {
+    id: 'shader',
+    kind: 'shader',
+    parent: 'root',
+    shaderType: 'voronoi',
+    sourceImage: '/tmp/source.png',
+  }
+
+  const result = validateScene(buildSceneBytes(scene))
+
+  assert.ok(
+    result.errors.includes(
+      'shader node shader voronoi does not accept an image source',
+    ),
+  )
 })
 
 test('validateScene rejects node entries that are not objects', () => {
@@ -1932,6 +2274,11 @@ test('buildSceneBytes writes camera defaults expected by the desktop app', () =>
     bloomStrength: 0.8,
     bloomRadius: 0.35,
     bloomThreshold: 0.75,
+    vhsEnabled: false,
+    vhsIntensity: 0.65,
+    vhsNoise: 0.35,
+    vhsScanlines: 0.5,
+    vhsColorBleed: 3,
     showFocusPlane: false,
   })
 })
@@ -2570,6 +2917,11 @@ test('buildSceneBytes writes camera lens and depth defaults', () => {
   assert.equal(camera.bloomStrength, 0.8)
   assert.equal(camera.bloomRadius, 0.35)
   assert.equal(camera.bloomThreshold, 0.75)
+  assert.equal(camera.vhsEnabled, false)
+  assert.equal(camera.vhsIntensity, 0.65)
+  assert.equal(camera.vhsNoise, 0.35)
+  assert.equal(camera.vhsScanlines, 0.5)
+  assert.equal(camera.vhsColorBleed, 3)
   assert.equal(camera.showFocusPlane, false)
 })
 
@@ -2599,6 +2951,11 @@ test('buildSceneBytes preserves explicit camera lens and depth fields', () => {
   camera.bloomStrength = 1.4
   camera.bloomRadius = 0.6
   camera.bloomThreshold = 0.45
+  camera.vhsEnabled = true
+  camera.vhsIntensity = 0.85
+  camera.vhsNoise = 0.65
+  camera.vhsScanlines = 0.75
+  camera.vhsColorBleed = 8
 
   const data = inspectScene(buildSceneBytes(scene))
   const nodes = data.nodes as PlainSceneMap
@@ -2626,6 +2983,11 @@ test('buildSceneBytes preserves explicit camera lens and depth fields', () => {
   assert.equal(cameraNode.bloomStrength, 1.4)
   assert.equal(cameraNode.bloomRadius, 0.6)
   assert.equal(cameraNode.bloomThreshold, 0.45)
+  assert.equal(cameraNode.vhsEnabled, true)
+  assert.equal(cameraNode.vhsIntensity, 0.85)
+  assert.equal(cameraNode.vhsNoise, 0.65)
+  assert.equal(cameraNode.vhsScanlines, 0.75)
+  assert.equal(cameraNode.vhsColorBleed, 8)
 })
 
 test('buildSceneBytes derives camera point of interest x/y from transform', () => {

--- a/cli/src/scene/build.ts
+++ b/cli/src/scene/build.ts
@@ -45,12 +45,47 @@ export interface SceneMetaJson {
 export type TextAlignJson = 'start' | 'center' | 'end'
 export type NodePositionJson = 'flow' | 'absolute'
 
+export const PAPER_SHADER_TYPES = [
+  'mesh-gradient',
+  'smoke-ring',
+  'neuro-noise',
+  'dot-orbit',
+  'dot-grid',
+  'simplex-noise',
+  'metaballs',
+  'waves',
+  'perlin-noise',
+  'voronoi',
+  'warp',
+  'god-rays',
+  'spiral',
+  'swirl',
+  'dithering',
+  'grain-gradient',
+  'pulsing-border',
+  'color-panels',
+  'static-mesh-gradient',
+  'static-radial-gradient',
+  'paper-texture',
+  'fluted-glass',
+  'water',
+  'image-dithering',
+  'halftone-dots',
+  'halftone-cmyk',
+  'heatmap',
+  'liquid-metal',
+  'gem-smoke',
+] as const
+
+export type PaperShaderTypeJson = (typeof PAPER_SHADER_TYPES)[number]
+
 export type NodeKindJson =
   | 'frame'
   | 'rect'
   | 'ellipse'
   | 'text'
   | 'image'
+  | 'shader'
   | 'video'
   | 'audio'
   | 'component'
@@ -63,6 +98,7 @@ export const NODE_KINDS = [
   'ellipse',
   'text',
   'image',
+  'shader',
   'video',
   'audio',
   'component',
@@ -226,6 +262,16 @@ export interface NodeJson {
   src?: string
   fit?: MediaFitJson
   importWarning?: string
+  shaderType?: PaperShaderTypeJson
+  colors?: string[]
+  params?: JsonObject
+  sourceNodeId?: string
+  sourceImage?: string
+  speed?: number
+  scale?: number
+  distortion?: number
+  swirl?: number
+  grain?: number
   duration?: number
   volume?: number
   playbackRate?: number
@@ -301,6 +347,11 @@ export interface NodeJson {
   bloomStrength?: number
   bloomRadius?: number
   bloomThreshold?: number
+  vhsEnabled?: boolean
+  vhsIntensity?: number
+  vhsNoise?: number
+  vhsScanlines?: number
+  vhsColorBleed?: number
   showFocusPlane?: boolean
 }
 
@@ -428,6 +479,10 @@ export const PROPERTY_IDS = [
   'camera.bloomStrength',
   'camera.bloomRadius',
   'camera.bloomThreshold',
+  'camera.vhsIntensity',
+  'camera.vhsNoise',
+  'camera.vhsScanlines',
+  'camera.vhsColorBleed',
   'appearance.opacity',
   'appearance.cornerRadius',
   'appearance.cornerRadii',
@@ -761,6 +816,234 @@ const DEFAULT_LAYOUT: SceneLayout = {
 }
 
 const DEFAULT_SIZE: SceneSize = { width: 100, height: 100 }
+const DEFAULT_SHADER_SIZE: SceneSize = { width: 640, height: 360 }
+const PAPER_SHADER_HEX_COLOR = /^#(?:[0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+const PAPER_SHADER_TYPE_SET: ReadonlySet<string> = new Set(PAPER_SHADER_TYPES)
+
+interface PaperShaderDefinitionJson {
+  label: string
+  requiresImage: boolean
+  acceptsImage: boolean
+  maxColors: number
+  colors: readonly string[]
+  speed: number
+  scale: number
+}
+
+const PAPER_SHADER_DEFINITIONS: Record<
+  PaperShaderTypeJson,
+  PaperShaderDefinitionJson
+> = {
+  'mesh-gradient': {
+    label: 'Mesh Gradient',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 10,
+    colors: ['#e0eaff', '#241d9a', '#f75092', '#9f50d3'],
+    speed: 0.6,
+    scale: 1,
+  },
+  'smoke-ring': {
+    label: 'Smoke Ring',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 10,
+    colors: ['#ffffff'],
+    speed: 0.5,
+    scale: 0.8,
+  },
+  'neuro-noise': shaderDefaults('Neuro Noise', 1),
+  'dot-orbit': {
+    label: 'Dot Orbit',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 10,
+    colors: ['#ffc96b', '#ff6200', '#ff2f00', '#421100', '#1a0000'],
+    speed: 1.5,
+    scale: 1,
+  },
+  'dot-grid': shaderDefaults('Dot Grid', 0),
+  'simplex-noise': {
+    label: 'Simplex Noise',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 10,
+    colors: ['#4449cf', '#ffd1e0', '#f94446', '#ffd36b', '#ffffff'],
+    speed: 0.5,
+    scale: 0.6,
+  },
+  metaballs: {
+    label: 'Metaballs',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 8,
+    colors: ['#6e33cc', '#ff5500', '#ffc105', '#ffc800', '#f585ff'],
+    speed: 1,
+    scale: 1,
+  },
+  waves: shaderDefaults('Waves', 0, 0.6),
+  'perlin-noise': shaderDefaults('Perlin Noise', 0.5),
+  voronoi: {
+    label: 'Voronoi',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 5,
+    colors: ['#ff8247', '#ffe53d'],
+    speed: 0.5,
+    scale: 0.5,
+  },
+  warp: {
+    label: 'Warp',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 10,
+    colors: ['#121212', '#9470ff', '#121212', '#8838ff'],
+    speed: 1,
+    scale: 1,
+  },
+  'god-rays': {
+    label: 'God Rays',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 5,
+    colors: ['#a600ff6e', '#6200fff0', '#ffffff', '#33fff5'],
+    speed: 0.75,
+    scale: 1,
+  },
+  spiral: shaderDefaults('Spiral', 1),
+  swirl: {
+    label: 'Swirl',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 10,
+    colors: ['#ffd1d1', '#ff8a8a', '#660000'],
+    speed: 0.32,
+    scale: 1,
+  },
+  dithering: shaderDefaults('Dithering', 1, 0.6),
+  'grain-gradient': {
+    label: 'Grain Gradient',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 7,
+    colors: ['#7300ff', '#eba8ff', '#00bfff', '#2a00ff'],
+    speed: 1,
+    scale: 1,
+  },
+  'pulsing-border': {
+    label: 'Pulsing Border',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 5,
+    colors: ['#0dc1fd', '#d915ef', '#ff3f2ecc'],
+    speed: 1,
+    scale: 0.6,
+  },
+  'color-panels': {
+    label: 'Color Panels',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 7,
+    colors: [
+      '#ff9d00',
+      '#fd4f30',
+      '#809bff',
+      '#6d2eff',
+      '#333aff',
+      '#f15cff',
+      '#ffd557',
+    ],
+    speed: 0.5,
+    scale: 0.8,
+  },
+  'static-mesh-gradient': {
+    label: 'Static Mesh Gradient',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 10,
+    colors: ['#ffad0a', '#6200ff', '#e2a3ff', '#ff99fd'],
+    speed: 0,
+    scale: 1,
+  },
+  'static-radial-gradient': {
+    label: 'Static Radial Gradient',
+    requiresImage: false,
+    acceptsImage: false,
+    maxColors: 10,
+    colors: ['#00bbff', '#00ffe1', '#ffffff'],
+    speed: 0,
+    scale: 1,
+  },
+  'paper-texture': shaderDefaults('Paper Texture', 0, 0.6, true),
+  'fluted-glass': shaderDefaults('Fluted Glass', 0, 1, true, true),
+  water: shaderDefaults('Water', 1, 0.8, true),
+  'image-dithering': shaderDefaults(
+    'Image Dithering',
+    0,
+    1,
+    true,
+    true,
+  ),
+  'halftone-dots': shaderDefaults('Halftone Dots', 0, 1, true, true),
+  'halftone-cmyk': shaderDefaults('Halftone CMYK', 0, 1, true, true),
+  heatmap: {
+    label: 'Heatmap',
+    requiresImage: true,
+    acceptsImage: true,
+    maxColors: 10,
+    colors: [
+      '#11206a',
+      '#1f3ba2',
+      '#2f63e7',
+      '#6bd7ff',
+      '#ffe679',
+      '#ff991e',
+      '#ff4c00',
+    ],
+    speed: 1,
+    scale: 0.75,
+  },
+  'liquid-metal': shaderDefaults('Liquid Metal', 1, 0.6, true),
+  'gem-smoke': {
+    label: 'Gem Smoke',
+    requiresImage: false,
+    acceptsImage: true,
+    maxColors: 6,
+    colors: ['#333333', '#e7e6df'],
+    speed: 1,
+    scale: 0.6,
+  },
+}
+
+function shaderDefaults(
+  label: string,
+  speed: number,
+  scale = 1,
+  acceptsImage = false,
+  requiresImage = false,
+): PaperShaderDefinitionJson {
+  return {
+    label,
+    requiresImage,
+    acceptsImage,
+    maxColors: 10,
+    colors: [],
+    speed,
+    scale,
+  }
+}
+
+function isPaperShaderType(value: unknown): value is PaperShaderTypeJson {
+  return typeof value === 'string' && PAPER_SHADER_TYPE_SET.has(value)
+}
+
+function paperShaderDefinition(
+  value: unknown,
+): PaperShaderDefinitionJson {
+  return PAPER_SHADER_DEFINITIONS[
+    isPaperShaderType(value) ? value : 'mesh-gradient'
+  ]
+}
 
 const DEFAULT_META: SceneMeta = {
   id: 'scene',
@@ -796,10 +1079,14 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
   scene.set('nodes', nodes)
 
   for (const node of Object.values(json.nodes ?? {})) {
+    assertNodeKindCanBeAuthored(node.id, node.kind)
     const y = new Y.Map<unknown>()
     y.set('id', node.id)
     y.set('kind', node.kind)
-    y.set('name', node.name ?? defaultName(node.kind))
+    y.set(
+      'name',
+      node.name ?? defaultName(node.kind, node.shaderType),
+    )
     y.set('parent', node.parent ?? null)
     // Children: store as Y.Array so reorder ops work in the editor.
     const childArr = new Y.Array<string>()
@@ -807,7 +1094,10 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
     y.set('children', childArr)
     y.set(
       'transform',
-      mergeWithDefaults(DEFAULT_TRANSFORM, node.transform),
+      mergeWithDefaults(
+        DEFAULT_TRANSFORM,
+        node.transform,
+      ),
     )
     y.set(
       'appearance',
@@ -859,6 +1149,26 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
       y.set('src', node.src ?? '')
       y.set('fit', node.fit ?? 'cover')
       if (node.importWarning !== undefined) y.set('importWarning', node.importWarning)
+    }
+    if (node.kind === 'shader') {
+      const shaderType = node.shaderType ?? 'mesh-gradient'
+      const definition = paperShaderDefinition(shaderType)
+      y.set('size', mergeWithDefaults(DEFAULT_SHADER_SIZE, node.size))
+      y.set('shaderType', shaderType)
+      y.set('colors', node.colors ?? [...definition.colors])
+      y.set('params', node.params ?? {})
+      if (node.sourceNodeId !== undefined) {
+        y.set('sourceNodeId', node.sourceNodeId)
+      }
+      if (node.sourceImage !== undefined) y.set('sourceImage', node.sourceImage)
+      y.set('speed', node.speed ?? definition.speed)
+      y.set('scale', node.scale ?? definition.scale)
+      y.set(
+        'distortion',
+        node.distortion ?? (shaderType === 'mesh-gradient' ? 0.8 : 0),
+      )
+      y.set('swirl', node.swirl ?? (shaderType === 'mesh-gradient' ? 0.1 : 0))
+      y.set('grain', node.grain ?? (shaderType === 'mesh-gradient' ? 0.08 : 0))
     }
     if (node.kind === 'instance') {
       y.set('size', mergeWithDefaults(DEFAULT_SIZE, node.size))
@@ -958,6 +1268,11 @@ export function buildSceneBytes(json: SceneJson): Uint8Array {
       y.set('bloomStrength', node.bloomStrength ?? 0.8)
       y.set('bloomRadius', node.bloomRadius ?? 0.35)
       y.set('bloomThreshold', node.bloomThreshold ?? 0.75)
+      y.set('vhsEnabled', node.vhsEnabled ?? false)
+      y.set('vhsIntensity', node.vhsIntensity ?? 0.65)
+      y.set('vhsNoise', node.vhsNoise ?? 0.35)
+      y.set('vhsScanlines', node.vhsScanlines ?? 0.5)
+      y.set('vhsColorBleed', node.vhsColorBleed ?? 3)
       y.set('showFocusPlane', node.showFocusPlane ?? false)
     }
 
@@ -1093,6 +1408,106 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
     if (node.kind === 'camera' && parent) {
       errors.push(`camera node ${id} must be scene-level with parent: null`)
     }
+    if (node.kind === 'shader') {
+      const shaderType = node.shaderType
+      const supportedShaderType = isPaperShaderType(shaderType)
+      if (!supportedShaderType) {
+        errors.push(
+          `shader node ${id} has unsupported shaderType: ${String(node.shaderType)}`,
+        )
+      }
+      const definition = paperShaderDefinition(shaderType)
+      const minimumColors = definition.colors.length > 0 ? 1 : 0
+      if (
+        !Array.isArray(node.colors) ||
+        node.colors.length < minimumColors ||
+        node.colors.length > definition.maxColors ||
+        node.colors.some(
+          (color) =>
+            typeof color !== 'string' ||
+            !PAPER_SHADER_HEX_COLOR.test(color),
+        )
+      ) {
+        const range =
+          minimumColors === 0
+            ? `0-${definition.maxColors}`
+            : `1-${definition.maxColors}`
+        errors.push(
+          `shader node ${id} colors must contain ${range} hex colors (#RGB, #RRGGBB, or #RRGGBBAA)`,
+        )
+      }
+      if (
+        node.params !== undefined &&
+        (!isPlainObject(node.params) || !isValidShaderParams(node.params))
+      ) {
+        errors.push(
+          `shader node ${id} params must be a bounded JSON object with finite numbers`,
+        )
+      }
+      const sourceNodeId =
+        typeof node.sourceNodeId === 'string' ? node.sourceNodeId.trim() : ''
+      const sourceImage =
+        typeof node.sourceImage === 'string' ? node.sourceImage.trim() : ''
+      if (
+        node.sourceNodeId !== undefined &&
+        (typeof node.sourceNodeId !== 'string' ||
+          sourceNodeId.length === 0 ||
+          sourceNodeId.length > 512)
+      ) {
+        errors.push(
+          `shader node ${id} sourceNodeId must be a non-empty string up to 512 characters`,
+        )
+      } else if (sourceNodeId === id) {
+        errors.push(`shader node ${id} cannot use itself as sourceNodeId`)
+      } else if (sourceNodeId && !nodes[sourceNodeId]) {
+        errors.push(
+          `shader node ${id} sourceNodeId points to missing node: ${sourceNodeId}`,
+        )
+      }
+      if (
+        node.sourceImage !== undefined &&
+        (typeof node.sourceImage !== 'string' || sourceImage.length === 0)
+      ) {
+        errors.push(
+          `shader node ${id} sourceImage must be a non-empty string`,
+        )
+      }
+      if (
+        supportedShaderType &&
+        !definition.acceptsImage &&
+        (sourceNodeId || sourceImage)
+      ) {
+        errors.push(
+          `shader node ${id} ${shaderType} does not accept an image source`,
+        )
+      }
+      if (
+        supportedShaderType &&
+        definition.requiresImage &&
+        !sourceNodeId &&
+        !sourceImage
+      ) {
+        errors.push(
+          `shader node ${id} ${shaderType} requires sourceNodeId or sourceImage`,
+        )
+      }
+      for (const [field, min, max] of [
+        ['speed', 0, 2],
+        ['scale', 0.1, 4],
+        ['distortion', 0, 1],
+        ['swirl', 0, 1],
+        ['grain', 0, 1],
+      ] as const) {
+        const value = node[field]
+        if (typeof value !== 'number' || !Number.isFinite(value)) {
+          errors.push(`shader node ${id} ${field} must be a finite number`)
+        } else if (value < min || value > max) {
+          errors.push(
+            `shader node ${id} ${field} must be between ${min} and ${max}`,
+          )
+        }
+      }
+    }
     if (parent && !nodes[parent]) errors.push(`node ${id} has missing parent: ${parent}`)
     else if (parent) {
       const parentChildren = asRecord(nodes[parent]).children
@@ -1211,8 +1626,19 @@ export function validateScene(bytes: Uint8Array): SceneValidationResult {
   return { ok: errors.length === 0, errors, warnings }
 }
 
-function isNodeKind(value: string): value is NodeKindJson {
-  return NODE_KIND_SET.has(value as NodeKindJson)
+function isNodeKind(value: unknown): value is NodeKindJson {
+  return (
+    typeof value === 'string' &&
+    NODE_KIND_SET.has(value as NodeKindJson)
+  )
+}
+
+function assertNodeKindCanBeAuthored(nodeId: unknown, kind: unknown): void {
+  if (kind === 'primitive3d') {
+    throw new Error(
+      `node ${String(nodeId)} has unsupported kind: ${String(kind)}`,
+    )
+  }
 }
 
 function isNodePosition(value: string): value is NodePositionJson {
@@ -1230,6 +1656,31 @@ function isJsonValue(value: unknown): value is JsonValue {
   if (Array.isArray(value)) return value.every(isJsonValue)
   if (!isPlainObject(value)) return false
   return Object.values(value).every(isJsonValue)
+}
+
+function isValidShaderParams(value: unknown, depth = 0): boolean {
+  if (value === null || typeof value === 'boolean') return true
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && Math.abs(value) <= 1_000_000
+  }
+  if (typeof value === 'string') return value.length <= 32_768
+  if (depth >= 6) return false
+  if (Array.isArray(value)) {
+    return (
+      value.length <= 128 &&
+      value.every((item) => isValidShaderParams(item, depth + 1))
+    )
+  }
+  if (!isPlainObject(value)) return false
+  const entries = Object.entries(value)
+  if (entries.length > 128) return false
+  return entries.every(
+    ([key, item]) =>
+      key !== '__proto__' &&
+      key !== 'constructor' &&
+      key !== 'prototype' &&
+      isValidShaderParams(item, depth + 1),
+  )
 }
 
 export function applyScenePatch(bytes: Uint8Array, patch: ScenePatch | PatchOperation[]): Uint8Array {
@@ -1282,6 +1733,7 @@ function applyPatchOperation(scene: Y.Map<unknown>, op: PatchOperation): void {
     case 'setNode': {
       const node = getNodeMap(scene, op.nodeId)
       for (const [k, v] of Object.entries(op.patch)) {
+        if (k === 'kind') assertNodeKindCanBeAuthored(op.nodeId, v)
         if (k === 'children' && Array.isArray(v)) node.set(k, arrayToY(v))
         else node.set(k, v)
       }
@@ -1289,6 +1741,9 @@ function applyPatchOperation(scene: Y.Map<unknown>, op: PatchOperation): void {
     }
     case 'setNodeProperty': {
       const node = getNodeMap(scene, op.nodeId)
+      if (op.key === 'kind') {
+        assertNodeKindCanBeAuthored(op.nodeId, op.value)
+      }
       if (op.key === 'children' && Array.isArray(op.value)) node.set(op.key, arrayToY(op.value))
       else node.set(op.key, op.value)
       return
@@ -1338,6 +1793,7 @@ function applyPatchOperation(scene: Y.Map<unknown>, op: PatchOperation): void {
 }
 
 function nodeToYMap(node: NodeJson, meta: SceneMeta = DEFAULT_META): Y.Map<unknown> {
+  assertNodeKindCanBeAuthored(node.id, node.kind)
   const y = new Y.Map<unknown>()
   const handledKeys = new Set([
     'id',
@@ -1356,10 +1812,19 @@ function nodeToYMap(node: NodeJson, meta: SceneMeta = DEFAULT_META): Y.Map<unkno
   ])
   y.set('id', node.id)
   y.set('kind', node.kind)
-  y.set('name', node.name ?? defaultName(node.kind))
+  y.set(
+    'name',
+    node.name ?? defaultName(node.kind, node.shaderType),
+  )
   y.set('parent', node.parent ?? null)
   y.set('children', arrayToY(node.children ?? []))
-  y.set('transform', mergeWithDefaults(DEFAULT_TRANSFORM, node.transform as Partial<typeof DEFAULT_TRANSFORM>))
+  y.set(
+    'transform',
+    mergeWithDefaults(
+      DEFAULT_TRANSFORM,
+      node.transform as Partial<typeof DEFAULT_TRANSFORM>,
+    ),
+  )
   y.set('appearance', mergeWithDefaults(defaultAppearance(node.kind), node.appearance))
   y.set('visible', node.visible ?? true)
   y.set('locked', node.locked ?? false)
@@ -1403,6 +1868,39 @@ function nodeToYMap(node: NodeJson, meta: SceneMeta = DEFAULT_META): Y.Map<unkno
     y.set('src', node.src ?? '')
     y.set('fit', node.fit ?? 'cover')
     if (node.importWarning !== undefined) y.set('importWarning', node.importWarning)
+  }
+  if (node.kind === 'shader') {
+    for (const key of [
+      'size',
+      'shaderType',
+      'colors',
+      'params',
+      'sourceNodeId',
+      'sourceImage',
+      'speed',
+      'scale',
+      'distortion',
+      'swirl',
+      'grain',
+    ]) {
+      handledKeys.add(key)
+    }
+    const shaderType = node.shaderType ?? 'mesh-gradient'
+    const definition = paperShaderDefinition(shaderType)
+    y.set('size', mergeWithDefaults(DEFAULT_SHADER_SIZE, node.size))
+    y.set('shaderType', shaderType)
+    y.set('colors', node.colors ?? [...definition.colors])
+    y.set('params', node.params ?? {})
+    if (node.sourceNodeId !== undefined) y.set('sourceNodeId', node.sourceNodeId)
+    if (node.sourceImage !== undefined) y.set('sourceImage', node.sourceImage)
+    y.set('speed', node.speed ?? definition.speed)
+    y.set('scale', node.scale ?? definition.scale)
+    y.set(
+      'distortion',
+      node.distortion ?? (shaderType === 'mesh-gradient' ? 0.8 : 0),
+    )
+    y.set('swirl', node.swirl ?? (shaderType === 'mesh-gradient' ? 0.1 : 0))
+    y.set('grain', node.grain ?? (shaderType === 'mesh-gradient' ? 0.08 : 0))
   }
   if (node.kind === 'frame' || node.kind === 'component') {
     for (const key of [
@@ -1500,6 +1998,11 @@ function nodeToYMap(node: NodeJson, meta: SceneMeta = DEFAULT_META): Y.Map<unkno
       'bloomStrength',
       'bloomRadius',
       'bloomThreshold',
+      'vhsEnabled',
+      'vhsIntensity',
+      'vhsNoise',
+      'vhsScanlines',
+      'vhsColorBleed',
       'showFocusPlane',
     ]) {
       handledKeys.add(key)
@@ -1547,6 +2050,11 @@ function nodeToYMap(node: NodeJson, meta: SceneMeta = DEFAULT_META): Y.Map<unkno
     y.set('bloomStrength', node.bloomStrength ?? 0.8)
     y.set('bloomRadius', node.bloomRadius ?? 0.35)
     y.set('bloomThreshold', node.bloomThreshold ?? 0.75)
+    y.set('vhsEnabled', node.vhsEnabled ?? false)
+    y.set('vhsIntensity', node.vhsIntensity ?? 0.65)
+    y.set('vhsNoise', node.vhsNoise ?? 0.35)
+    y.set('vhsScanlines', node.vhsScanlines ?? 0.5)
+    y.set('vhsColorBleed', node.vhsColorBleed ?? 3)
     y.set('showFocusPlane', node.showFocusPlane ?? false)
   }
   for (const [k, v] of Object.entries(node)) {
@@ -1796,13 +2304,17 @@ function keyframeLength(value: unknown): number {
   return 0
 }
 
-function defaultName(kind: NodeKindJson): string {
+function defaultName(
+  kind: NodeKindJson,
+  shaderType?: PaperShaderTypeJson,
+): string {
   switch (kind) {
     case 'frame': return 'Frame'
     case 'rect': return 'Rectangle'
     case 'ellipse': return 'Ellipse'
     case 'text': return 'Text'
     case 'image': return 'Image'
+    case 'shader': return paperShaderDefinition(shaderType).label
     case 'video': return 'Video'
     case 'audio': return 'Audio'
     case 'component': return 'Component'
@@ -1812,7 +2324,12 @@ function defaultName(kind: NodeKindJson): string {
 }
 
 function defaultAppearance(kind: NodeKindJson): Record<string, unknown> {
-  if (kind === 'text' || kind === 'video' || kind === 'audio') {
+  if (
+    kind === 'text' ||
+    kind === 'video' ||
+    kind === 'audio' ||
+    kind === 'shader'
+  ) {
     return { ...DEFAULT_APPEARANCE, fill: null, stroke: null }
   }
   return { ...DEFAULT_APPEARANCE }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:win": "pnpm build:figma-plugin && vite build && electron-builder --win --publish=never",
     "lint": "eslint .",
     "test": "pnpm --dir cli test",
-    "test:canvas": "vitest run src/render/strokePattern.test.ts src/render/apertureBokeh.test.ts src/render/CameraPostEffectsFallback.test.tsx src/render3d/depthOfFieldShader.test.ts src/render3d/postEffects.test.ts src/render3d/texturePolicy.test.ts src/render3d/planeAnimationSnapshot.test.ts src/render3d/scene3d.focus.test.ts src/render3d/scene3d.hitTest.test.ts src/render3d/selectionProjection.test.ts src/render3d/textAnimationLayout.test.ts src/render3d/textSegmentBatch.test.ts src/render3d/textSegmentMaterial.test.ts src/anim/easingPresets.test.ts src/anim/engine.test.ts src/anim/keyframeEasing.test.ts src/anim/multiKeyframes.test.ts src/anim/presets.test.ts src/anim/staggerSets.test.ts src/anim/textAnimations.test.ts src/anim/textMotionPath.test.ts src/anim/textMotionRail.test.ts src/anim/textMotionVector.test.ts src/anim/textScramble.test.ts src/anim/textSegmentEnvelope.test.ts src/anim/textSegmentMotion.test.ts src/anim/textStaggerCurve.test.ts src/anim/tracks.test.ts src/scene/cameraDof.test.ts src/state/groupActions.test.ts src/state/staggerSelection.test.ts src/ui/BezierTimingEditor.test.ts src/ui/GraphEditor.test.ts src/ui/StaggerCurveEditor.test.ts src/ui/TextMotionPathEditor.test.ts src/ui/hooks/useAnimatedValues.test.ts src/ui/cameraPreviewStore.test.ts src/ui/cameraWheel.test.ts src/ui/cameraReset.test.ts src/ui/canvasTextEditing.test.ts src/ui/keyframeDragPreviewStore.test.ts src/ui/multiRenderMode.test.ts src/ui/sectionDragPreviewStore.test.ts src/ui/textStaggerCurvePreviewStore.test.ts src/ui/timelineDragHitArea.test.ts src/ui/textAnimationSegments.test.ts",
+    "test:canvas": "vitest run src/render/strokePattern.test.ts src/render/apertureBokeh.test.ts src/render/CameraPostEffectsFallback.test.tsx src/render/paperShaderRegistry.test.ts src/render/paperShaderSource.test.ts src/render3d/depthOfFieldShader.test.ts src/render3d/layerBlendMode.test.ts src/render3d/postEffects.test.ts src/render3d/texturePolicy.test.ts src/render3d/planeAnimationSnapshot.test.ts src/render3d/scene3d.focus.test.ts src/render3d/scene3d.hitTest.test.ts src/render3d/selectionProjection.test.ts src/render3d/textAnimationLayout.test.ts src/render3d/textSegmentBatch.test.ts src/render3d/textSegmentMaterial.test.ts src/anim/easingPresets.test.ts src/anim/engine.test.ts src/anim/keyframeEasing.test.ts src/anim/multiKeyframes.test.ts src/anim/presets.test.ts src/anim/staggerSets.test.ts src/anim/textAnimations.test.ts src/anim/textMotionPath.test.ts src/anim/textMotionRail.test.ts src/anim/textMotionVector.test.ts src/anim/textScramble.test.ts src/anim/textSegmentEnvelope.test.ts src/anim/textSegmentMotion.test.ts src/anim/textStaggerCurve.test.ts src/anim/tracks.test.ts src/audio/beatSync.test.ts src/audio/beatSyncPlan.test.ts src/scene/audioBeatPersistence.test.ts src/scene/cameraDof.test.ts src/scene/removeLegacy3DObjects.test.ts src/scene/shaderNode.test.ts src/state/groupActions.test.ts src/state/staggerSelection.test.ts src/ui/BezierTimingEditor.test.ts src/ui/GraphEditor.test.ts src/ui/StaggerCurveEditor.test.ts src/ui/TextMotionPathEditor.test.ts src/ui/hooks/useAnimatedValues.test.ts src/ui/cameraPreviewStore.test.ts src/ui/cameraWheel.test.ts src/ui/cameraReset.test.ts src/ui/canvasTextEditing.test.ts src/ui/keyframeDragPreviewStore.test.ts src/ui/multiRenderMode.test.ts src/ui/sectionDragPreviewStore.test.ts src/ui/textStaggerCurvePreviewStore.test.ts src/ui/timelineDragHitArea.test.ts src/ui/textAnimationSegments.test.ts",
     "test:figma": "vitest run src/import/figma src/scene/vector/path.test.ts src/scene/vector/svgSecurity.test.ts src/scene/vector/vectorNode.test.ts src/render/vectorPaint.test.ts src/render/vectorSource.test.ts src/layout/vectorMeasure.test.ts src/ui/fonts/googleFonts.test.ts",
     "test:figma-plugin-shell": "vitest run electron/figmaPlugin.test.ts",
     "typecheck": "tsc -b",
@@ -26,6 +26,7 @@
   "dependencies": {
     "@ffmpeg/ffmpeg": "^0.12.10",
     "@ffmpeg/util": "^0.12.1",
+    "@paper-design/shaders-react": "0.0.77",
     "gifenc": "^1.0.3",
     "immer": "^11.1.4",
     "lucide-react": "^1.25.0",
@@ -74,6 +75,14 @@
       "package.json"
     ],
     "extraResources": [
+      {
+        "from": "LICENSE",
+        "to": "LICENSE"
+      },
+      {
+        "from": "NOTICE",
+        "to": "NOTICE"
+      },
       {
         "from": "figma-plugin",
         "to": "figma-plugin",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@ffmpeg/util':
         specifier: ^0.12.1
         version: 0.12.2
+      '@paper-design/shaders-react':
+        specifier: 0.0.77
+        version: 0.0.77(@types/react@19.2.14)(react@19.2.5)
       gifenc:
         specifier: ^1.0.3
         version: 1.0.3
@@ -542,6 +545,18 @@ packages:
 
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
+
+  '@paper-design/shaders-react@0.0.77':
+    resolution: {integrity: sha512-VCjhK7k6GT1BMjq7kLsDHMnMy1ryjCTALdhOVIf2Z5b1jh5eEHXqHdQCvMAJ7v6evjiN1twzjM1KUNOg2RoXBw==}
+    peerDependencies:
+      '@types/react': ^18 || ^19
+      react: ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@paper-design/shaders@0.0.77':
+    resolution: {integrity: sha512-y0mR3brBu6qvVgbnvBdXX3zL/hajdamkECLt8NbexaEc1L46W3a+ZIEwxu1NJ2/bqwxAgjJC0o2+4CAii5wp/w==}
 
   '@pixi/colord@2.9.6':
     resolution: {integrity: sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==}
@@ -3499,6 +3514,15 @@ snapshots:
       rimraf: 3.0.2
 
   '@oxc-project/types@0.126.0': {}
+
+  '@paper-design/shaders-react@0.0.77(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@paper-design/shaders': 0.0.77
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@paper-design/shaders@0.0.77': {}
 
   '@pixi/colord@2.9.6': {}
 

--- a/src/anim/engine.test.ts
+++ b/src/anim/engine.test.ts
@@ -104,6 +104,31 @@ describe('animation engine track preview', () => {
     expect(engine.getSnapshot()[nodeId]?.opacity).toBe(1)
   })
 
+  it('steps animated layer blend modes at their authored keyframes', () => {
+    const api = createSceneAPI()
+    const nodeId = api.createNode('rect', null)
+    api.setTrack({
+      id: 'blend-mode-track',
+      nodeId,
+      propertyId: 'appearance.blendMode',
+      defaultEasing: 'linear',
+      keyframes: [
+        { id: 'normal', time: 0, value: 'normal' },
+        { id: 'overlay', time: 1, value: 'overlay' },
+      ],
+    })
+
+    const engine = getAnimEngine()
+    engine.attach(api)
+
+    engine.seek(0)
+    expect(engine.getSnapshot()[nodeId]?.blendMode).toBe('normal')
+    engine.seek(0.999)
+    expect(engine.getSnapshot()[nodeId]?.blendMode).toBe('normal')
+    engine.seek(1)
+    expect(engine.getSnapshot()[nodeId]?.blendMode).toBe('overlay')
+  })
+
   it('evaluates transient keyframe timing without mutating the scene', () => {
     const api = createSceneAPI()
     const nodeId = api.createNode('rect', null)

--- a/src/anim/engine.ts
+++ b/src/anim/engine.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { NodeId, PropertyId, Track, TrackId } from '@/scene'
+import type { BlendMode, NodeId, PropertyId, Track, TrackId } from '@/scene'
 import type { SceneAPI } from '@/scene/doc'
 import { PROPERTIES } from '@/scene/props'
 import { lerpOklchStrings } from './color'
@@ -73,6 +73,8 @@ export interface AnimatedValue {
   cornerRadius?: number
   /** Override for the node's `appearance.fill` solid color. */
   fill?: string
+  /** Discrete override for `node.appearance.blendMode`. */
+  blendMode?: BlendMode
   /** 0→1 progress for text-specific animation effects. */
   textProgress?: number
   /** Text effect config attached to the active text.progress track. */
@@ -105,6 +107,10 @@ export interface AnimatedValue {
   bloomStrength?: number
   bloomRadius?: number
   bloomThreshold?: number
+  vhsIntensity?: number
+  vhsNoise?: number
+  vhsScanlines?: number
+  vhsColorBleed?: number
 }
 
 /** Empty snapshot value — no tracks means no overrides. */
@@ -597,6 +603,10 @@ function writeProperty(
     if (typeof value === 'string') into.fill = value
     return
   }
+  if (id === 'appearance.blendMode') {
+    if (isBlendMode(value)) into.blendMode = value
+    return
+  }
   if (typeof value !== 'number') return
   // REPLACE semantics — a track's keyframe value is the absolute value
   // the rendered property should take on at that instant. Composition
@@ -728,8 +738,44 @@ function writeProperty(
     case 'camera.bloomThreshold':
       into.bloomThreshold = value
       break
+    case 'camera.vhsIntensity':
+      into.vhsIntensity = value
+      break
+    case 'camera.vhsNoise':
+      into.vhsNoise = value
+      break
+    case 'camera.vhsScanlines':
+      into.vhsScanlines = value
+      break
+    case 'camera.vhsColorBleed':
+      into.vhsColorBleed = value
+      break
     // Other PropertyIds ignored for MVP (layout + variant go through FLIP).
     default:
       break
+  }
+}
+
+function isBlendMode(value: unknown): value is BlendMode {
+  switch (value) {
+    case 'normal':
+    case 'multiply':
+    case 'screen':
+    case 'overlay':
+    case 'darken':
+    case 'lighten':
+    case 'color-dodge':
+    case 'color-burn':
+    case 'hard-light':
+    case 'soft-light':
+    case 'difference':
+    case 'exclusion':
+    case 'hue':
+    case 'saturation':
+    case 'color':
+    case 'luminosity':
+      return true
+    default:
+      return false
   }
 }

--- a/src/anim/recordKeyframes.ts
+++ b/src/anim/recordKeyframes.ts
@@ -87,6 +87,10 @@ const CAMERA_PROP_IDS: Partial<Record<string, PropertyId>> = {
   bloomStrength: 'camera.bloomStrength',
   bloomRadius: 'camera.bloomRadius',
   bloomThreshold: 'camera.bloomThreshold',
+  vhsIntensity: 'camera.vhsIntensity',
+  vhsNoise: 'camera.vhsNoise',
+  vhsScanlines: 'camera.vhsScanlines',
+  vhsColorBleed: 'camera.vhsColorBleed',
 }
 
 export type PatchGroup = 'transform' | 'appearance' | 'size' | 'camera'

--- a/src/export/orchestrator.ts
+++ b/src/export/orchestrator.ts
@@ -301,6 +301,7 @@ async function runCaptureRect(
   const originalPlayhead = engine.getPlayhead()
 
   const ui = useUI.getState()
+  const originalUiPlayhead = ui.playhead
   const originalView = { ...ui.view }
   // Drop zoom to 1 and pan to 0 so the artboard sits at native CSS
   // size centered in the viewport. Necessary because CDP's clip rect
@@ -376,6 +377,7 @@ async function runCaptureRect(
         const frameStart = performance.now()
         const t = f / fps
         engine.seek(t)
+        ui.setPlayhead(t)
 
         // engine.seek schedules a React re-render through the
         // useSyncExternalStore subscription, which then has to
@@ -487,6 +489,7 @@ async function runCaptureRect(
       /* best effort */
     }
     ui.setView(originalView)
+    ui.setPlayhead(originalUiPlayhead)
     engine.seek(originalPlayhead)
     if (wasPlaying) engine.play()
   }

--- a/src/interaction/componentRuntime.ts
+++ b/src/interaction/componentRuntime.ts
@@ -368,6 +368,10 @@ function writeProperty(
     case 'camera.bloomStrength': into.bloomStrength = value; break
     case 'camera.bloomRadius': into.bloomRadius = value; break
     case 'camera.bloomThreshold': into.bloomThreshold = value; break
+    case 'camera.vhsIntensity': into.vhsIntensity = value; break
+    case 'camera.vhsNoise': into.vhsNoise = value; break
+    case 'camera.vhsScanlines': into.vhsScanlines = value; break
+    case 'camera.vhsColorBleed': into.vhsColorBleed = value; break
     default: break
   }
 }

--- a/src/layout/mapper.ts
+++ b/src/layout/mapper.ts
@@ -67,7 +67,7 @@ export function applySize(yNode: YogaNode, axis: 'width' | 'height', value: Size
 
 /**
  * Copy all layout-affecting properties from a scene node onto a Yoga node.
- * Leaves (rect, ellipse, image, text) just get size. Containers (frame,
+ * Leaves (rect, ellipse, image, shader, text) just get size. Containers (frame,
  * component) branch on `layout.mode`:
  *
  *   - 'none' — padding + align/justify still honored (so a plain frame

--- a/src/render/CameraPostEffectsFallback.test.tsx
+++ b/src/render/CameraPostEffectsFallback.test.tsx
@@ -22,6 +22,7 @@ describe('DOM camera post-effects fallback', () => {
     api.setNodeProperty(camera.id, 'chromaticAberrationAmount', 4)
     api.setNodeProperty(camera.id, 'bloomEnabled', true)
     api.setNodeProperty(camera.id, 'bloomStrength', 0.8)
+    api.setNodeProperty(camera.id, 'vhsEnabled', true)
     const authored = api.getActiveCamera()
     if (!authored) throw new Error('Expected the updated camera')
 
@@ -32,6 +33,10 @@ describe('DOM camera post-effects fallback', () => {
         bloomStrength: 1.4,
         bloomRadius: 0.6,
         bloomThreshold: 0.25,
+        vhsIntensity: 0.8,
+        vhsNoise: 0.6,
+        vhsScanlines: 0.7,
+        vhsColorBleed: 5,
       }),
     ).toMatchObject({
       chromaticAberrationEnabled: true,
@@ -41,6 +46,11 @@ describe('DOM camera post-effects fallback', () => {
       bloomStrength: 1.4,
       bloomRadius: 0.6,
       bloomThreshold: 0.25,
+      vhsEnabled: true,
+      vhsIntensity: 0.8,
+      vhsNoise: 0.6,
+      vhsScanlines: 0.7,
+      vhsColorBleed: 5,
     })
   })
 
@@ -125,5 +135,27 @@ describe('DOM camera post-effects fallback', () => {
     expect(fallbackPostEffectPadding(effects)).toBe(
       Math.ceil(fallbackBloomSigma(0.5) * 3 + 6 + 2),
     )
+  })
+
+  it('provides a lightweight static VHS fallback without an empty SVG filter', () => {
+    const markup = renderToStaticMarkup(
+      <CameraPostEffectsFallback
+        effects={normalizeCameraPostEffects({
+          vhsEnabled: true,
+          vhsIntensity: 0.8,
+          vhsScanlines: 0.5,
+        })}
+        width={960}
+        height={540}
+      >
+        <span>Scene</span>
+      </CameraPostEffectsFallback>,
+    )
+
+    expect(markup).toContain('data-camera-post-effects="vhs"')
+    expect(markup).toContain('data-vhs-fallback-scanlines="true"')
+    expect(markup).toContain('saturate(')
+    expect(markup).not.toContain('<filter')
+    expect(markup).not.toContain('url(&quot;#hm-camera-post-')
   })
 })

--- a/src/render/CameraPostEffectsFallback.tsx
+++ b/src/render/CameraPostEffectsFallback.tsx
@@ -40,6 +40,8 @@ export function CameraPostEffectsFallback({
     effects.chromaticAberrationEnabled &&
     effects.chromaticAberrationAmount > 0.001
   const bloomActive = effects.bloomEnabled && effects.bloomStrength > 0.001
+  const vhsActive = effects.vhsEnabled && effects.vhsIntensity > 0.001
+  const svgFilterActive = chromaticActive || bloomActive
   const filterId = `hm-camera-post-${reactId.replaceAll(':', '')}`
   const safeWidth = Math.max(1, finiteFallbackNumber(width, 1))
   const safeHeight = Math.max(1, finiteFallbackNumber(height, 1))
@@ -57,6 +59,7 @@ export function CameraPostEffectsFallback({
   const activeNames = [
     bloomActive ? 'bloom' : null,
     chromaticActive ? 'chromatic' : null,
+    vhsActive ? 'vhs' : null,
   ]
     .filter(Boolean)
     .join(' ')
@@ -67,24 +70,25 @@ export function CameraPostEffectsFallback({
       data-camera-post-effects={activeNames}
       style={{ isolation: 'isolate' }}
     >
-      <svg
-        aria-hidden="true"
-        focusable="false"
-        width="0"
-        height="0"
-        className="pointer-events-none absolute"
-      >
-        <defs>
-          <filter
-            id={filterId}
-            x={-padding}
-            y={-padding}
-            width={safeWidth + padding * 2}
-            height={safeHeight + padding * 2}
-            filterUnits="userSpaceOnUse"
-            primitiveUnits="userSpaceOnUse"
-            colorInterpolationFilters="linearRGB"
-          >
+      {svgFilterActive ? (
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          width="0"
+          height="0"
+          className="pointer-events-none absolute"
+        >
+          <defs>
+            <filter
+              id={filterId}
+              x={-padding}
+              y={-padding}
+              width={safeWidth + padding * 2}
+              height={safeHeight + padding * 2}
+              filterUnits="userSpaceOnUse"
+              primitiveUnits="userSpaceOnUse"
+              colorInterpolationFilters="linearRGB"
+            >
             {bloomActive ? (
               <>
                 <feColorMatrix
@@ -177,19 +181,43 @@ export function CameraPostEffectsFallback({
                 />
               </>
             ) : null}
-          </filter>
-        </defs>
-      </svg>
+            </filter>
+          </defs>
+        </svg>
+      ) : null}
       <div
         className="absolute inset-0"
         style={{
-          filter: `url("#${filterId}")`,
+          filter: [
+            svgFilterActive ? `url("#${filterId}")` : null,
+            vhsActive
+              ? `saturate(${1 - effects.vhsIntensity * 0.14}) contrast(${
+                  1 + effects.vhsIntensity * 0.08
+                })`
+              : null,
+          ]
+            .filter(Boolean)
+            .join(' '),
           transformStyle: 'preserve-3d',
           willChange: 'filter',
         }}
       >
         {children}
       </div>
+      {vhsActive ? (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0"
+          data-vhs-fallback-scanlines="true"
+          style={{
+            backgroundImage:
+              'repeating-linear-gradient(to bottom, transparent 0, transparent 1px, rgba(0, 0, 0, 0.55) 1px, rgba(0, 0, 0, 0.55) 2px)',
+            mixBlendMode: 'multiply',
+            opacity:
+              effects.vhsIntensity * effects.vhsScanlines * 0.18,
+          }}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/render/PaperShaderLayer.tsx
+++ b/src/render/PaperShaderLayer.tsx
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  Suspense,
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type CSSProperties,
+  type MutableRefObject,
+  type ReactNode,
+  type Ref,
+} from 'react'
+import type { PaperShaderElement } from '@paper-design/shaders-react'
+import type { SolvedLayout } from '@/layout'
+import {
+  useSceneAPI,
+  useSceneVersion,
+  type Node,
+  type SceneAPI,
+} from '@/scene'
+import {
+  notifyPaperShaderSourceChanged,
+  paperShaderSourceBelongsTo,
+  publishPaperShaderSource,
+  removePaperShaderSource,
+  resolvePaperShaderStatusMount,
+} from '@/render/paperShaderSource'
+import {
+  getPaperShaderRenderer,
+  paperShaderFrame,
+  paperShaderNeedsImageSource,
+  paperShaderRuntimeParams,
+  resolvePaperShaderSource,
+} from '@/render/paperShaderRegistry'
+import { useUI } from '@/state/ui'
+import { useAnimationPlaybackClock } from '@/ui/hooks/useAnimatedValues'
+
+type ShaderNode = Extract<Node, { kind: 'shader' }>
+
+type PaperShaderHost = HTMLDivElement
+
+interface PaperShaderRenderQuality {
+  minPixelRatio?: number
+  maxPixelCount?: number
+}
+
+const PaperShaderRenderQualityContext =
+  createContext<PaperShaderRenderQuality>({})
+
+const PAPER_WEBGL_ATTRIBUTES: WebGLContextAttributes = {
+  alpha: true,
+  premultipliedAlpha: true,
+  preserveDrawingBuffer: true,
+}
+
+function placeholderPixelRatio(
+  width: number,
+  height: number,
+  minPixelRatio?: number,
+  maxPixelCount?: number,
+): number {
+  let ratio = Math.max(
+    1,
+    minPixelRatio ??
+      (typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1),
+  )
+  if (
+    maxPixelCount !== undefined &&
+    Number.isFinite(maxPixelCount) &&
+    maxPixelCount > 0
+  ) {
+    ratio = Math.min(ratio, Math.sqrt(maxPixelCount / (width * height)))
+  }
+  return Math.max(0.1, ratio)
+}
+
+function drawShaderStatusPlaceholder(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+  ratio: number,
+  message: string,
+) {
+  const pixelWidth = Math.max(1, Math.round(width * ratio))
+  const pixelHeight = Math.max(1, Math.round(height * ratio))
+  if (canvas.width !== pixelWidth) canvas.width = pixelWidth
+  if (canvas.height !== pixelHeight) canvas.height = pixelHeight
+
+  const context = canvas.getContext('2d')
+  if (!context) return
+  context.setTransform(ratio, 0, 0, ratio, 0, 0)
+  context.clearRect(0, 0, width, height)
+  context.fillStyle = '#17181c'
+  context.fillRect(0, 0, width, height)
+
+  const grid = Math.max(12, Math.min(24, Math.round(Math.min(width, height) / 8)))
+  context.strokeStyle = '#22242a'
+  context.lineWidth = 1
+  for (let x = -height; x < width + height; x += grid) {
+    context.beginPath()
+    context.moveTo(x, 0)
+    context.lineTo(x + height, height)
+    context.stroke()
+  }
+
+  const iconSize = Math.max(20, Math.min(40, Math.min(width, height) * 0.25))
+  const iconX = width / 2 - iconSize / 2
+  const textVisible = width >= 128 && height >= 76
+  const iconY = height / 2 - iconSize / 2 - (textVisible ? 10 : 0)
+  context.strokeStyle = '#727781'
+  context.lineWidth = Math.max(1.5, iconSize / 16)
+  context.setLineDash([])
+  context.strokeRect(iconX, iconY, iconSize, iconSize * 0.78)
+  context.beginPath()
+  context.arc(
+    iconX + iconSize * 0.72,
+    iconY + iconSize * 0.22,
+    iconSize * 0.08,
+    0,
+    Math.PI * 2,
+  )
+  context.stroke()
+  context.beginPath()
+  context.moveTo(iconX + iconSize * 0.08, iconY + iconSize * 0.68)
+  context.lineTo(iconX + iconSize * 0.34, iconY + iconSize * 0.42)
+  context.lineTo(iconX + iconSize * 0.52, iconY + iconSize * 0.58)
+  context.lineTo(iconX + iconSize * 0.66, iconY + iconSize * 0.47)
+  context.lineTo(iconX + iconSize * 0.92, iconY + iconSize * 0.68)
+  context.stroke()
+
+  if (textVisible) {
+    context.fillStyle = '#a7abb3'
+    context.font = '500 12px Inter, system-ui, sans-serif'
+    context.textAlign = 'center'
+    context.textBaseline = 'middle'
+    context.fillText(message, width / 2, iconY + iconSize + 14)
+  }
+
+  context.strokeStyle = '#40434a'
+  context.lineWidth = 1
+  context.setLineDash([6, 5])
+  context.strokeRect(0.5, 0.5, Math.max(0, width - 1), Math.max(0, height - 1))
+  context.setLineDash([])
+}
+
+function PaperShaderStatusCanvas({
+  hostRef,
+  registerSource,
+  nodeId,
+  message,
+  processing,
+  minPixelRatio,
+  maxPixelCount,
+  style,
+}: {
+  hostRef: MutableRefObject<PaperShaderHost | null>
+  registerSource: boolean
+  nodeId: string
+  message: string
+  processing: boolean
+  minPixelRatio?: number
+  maxPixelCount?: number
+  style?: CSSProperties
+}) {
+  const statusRef = useRef<HTMLDivElement | null>(null)
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+
+  useLayoutEffect(() => {
+    const mount = resolvePaperShaderStatusMount(
+      statusRef.current,
+      hostRef.current,
+    )
+    const canvas = canvasRef.current
+    if (!mount || !canvas) return
+
+    const draw = () => {
+      const bounds = mount.measureElement.getBoundingClientRect()
+      const width = Math.max(1, bounds.width)
+      const height = Math.max(1, bounds.height)
+      const ratio = placeholderPixelRatio(
+        width,
+        height,
+        minPixelRatio,
+        maxPixelCount,
+      )
+      drawShaderStatusPlaceholder(canvas, width, height, ratio, message)
+      if (
+        registerSource &&
+        publishPaperShaderSource(nodeId, mount.publishElement) &&
+        paperShaderSourceBelongsTo(nodeId, mount.publishElement)
+      ) {
+        notifyPaperShaderSourceChanged()
+      }
+    }
+
+    draw()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(draw)
+    observer.observe(mount.measureElement)
+    return () => observer.disconnect()
+  }, [
+    hostRef,
+    maxPixelCount,
+    message,
+    minPixelRatio,
+    nodeId,
+    registerSource,
+  ])
+
+  return (
+    <div
+      ref={statusRef}
+      data-paper-shader-missing-source={processing ? undefined : nodeId}
+      data-paper-shader-processing={processing ? nodeId : undefined}
+      role="img"
+      aria-label={message}
+      style={{
+        width: '100%',
+        height: '100%',
+        overflow: 'hidden',
+        borderRadius: 'inherit',
+        ...style,
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        style={{ display: 'block', width: '100%', height: '100%' }}
+      />
+    </div>
+  )
+}
+
+function PaperShaderCanvas({
+  node,
+  playhead,
+  source,
+  registerSource = false,
+  minPixelRatio,
+  maxPixelCount,
+  style,
+}: {
+  node: ShaderNode
+  playhead: number
+  source?: string
+  registerSource?: boolean
+  minPixelRatio?: number
+  maxPixelCount?: number
+  style?: CSSProperties
+}) {
+  const hostRef = useRef<PaperShaderHost | null>(null)
+  const shaderRef = useRef<PaperShaderElement | null>(null)
+  const frame = paperShaderFrame(node, playhead)
+  const missingRequiredSource = paperShaderNeedsImageSource(node, source)
+  const renderer = getPaperShaderRenderer(node.shaderType)
+  const ShaderComponent = renderer.component
+  const runtimeParams = paperShaderRuntimeParams(node, playhead, source)
+  const parameterSignature = useMemo(
+    () =>
+      JSON.stringify([
+        node.shaderType,
+        node.colors,
+        node.params,
+        node.scale,
+        node.distortion,
+        node.swirl,
+        node.grain,
+      ]),
+    [
+      node.colors,
+      node.distortion,
+      node.grain,
+      node.params,
+      node.scale,
+      node.shaderType,
+      node.swirl,
+    ],
+  )
+
+  useLayoutEffect(() => {
+    if (missingRequiredSource) return
+    shaderRef.current?.paperShaderMount?.setFrame(frame)
+  }, [frame, missingRequiredSource])
+
+  useEffect(() => {
+    if (!registerSource) return
+    const host = hostRef.current
+    if (!host) return
+
+    let firstFrame = 0
+    let settledFrame = 0
+    const publish = () => {
+      const canvas = publishPaperShaderSource(node.id, host)
+      if (!canvas) return
+      // ResizeObserver updates Paper's drawing buffer after the mount enters
+      // layout. Publish again two paints later so Three replaces its fallback
+      // gradient with the correctly sized source rather than the default
+      // 300×150 WebGL canvas.
+      firstFrame = requestAnimationFrame(() => {
+        settledFrame = requestAnimationFrame(() => {
+          if (paperShaderSourceBelongsTo(node.id, host)) {
+            notifyPaperShaderSourceChanged()
+          }
+        })
+      })
+    }
+
+    publish()
+    const observer = new MutationObserver(publish)
+    observer.observe(host, { childList: true, subtree: true })
+    return () => {
+      observer.disconnect()
+      cancelAnimationFrame(firstFrame)
+      cancelAnimationFrame(settledFrame)
+      removePaperShaderSource(node.id, host)
+    }
+  }, [
+    missingRequiredSource,
+    node.id,
+    node.shaderType,
+    registerSource,
+  ])
+
+  useEffect(() => {
+    if (!registerSource) return
+    // The Paper React wrapper applies changed uniforms in a passive effect.
+    // Notify Three on the following paint so its cached CanvasTexture is
+    // refreshed only after those uniforms reach the source WebGL context.
+    const id = requestAnimationFrame(() => {
+      const host = hostRef.current
+      if (!host || !publishPaperShaderSource(node.id, host)) return
+      notifyPaperShaderSourceChanged()
+    })
+    return () => cancelAnimationFrame(id)
+  }, [
+    frame,
+    node.id,
+    parameterSignature,
+    source,
+    minPixelRatio,
+    maxPixelCount,
+    registerSource,
+  ])
+
+  useEffect(() => {
+    if (!registerSource || !source || missingRequiredSource) return
+    // Image effects may replace an asynchronously processed mask/texture after
+    // their first paint. Refresh Three at a few bounded checkpoints so paused
+    // previews and headless sources do not remain on Paper's transparent pixel.
+    const delays = [50, 150, 350, 750, 1500, 3000]
+    const timers = delays.map((delay) =>
+      window.setTimeout(() => {
+        const host = hostRef.current
+        if (!host || !publishPaperShaderSource(node.id, host)) return
+        notifyPaperShaderSourceChanged()
+      }, delay),
+    )
+    return () => timers.forEach((timer) => window.clearTimeout(timer))
+  }, [
+    missingRequiredSource,
+    node.id,
+    node.shaderType,
+    registerSource,
+    source,
+  ])
+
+  return (
+    <div
+      ref={hostRef}
+      data-paper-shader-host={node.id}
+      style={{
+        width: '100%',
+        height: '100%',
+        overflow: 'hidden',
+        borderRadius: 'inherit',
+        ...style,
+      }}
+    >
+      {missingRequiredSource ? (
+        <PaperShaderStatusCanvas
+          hostRef={hostRef}
+          registerSource={registerSource}
+          nodeId={node.id}
+          message="Add image source"
+          processing={false}
+          minPixelRatio={minPixelRatio}
+          maxPixelCount={maxPixelCount}
+        />
+      ) : (
+        <Suspense
+          fallback={
+            <PaperShaderStatusCanvas
+              hostRef={hostRef}
+              registerSource={registerSource}
+              nodeId={node.id}
+              message="Preparing image"
+              processing
+              minPixelRatio={minPixelRatio}
+              maxPixelCount={maxPixelCount}
+            />
+          }
+        >
+          <ShaderComponent
+            {...runtimeParams}
+            ref={shaderRef as Ref<PaperShaderElement>}
+            minPixelRatio={minPixelRatio}
+            maxPixelCount={maxPixelCount}
+            width="100%"
+            height="100%"
+            webGlContextAttributes={PAPER_WEBGL_ATTRIBUTES}
+            style={{
+              display: 'block',
+              width: '100%',
+              height: '100%',
+              overflow: 'hidden',
+              borderRadius: 'inherit',
+            }}
+          />
+        </Suspense>
+      )}
+    </div>
+  )
+}
+
+export function PaperShaderRenderQualityProvider({
+  minPixelRatio,
+  maxPixelCount,
+  children,
+}: PaperShaderRenderQuality & { children: ReactNode }) {
+  const value = useMemo(
+    () => ({ minPixelRatio, maxPixelCount }),
+    [minPixelRatio, maxPixelCount],
+  )
+  return (
+    <PaperShaderRenderQualityContext.Provider value={value}>
+      {children}
+    </PaperShaderRenderQualityContext.Provider>
+  )
+}
+
+/** Live DOM/fallback renderer for a visible shader node. */
+export function LivePaperShaderCanvas({ node }: { node: ShaderNode }) {
+  const api = useSceneAPI()
+  useSceneVersion()
+  const quality = useContext(PaperShaderRenderQualityContext)
+  const playing = useUI((state) => state.playing)
+  const pausedPlayhead = useUI((state) => state.playhead)
+  const playbackPlayhead = useAnimationPlaybackClock(
+    playing && node.speed > 0.0001,
+  )
+  const source = resolvePaperShaderSource(node, api)
+  return (
+    <PaperShaderCanvas
+      node={node}
+      playhead={playing ? playbackPlayhead : pausedPlayhead}
+      source={source}
+      minPixelRatio={quality.minPixelRatio}
+      maxPixelCount={quality.maxPixelCount}
+      style={{ pointerEvents: 'none' }}
+    />
+  )
+}
+
+/**
+ * Invisible source mounts used by the camera/Three path. The mounts remain in
+ * layout (far outside the captured viewport) so Paper's ResizeObserver can
+ * choose a real drawing-buffer size. `display:none` and `visibility:hidden`
+ * are deliberately avoided because both collapse or suppress WebGL output.
+ */
+export function PaperShaderSourceLayer({
+  api,
+  layout,
+  sceneVersion,
+  minPixelRatio,
+  maxPixelCount,
+}: {
+  api: SceneAPI
+  layout: SolvedLayout
+  sceneVersion: number
+  minPixelRatio?: number
+  maxPixelCount?: number
+}) {
+  const entries = useMemo(() => {
+    void sceneVersion
+    return api.getAllNodeIds().flatMap((id) => {
+      const node = api.getNode(id)
+      const rect = layout[id]
+      return node?.kind === 'shader' && node.visible && rect
+        ? [{ node, rect, source: resolvePaperShaderSource(node, api) }]
+        : []
+    })
+  }, [api, layout, sceneVersion])
+  const playing = useUI((state) => state.playing)
+  const pausedPlayhead = useUI((state) => state.playhead)
+  const hasMotion = entries.some(({ node }) => node.speed > 0.0001)
+  const playbackPlayhead = useAnimationPlaybackClock(playing && hasMotion)
+  const playhead = playing ? playbackPlayhead : pausedPlayhead
+
+  if (entries.length === 0) return null
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: 'fixed',
+        left: -100000,
+        top: 0,
+        width: 1,
+        height: 1,
+        overflow: 'visible',
+        opacity: 0,
+        pointerEvents: 'none',
+      }}
+    >
+      {entries.map(({ node, rect, source }) => (
+        <div
+          key={node.id}
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            width: Math.max(1, rect.width),
+            height: Math.max(1, rect.height),
+          }}
+        >
+          <PaperShaderCanvas
+            node={node}
+            playhead={playhead}
+            source={source}
+            registerSource
+            minPixelRatio={minPixelRatio}
+            maxPixelCount={maxPixelCount}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/render/RenderWindowApp.tsx
+++ b/src/render/RenderWindowApp.tsx
@@ -23,6 +23,11 @@ import {
 import { ThreeSceneViewport } from '@/render3d/ThreeSceneViewport'
 import { resolveFallbackCameraPostEffects } from '@/render/cameraPostEffectsFallbackState'
 import { resolveCameraDomProjection } from '@/render/cameraDomProjection'
+import {
+  PaperShaderRenderQualityProvider,
+  PaperShaderSourceLayer,
+} from '@/render/PaperShaderLayer'
+import { waitForPaperShadersReady } from '@/render/paperShaderSource'
 import { getAnimEngine } from '@/anim'
 import {
   createElectronCapture,
@@ -409,9 +414,18 @@ function RenderCanvas({ job }: { job: RenderJob }) {
   // resolveDimensions guarantees they match, but defensive math here
   // keeps a misconfigured job from producing letterboxed exports.
   const scale = Math.min(scaleX, scaleY)
+  const paperShaderMinPixelRatio = Math.max(2, scaleX, scaleY)
+  const paperShaderMaxPixelCount = Math.max(
+    1920 * 1080 * 4,
+    job.outputWidth * job.outputHeight,
+  )
 
   return (
-    <div
+    <PaperShaderRenderQualityProvider
+      minPixelRatio={paperShaderMinPixelRatio}
+      maxPixelCount={paperShaderMaxPixelCount}
+    >
+      <div
       // Black backdrop fills the window completely — any window pixels
       // outside the artboard (shouldn't happen if main sized correctly,
       // but defensive) will encode as flat black, not random GPU
@@ -426,6 +440,17 @@ function RenderCanvas({ job }: { job: RenderJob }) {
         overflow: 'hidden',
       }}
     >
+      {solved &&
+      camera?.kind === 'camera' &&
+      threeCameraAvailable ? (
+        <PaperShaderSourceLayer
+          api={api}
+          layout={solved}
+          sceneVersion={version}
+          minPixelRatio={paperShaderMinPixelRatio}
+          maxPixelCount={paperShaderMaxPixelCount}
+        />
+      ) : null}
       <div
         data-canvas-root
         data-render-camera-backend={
@@ -469,33 +494,27 @@ function RenderCanvas({ job }: { job: RenderJob }) {
             className="absolute inset-0"
             style={{ transformStyle: 'preserve-3d' }}
           >
-            <div
-              className="absolute inset-0"
-              style={{
-                opacity: threeCameraAvailable ? 0 : 1,
-                transformStyle: 'preserve-3d',
-              }}
-            >
-              <ScenePostProcessLayer
-                rootId={rootId}
-                solved={solved}
-                order={renderOrder}
-                animated={animated}
-                inherited={inherited}
-                cameraDepthOfField={threeCameraAvailable ? null : cameraDepthOfField}
-                cameraPostEffects={
-                  threeCameraAvailable ? null : cameraPostEffects
-                }
-                sceneFill={sceneFill}
-                canvasWidth={canvasWidth}
-                canvasHeight={canvasHeight}
-                sceneCorner={sceneCorner}
-                includeSceneFill
-                textureSource
-                sceneContentStyle={
-                  threeCameraAvailable
-                    ? undefined
-                    : cameraTransform
+            {!threeCameraAvailable ? (
+              <div
+                className="absolute inset-0"
+                style={{ transformStyle: 'preserve-3d' }}
+              >
+                <ScenePostProcessLayer
+                  rootId={rootId}
+                  solved={solved}
+                  order={renderOrder}
+                  animated={animated}
+                  inherited={inherited}
+                  cameraDepthOfField={cameraDepthOfField}
+                  cameraPostEffects={cameraPostEffects}
+                  sceneFill={sceneFill}
+                  canvasWidth={canvasWidth}
+                  canvasHeight={canvasHeight}
+                  sceneCorner={sceneCorner}
+                  includeSceneFill
+                  textureSource
+                  sceneContentStyle={
+                    cameraTransform
                       ? {
                           transform: cameraTransform,
                           transformOrigin: '0 0',
@@ -503,9 +522,10 @@ function RenderCanvas({ job }: { job: RenderJob }) {
                           backfaceVisibility: 'visible',
                         }
                       : undefined
-                }
-              />
-            </div>
+                  }
+                />
+              </div>
+            ) : null}
             <ThreeSceneViewport
               api={api}
               layout={solved}
@@ -556,7 +576,8 @@ function RenderCanvas({ job }: { job: RenderJob }) {
           </>
         )}
       </div>
-    </div>
+      </div>
+    </PaperShaderRenderQualityProvider>
   )
 }
 
@@ -601,6 +622,17 @@ async function runExportLoop(
   // solve has fully committed + the canvas has painted at least once
   // before the first capture.
   await waitForFrames(4)
+  const paperShadersReady = await waitForPaperShadersReady()
+  if (!paperShadersReady) {
+    reportError(
+      requestId,
+      'A Paper shader image could not be prepared for export. Check its source image and CORS access, then try again.',
+    )
+    return
+  }
+  // Paper's processed object URL still needs to reach ShaderMount and paint
+  // into its WebGL canvas after Suspense resolves.
+  await waitForFrames(3)
 
   const sceneCanvas = {
     width: api.getMeta().canvas?.width ?? job.outputWidth,

--- a/src/render/cameraPostEffectsFallbackState.ts
+++ b/src/render/cameraPostEffectsFallbackState.ts
@@ -26,6 +26,11 @@ export function resolveFallbackCameraPostEffects(
     bloomStrength: animated?.bloomStrength ?? camera.bloomStrength,
     bloomRadius: animated?.bloomRadius ?? camera.bloomRadius,
     bloomThreshold: animated?.bloomThreshold ?? camera.bloomThreshold,
+    vhsEnabled: camera.vhsEnabled,
+    vhsIntensity: animated?.vhsIntensity ?? camera.vhsIntensity,
+    vhsNoise: animated?.vhsNoise ?? camera.vhsNoise,
+    vhsScanlines: animated?.vhsScanlines ?? camera.vhsScanlines,
+    vhsColorBleed: animated?.vhsColorBleed ?? camera.vhsColorBleed,
   })
 }
 

--- a/src/render/paperShaderRegistry.test.ts
+++ b/src/render/paperShaderRegistry.test.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { createSceneAPI, type SceneAPI } from '@/scene/doc'
+import type { Node } from '@/scene/types'
+import { PAPER_SHADER_TYPES } from '@/scene/paperShaders'
+import {
+  PAPER_SHADER_RENDERERS,
+  getPaperShaderRenderer,
+  paperShaderFrame,
+  paperShaderNeedsImageSource,
+  paperShaderRuntimeParams,
+  resolvePaperShaderSource,
+} from './paperShaderRegistry'
+
+type ShaderNode = Extract<Node, { kind: 'shader' }>
+
+function createShader(
+  api: SceneAPI,
+  props: Partial<ShaderNode> = {},
+): ShaderNode {
+  const id = api.createNode('shader', null, props)
+  const node = api.getNode(id)
+  if (!node || node.kind !== 'shader') throw new Error('Expected shader node')
+  return node
+}
+
+describe('Paper shader renderer registry', () => {
+  it('maps all 29 stable scene ids to Paper components and Default presets', () => {
+    expect(Object.keys(PAPER_SHADER_RENDERERS)).toEqual([
+      ...PAPER_SHADER_TYPES,
+    ])
+
+    for (const type of PAPER_SHADER_TYPES) {
+      const entry = getPaperShaderRenderer(type)
+      expect(entry.component).toBeTruthy()
+      expect(entry.defaultParams).toEqual(expect.any(Object))
+    }
+
+    expect(
+      getPaperShaderRenderer('mesh-gradient').defaultParams,
+    ).toMatchObject({
+      colors: ['#e0eaff', '#241d9a', '#f75092', '#9f50d3'],
+      distortion: 0.8,
+      swirl: 0.1,
+    })
+  })
+
+  it('freezes Paper wall-clock motion and derives every frame from scene time', () => {
+    const api = createSceneAPI()
+
+    for (const type of PAPER_SHADER_TYPES) {
+      const node = createShader(api, {
+        shaderType: type,
+        speed: 1.25,
+      })
+      const params = paperShaderRuntimeParams(node, 2.5)
+      expect(params.speed, type).toBe(0)
+      expect(params.frame, type).toBe(3125)
+      expect(params.scale, type).toBe(node.scale)
+      expect(paperShaderFrame(node, -10), type).toBe(0)
+    }
+
+    const invalid = createShader(api)
+    invalid.speed = Number.NaN
+    expect(paperShaderFrame(invalid, Number.POSITIVE_INFINITY)).toBe(0)
+  })
+
+  it('applies scene params over the official preset without forwarding unknown props', () => {
+    const api = createSceneAPI()
+    const node = createShader(api, {
+      shaderType: 'mesh-gradient',
+      colors: ['#001122', '#ddeeff'],
+      scale: 1.75,
+      params: {
+        distortion: 0.35,
+        swirl: 0.25,
+        grainOverlay: 0.15,
+        unsafeDomProp: 'do-not-forward',
+      },
+    })
+
+    expect(paperShaderRuntimeParams(node, 1)).toMatchObject({
+      colors: ['#001122', '#ddeeff'],
+      distortion: 0.35,
+      swirl: 0.25,
+      grainOverlay: 0.15,
+      scale: 1.75,
+      speed: 0,
+      frame: 600,
+    })
+    expect(
+      paperShaderRuntimeParams(node, 1, 'data:image/png;base64,abc').image,
+    ).toBeUndefined()
+    expect(
+      paperShaderRuntimeParams(node, 1).unsafeDomProp,
+    ).toBeUndefined()
+  })
+
+  it('contains Paper image preprocessing in the renderer Suspense boundary', () => {
+    const api = createSceneAPI()
+    for (const type of ['liquid-metal', 'gem-smoke', 'heatmap'] as const) {
+      const node = createShader(api, { shaderType: type })
+      const params = paperShaderRuntimeParams(
+        node,
+        0,
+        'data:image/png;base64,abc',
+      )
+      expect(params.suspendWhenProcessingImage, type).toBe(true)
+      expect(params.image, type).toBe('data:image/png;base64,abc')
+      expect(
+        paperShaderRuntimeParams(node, 0).suspendWhenProcessingImage,
+        type,
+      ).toBe(false)
+    }
+  })
+})
+
+describe('Paper shader image sources', () => {
+  it('prefers an embedded source, then resolves an image layer through SceneAPI', () => {
+    const api = createSceneAPI()
+    const imageId = api.createNode('image', null, {
+      src: '  data:image/png;base64,layer  ',
+    })
+
+    const linked = createShader(api, {
+      shaderType: 'halftone-dots',
+      sourceNodeId: imageId,
+    })
+    expect(resolvePaperShaderSource(linked, api)).toBe(
+      'data:image/png;base64,layer',
+    )
+
+    const embedded = createShader(api, {
+      shaderType: 'halftone-dots',
+      sourceNodeId: imageId,
+      sourceImage: '  data:image/png;base64,embedded  ',
+    })
+    expect(resolvePaperShaderSource(embedded, api)).toBe(
+      'data:image/png;base64,embedded',
+    )
+  })
+
+  it('rejects missing and non-image source layers', () => {
+    const api = createSceneAPI()
+    const rectId = api.createNode('rect', null)
+    expect(
+      resolvePaperShaderSource(
+        createShader(api, {
+          shaderType: 'fluted-glass',
+          sourceNodeId: rectId,
+        }),
+        api,
+      ),
+    ).toBeUndefined()
+    expect(
+      resolvePaperShaderSource(
+        createShader(api, {
+          shaderType: 'fluted-glass',
+          sourceNodeId: 'missing-node',
+        }),
+        api,
+      ),
+    ).toBeUndefined()
+  })
+
+  it('requires sources for the five Paper image filters but not generated shapes', () => {
+    const api = createSceneAPI()
+    const required = [
+      'fluted-glass',
+      'image-dithering',
+      'halftone-dots',
+      'halftone-cmyk',
+      'heatmap',
+    ] as const
+
+    for (const type of required) {
+      const node = createShader(api, { shaderType: type })
+      expect(paperShaderNeedsImageSource(node), type).toBe(true)
+      expect(paperShaderNeedsImageSource(node, '   '), type).toBe(true)
+      expect(
+        paperShaderNeedsImageSource(node, 'data:image/png;base64,abc'),
+        type,
+      ).toBe(false)
+    }
+
+    expect(
+      paperShaderNeedsImageSource(
+        createShader(api, { shaderType: 'liquid-metal' }),
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/render/paperShaderRegistry.ts
+++ b/src/render/paperShaderRegistry.ts
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ComponentType, Ref } from 'react'
+import {
+  ColorPanels,
+  Dithering,
+  DotGrid,
+  DotOrbit,
+  FlutedGlass,
+  GemSmoke,
+  GodRays,
+  GrainGradient,
+  HalftoneCmyk,
+  HalftoneDots,
+  Heatmap,
+  ImageDithering,
+  LiquidMetal,
+  MeshGradient,
+  Metaballs,
+  NeuroNoise,
+  PaperTexture,
+  PerlinNoise,
+  PulsingBorder,
+  SimplexNoise,
+  SmokeRing,
+  Spiral,
+  StaticMeshGradient,
+  StaticRadialGradient,
+  Swirl,
+  Voronoi,
+  Warp,
+  Water,
+  Waves,
+  colorPanelsPresets,
+  ditheringPresets,
+  dotGridPresets,
+  dotOrbitPresets,
+  flutedGlassPresets,
+  gemSmokePresets,
+  godRaysPresets,
+  grainGradientPresets,
+  halftoneCmykPresets,
+  halftoneDotsPresets,
+  heatmapPresets,
+  imageDitheringPresets,
+  liquidMetalPresets,
+  meshGradientPresets,
+  metaballsPresets,
+  neuroNoisePresets,
+  paperTexturePresets,
+  perlinNoisePresets,
+  pulsingBorderPresets,
+  simplexNoisePresets,
+  smokeRingPresets,
+  spiralPresets,
+  staticMeshGradientPresets,
+  staticRadialGradientPresets,
+  swirlPresets,
+  voronoiPresets,
+  warpPresets,
+  waterPresets,
+  wavesPresets,
+  type PaperShaderElement,
+} from '@paper-design/shaders-react'
+import type { SceneAPI } from '@/scene'
+import type { Node, PaperShaderType } from '@/scene'
+import { getPaperShaderDefinition } from '@/scene/paperShaders'
+
+type ShaderNode = Extract<Node, { kind: 'shader' }>
+
+type PaperRuntimeProps = Record<string, unknown> & {
+  ref?: Ref<PaperShaderElement>
+}
+
+export type PaperShaderRuntimeComponent = ComponentType<PaperRuntimeProps>
+
+interface PaperPreset {
+  params: Record<string, unknown>
+}
+
+export interface PaperShaderRendererDefinition {
+  component: PaperShaderRuntimeComponent
+  defaultParams: Readonly<Record<string, unknown>>
+}
+
+function renderer(
+  component: unknown,
+  presets: readonly unknown[],
+): PaperShaderRendererDefinition {
+  const firstPreset = presets[0] as PaperPreset | undefined
+  return {
+    component: component as PaperShaderRuntimeComponent,
+    defaultParams: firstPreset?.params ?? {},
+  }
+}
+
+/**
+ * Exhaustive bridge from stable scene ids to the pinned Paper React exports.
+ * The `satisfies` clause makes a newly-added scene id a compile error until
+ * its renderer is deliberately wired up.
+ */
+export const PAPER_SHADER_RENDERERS = {
+  'mesh-gradient': renderer(MeshGradient, meshGradientPresets),
+  'smoke-ring': renderer(SmokeRing, smokeRingPresets),
+  'neuro-noise': renderer(NeuroNoise, neuroNoisePresets),
+  'dot-orbit': renderer(DotOrbit, dotOrbitPresets),
+  'dot-grid': renderer(DotGrid, dotGridPresets),
+  'simplex-noise': renderer(SimplexNoise, simplexNoisePresets),
+  metaballs: renderer(Metaballs, metaballsPresets),
+  waves: renderer(Waves, wavesPresets),
+  'perlin-noise': renderer(PerlinNoise, perlinNoisePresets),
+  voronoi: renderer(Voronoi, voronoiPresets),
+  warp: renderer(Warp, warpPresets),
+  'god-rays': renderer(GodRays, godRaysPresets),
+  spiral: renderer(Spiral, spiralPresets),
+  swirl: renderer(Swirl, swirlPresets),
+  dithering: renderer(Dithering, ditheringPresets),
+  'grain-gradient': renderer(GrainGradient, grainGradientPresets),
+  'pulsing-border': renderer(PulsingBorder, pulsingBorderPresets),
+  'color-panels': renderer(ColorPanels, colorPanelsPresets),
+  'static-mesh-gradient': renderer(
+    StaticMeshGradient,
+    staticMeshGradientPresets,
+  ),
+  'static-radial-gradient': renderer(
+    StaticRadialGradient,
+    staticRadialGradientPresets,
+  ),
+  'paper-texture': renderer(PaperTexture, paperTexturePresets),
+  'fluted-glass': renderer(FlutedGlass, flutedGlassPresets),
+  water: renderer(Water, waterPresets),
+  'image-dithering': renderer(ImageDithering, imageDitheringPresets),
+  'halftone-dots': renderer(HalftoneDots, halftoneDotsPresets),
+  'halftone-cmyk': renderer(HalftoneCmyk, halftoneCmykPresets),
+  heatmap: renderer(Heatmap, heatmapPresets),
+  'liquid-metal': renderer(LiquidMetal, liquidMetalPresets),
+  'gem-smoke': renderer(GemSmoke, gemSmokePresets),
+} satisfies Record<PaperShaderType, PaperShaderRendererDefinition>
+
+export function getPaperShaderRenderer(
+  shaderType: PaperShaderType,
+): PaperShaderRendererDefinition {
+  return PAPER_SHADER_RENDERERS[shaderType]
+}
+
+export function paperShaderFrame(node: ShaderNode, playhead: number): number {
+  const safePlayhead = Number.isFinite(playhead) ? Math.max(0, playhead) : 0
+  const safeSpeed = Number.isFinite(node.speed) ? Math.max(0, node.speed) : 0
+  return safePlayhead * 1000 * safeSpeed
+}
+
+function finiteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+/**
+ * Builds the Paper props from its official Default preset, then applies
+ * persisted scene values. Only keys known to the pinned preset are forwarded;
+ * renderer-owned props such as frame, image, ref, and WebGL attributes are
+ * always assigned by the host layer.
+ */
+export function paperShaderRuntimeParams(
+  node: ShaderNode,
+  playhead: number,
+  source?: string,
+): Record<string, unknown> {
+  const rendererDefinition = getPaperShaderRenderer(node.shaderType)
+  const defaults = rendererDefinition.defaultParams
+  const params: Record<string, unknown> = { ...defaults }
+  const resolvedSource = source?.trim() || undefined
+
+  for (const key of Object.keys(defaults)) {
+    const value = node.params[key]
+    if (value !== undefined) params[key] = value
+  }
+
+  if ('colors' in defaults && node.colors.length > 0) {
+    params.colors = node.colors
+  }
+  if (finiteNumber(node.scale)) params.scale = node.scale
+
+  // Original Mesh Gradient scenes predate the generic `params` bag. Preserve
+  // those authored values unless a newer scene explicitly sets the same prop.
+  if (node.shaderType === 'mesh-gradient') {
+    if (node.params.distortion === undefined && finiteNumber(node.distortion)) {
+      params.distortion = node.distortion
+    }
+    if (node.params.swirl === undefined && finiteNumber(node.swirl)) {
+      params.swirl = node.swirl
+    }
+    if (node.params.grainOverlay === undefined && finiteNumber(node.grain)) {
+      params.grainOverlay = node.grain
+    }
+  }
+
+  // Paper normally advances from wall-clock time. Hyper Motion owns time, so
+  // the shader is frozen internally and receives an exact timeline frame.
+  params.speed = 0
+  params.frame = paperShaderFrame(node, playhead)
+
+  if (
+    resolvedSource &&
+    getPaperShaderDefinition(node.shaderType).acceptsImage
+  ) {
+    params.image = resolvedSource
+  } else {
+    delete params.image
+  }
+
+  if (paperShaderCanPreprocessImage(node)) {
+    // Paper's preprocessing promise is contained by PaperShaderLayer's local
+    // Suspense boundary. Without a source, Liquid Metal and Gem Smoke retain
+    // their built-in procedural shapes and must not suspend.
+    params.suspendWhenProcessingImage = Boolean(resolvedSource)
+  }
+
+  return params
+}
+
+export function paperShaderCanPreprocessImage(node: ShaderNode): boolean {
+  return (
+    node.shaderType === 'liquid-metal' ||
+    node.shaderType === 'gem-smoke' ||
+    node.shaderType === 'heatmap'
+  )
+}
+
+export function resolvePaperShaderSource(
+  node: ShaderNode,
+  api?: Pick<SceneAPI, 'getNode'>,
+): string | undefined {
+  const embedded = node.sourceImage?.trim()
+  if (embedded) return embedded
+
+  const sourceId = node.sourceNodeId?.trim()
+  if (!sourceId || !api) return undefined
+  const sourceNode = api.getNode(sourceId)
+  if (sourceNode?.kind !== 'image') return undefined
+  const source = sourceNode.src.trim()
+  return source || undefined
+}
+
+export function paperShaderNeedsImageSource(
+  node: ShaderNode,
+  source?: string,
+): boolean {
+  return (
+    getPaperShaderDefinition(node.shaderType).requiresImage &&
+    !source?.trim()
+  )
+}

--- a/src/render/paperShaderSource.test.ts
+++ b/src/render/paperShaderSource.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { resolvePaperShaderStatusMount } from './paperShaderSource'
+
+describe('Paper shader status mount', () => {
+  it('measures the local status wrapper when the parent ref is not attached yet', () => {
+    const parent = {} as HTMLElement
+    const status = { parentElement: parent } as HTMLElement
+
+    expect(resolvePaperShaderStatusMount(status, null)).toEqual({
+      measureElement: status,
+      publishElement: parent,
+    })
+  })
+
+  it('publishes through the stable shared host once it is available', () => {
+    const parent = {} as HTMLElement
+    const sharedHost = {} as HTMLElement
+    const status = { parentElement: parent } as HTMLElement
+
+    expect(resolvePaperShaderStatusMount(status, sharedHost)).toEqual({
+      measureElement: status,
+      publishElement: sharedHost,
+    })
+  })
+
+  it('returns null until the local status wrapper has mounted', () => {
+    expect(resolvePaperShaderStatusMount(null, null)).toBeNull()
+  })
+})

--- a/src/render/paperShaderSource.ts
+++ b/src/render/paperShaderSource.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { NodeId } from '@/scene'
+
+interface PaperShaderSource {
+  canvas: HTMLCanvasElement
+  host: HTMLElement
+}
+
+const PAPER_SHADER_SOURCE_EVENT = 'hypermotion:paper-shader-source'
+export const PAPER_SHADER_PROCESSING_SELECTOR =
+  '[data-paper-shader-processing]'
+export const PAPER_SHADER_HOST_SELECTOR = '[data-paper-shader-host]'
+const paperShaderSources = new Map<NodeId, PaperShaderSource>()
+
+export interface PaperShaderStatusMount {
+  /** The status wrapper always exists before its own layout effect runs. */
+  measureElement: HTMLElement
+  /** Prefer the stable shader host so Three's source ownership survives swaps. */
+  publishElement: HTMLElement
+}
+
+export function resolvePaperShaderStatusMount(
+  statusElement: HTMLElement | null,
+  sharedHost: HTMLElement | null,
+): PaperShaderStatusMount | null {
+  if (!statusElement) return null
+  return {
+    measureElement: statusElement,
+    publishElement:
+      sharedHost ?? statusElement.parentElement ?? statusElement,
+  }
+}
+
+export function getPaperShaderSourceCanvas(
+  nodeId: NodeId,
+): HTMLCanvasElement | null {
+  return paperShaderSources.get(nodeId)?.canvas ?? null
+}
+
+export function paperShaderSourceEventName(): string {
+  return PAPER_SHADER_SOURCE_EVENT
+}
+
+export function publishPaperShaderSource(
+  nodeId: NodeId,
+  host: HTMLElement,
+): HTMLCanvasElement | null {
+  const canvas = host.querySelector('canvas')
+  if (!(canvas instanceof HTMLCanvasElement)) return null
+  const previous = paperShaderSources.get(nodeId)
+  paperShaderSources.set(nodeId, { canvas, host })
+  if (previous?.canvas !== canvas) notifyPaperShaderSourceChanged()
+  return canvas
+}
+
+export function paperShaderSourceBelongsTo(
+  nodeId: NodeId,
+  host: HTMLElement,
+): boolean {
+  return paperShaderSources.get(nodeId)?.host === host
+}
+
+export function removePaperShaderSource(
+  nodeId: NodeId,
+  host: HTMLElement,
+): void {
+  if (!paperShaderSourceBelongsTo(nodeId, host)) return
+  paperShaderSources.delete(nodeId)
+  notifyPaperShaderSourceChanged()
+}
+
+export function notifyPaperShaderSourceChanged(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event(PAPER_SHADER_SOURCE_EVENT))
+}
+
+export function paperShadersAreReady(
+  root: ParentNode = document,
+): boolean {
+  if (root.querySelector(PAPER_SHADER_PROCESSING_SELECTOR)) return false
+  return Array.from(root.querySelectorAll(PAPER_SHADER_HOST_SELECTOR)).every(
+    (host) => host.querySelector('canvas') !== null,
+  )
+}
+
+/**
+ * Wait for Paper's async mask preprocessors to leave their local Suspense
+ * fallbacks. Call after the render tree has mounted (the export window already
+ * waits for initial animation frames before capture).
+ *
+ * Resolves `false` on timeout so callers can surface a useful export error
+ * instead of hanging indefinitely on an invalid/CORS-blocked source.
+ */
+export function waitForPaperShadersReady(
+  timeoutMs = 10_000,
+  root: ParentNode = document,
+): Promise<boolean> {
+  if (paperShadersAreReady(root)) return Promise.resolve(true)
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (ready: boolean) => {
+      if (settled) return
+      settled = true
+      observer.disconnect()
+      window.clearTimeout(timeout)
+      resolve(ready)
+    }
+    const observer = new MutationObserver(() => {
+      if (paperShadersAreReady(root)) finish(true)
+    })
+    observer.observe(root, { childList: true, subtree: true })
+    const timeout = window.setTimeout(() => finish(false), timeoutMs)
+  })
+}

--- a/src/render3d/ThreeSceneViewport.tsx
+++ b/src/render3d/ThreeSceneViewport.tsx
@@ -82,6 +82,11 @@ import {
   updateDepthOfFieldShader,
 } from '@/render3d/depthOfFieldShader'
 import {
+  captureBackdropForMaterial,
+  disposeBackdropBlendMode,
+  setBackdropBlendMode,
+} from '@/render3d/layerBlendMode'
+import {
   PostEffectsIdleQualityController,
   ScenePostEffectsRenderer,
   cameraPostEffectsActive,
@@ -105,6 +110,10 @@ import {
   paintVectorNodeToCanvas,
   vectorTrimState,
 } from '@/render/vectorPaint'
+import {
+  getPaperShaderSourceCanvas,
+  paperShaderSourceEventName,
+} from '@/render/paperShaderSource'
 import { getPreservedVectorSource } from '@/render/vectorSource'
 import { textStaggerCurvePreviewStore } from '@/ui/textStaggerCurvePreviewStore'
 
@@ -340,6 +349,7 @@ function disposePlaneRecord(record: PlaneRecord) {
   record.video?.load()
   record.video = undefined
   record.mesh.geometry.dispose()
+  disposeBackdropBlendMode(record.mesh.material)
   record.mesh.material.dispose()
   record.texture.dispose()
 }
@@ -568,8 +578,15 @@ export function ThreeSceneViewport({
     void sceneVersion
     const ranges = new Map<NodeId, PlayheadDrivenTextureRange>()
     if (!showPlanes) return ranges
+    const duration = Math.max(0, api.getMeta().duration)
     for (const id of api.getAllNodeIds()) {
       const node = api.getNode(id)
+      if (node?.kind === 'shader') {
+        if (node.speed > 0.0001) {
+          ranges.set(id, { start: 0, end: duration })
+        }
+        continue
+      }
       if (node?.kind !== 'text' || !node.textAnimation) continue
       const engineDriven = api
         .getTracksForNode(id)
@@ -607,8 +624,13 @@ export function ThreeSceneViewport({
 
   useEffect(() => {
     const onImageLoaded = () => setImageRevision((revision) => revision + 1)
+    const paperShaderEvent = paperShaderSourceEventName()
     window.addEventListener(IMAGE_TEXTURE_LOADED_EVENT, onImageLoaded)
-    return () => window.removeEventListener(IMAGE_TEXTURE_LOADED_EVENT, onImageLoaded)
+    window.addEventListener(paperShaderEvent, onImageLoaded)
+    return () => {
+      window.removeEventListener(IMAGE_TEXTURE_LOADED_EVENT, onImageLoaded)
+      window.removeEventListener(paperShaderEvent, onImageLoaded)
+    }
   }, [])
 
   useEffect(
@@ -876,6 +898,7 @@ export function ThreeSceneViewport({
         width,
         height,
         postEffectsPixelRatio,
+        playhead,
       )
       if (postEffectsActive) {
         postEffects.render()
@@ -1254,6 +1277,9 @@ function syncPlanes(
       installDepthOfFieldShader(material)
       const mesh = new THREE.Mesh(geometry, material)
       mesh.name = plane.node.name
+      mesh.onBeforeRender = (activeRenderer) => {
+        captureBackdropForMaterial(activeRenderer, material)
+      }
       const outline = makePlaneOutline(plane.rect.width, plane.rect.height)
       scene.add(mesh)
       scene.add(outline)
@@ -1343,7 +1369,14 @@ function syncPlanes(
     applyPlaneTransform(record.outline, plane)
     record.mesh.renderOrder = plane.paintOrder
     record.outline.renderOrder = 100000 + plane.paintOrder
-    applyMaterialBlendMode(record.mesh.material, plane.node.appearance.blendMode)
+    const blendMode =
+      animated[plane.nodeId]?.blendMode ??
+      plane.node.appearance.blendMode
+    if (plane.node.kind === 'shader') {
+      setBackdropBlendMode(record.mesh.material, blendMode)
+    } else {
+      applyMaterialBlendMode(record.mesh.material, blendMode)
+    }
     syncMaterialClipping(record, plane)
     record.mesh.material.opacity = Math.max(0, Math.min(1, plane.opacity))
     record.mesh.visible = plane.node.visible
@@ -1708,7 +1741,10 @@ function syncTextSegmentPlane({
   applyPlaneTransform(record.outline, plane)
   record.mesh.renderOrder = plane.paintOrder
   record.outline.renderOrder = 100000 + plane.paintOrder
-  applyMaterialBlendMode(record.mesh.material, plane.node.appearance.blendMode)
+  applyMaterialBlendMode(
+    record.mesh.material,
+    anim?.blendMode ?? plane.node.appearance.blendMode,
+  )
   syncMaterialClipping(record, plane)
   record.mesh.material.opacity = Math.max(0, Math.min(1, plane.opacity))
   record.mesh.visible = plane.node.visible
@@ -3226,8 +3262,14 @@ function syncMaterialClipping(record: PlaneRecord, plane: Plane3D) {
 }
 
 function clippingSignatureForPlane(plane: Plane3D): string {
-  if (!plane.clips?.length) return 'none'
-  return plane.clips
+  return clippingSignatureForClips(plane.clips)
+}
+
+function clippingSignatureForClips(
+  clips: readonly PlaneClip3D[] | undefined,
+): string {
+  if (!clips?.length) return 'none'
+  return clips
     .map((clip) => [
       clip.center.x,
       clip.center.y,
@@ -3245,8 +3287,14 @@ function clippingSignatureForPlane(plane: Plane3D): string {
 }
 
 function clippingPlanesForPlane(plane: Plane3D): THREE.Plane[] | null {
-  if (!plane.clips?.length) return null
-  return plane.clips.flatMap((clip) => clippingPlanesForClip(clip))
+  return clippingPlanesForClips(plane.clips)
+}
+
+function clippingPlanesForClips(
+  clips: readonly PlaneClip3D[] | undefined,
+): THREE.Plane[] | null {
+  if (!clips?.length) return null
+  return clips.flatMap((clip) => clippingPlanesForClip(clip))
 }
 
 function clippingPlanesForClip(clip: PlaneClip3D): THREE.Plane[] {
@@ -3456,6 +3504,9 @@ function renderPlaneTexture(
     paintFill(ctx, node.appearance.fill, w, h, node.kind === 'text')
     if (node.kind === 'image' && node.src) {
       paintImageNode(ctx, node, w, h)
+    }
+    if (node.kind === 'shader') {
+      paintPaperShaderNode(ctx, node, w, h)
     }
   })
   if (node.kind === 'text') {
@@ -3699,7 +3750,7 @@ function paintNodeIntoSubtree(
   ctx.globalAlpha *= ownOpacity * inherited.opacity
   const previousComposite = ctx.globalCompositeOperation
   ctx.globalCompositeOperation = canvasCompositeForBlendMode(
-    node.appearance.blendMode,
+    anim?.blendMode ?? node.appearance.blendMode,
   )
   ctx.translate(x + inherited.x + tx + w / 2, y + inherited.y + ty + h / 2)
   const inheritedRotation = inherited.rotation + rot
@@ -3794,6 +3845,7 @@ function renderNodePaint(
   withRoundedClip(ctx, w, h, cornerRadius, () => {
     paintFill(ctx, node.appearance.fill, w, h, node.kind === 'text')
     if (node.kind === 'image' && node.src) paintImageNode(ctx, node, w, h)
+    if (node.kind === 'shader') paintPaperShaderNode(ctx, node, w, h)
   })
   if (node.kind === 'text') {
     paintAnimatedTextNode(ctx, node, 0, 0, w, h, anim, playhead)
@@ -3859,6 +3911,40 @@ function paintFill(
     paintImageFill(ctx, fill, width, height)
     return
   }
+}
+
+function paintPaperShaderNode(
+  ctx: CanvasRenderingContext2D,
+  node: Extract<Node, { kind: 'shader' }>,
+  width: number,
+  height: number,
+) {
+  const source = getPaperShaderSourceCanvas(node.id)
+  if (source && source.width > 0 && source.height > 0) {
+    ctx.drawImage(source, 0, 0, width, height)
+    return
+  }
+
+  // Paper's WebGL2 mount initializes after the first scene raster. Keep that
+  // frame useful—and make unsupported-WebGL fallbacks graceful—by painting a
+  // deterministic approximation from the authored colors until the live
+  // source canvas announces readiness.
+  const safeColors = node.colors
+    .filter((color) =>
+      /^#(?:[0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(color),
+    )
+    .slice(0, 10)
+  const colors =
+    safeColors.length > 0 ? safeColors : ['#241d9a', '#f75092']
+  const gradient = ctx.createLinearGradient(0, 0, width, height)
+  colors.forEach((color, index) => {
+    gradient.addColorStop(
+      colors.length === 1 ? 0 : index / (colors.length - 1),
+      color,
+    )
+  })
+  ctx.fillStyle = gradient
+  ctx.fillRect(0, 0, width, height)
 }
 
 function canvasLinearGradient(

--- a/src/render3d/layerBlendMode.test.ts
+++ b/src/render3d/layerBlendMode.test.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import * as THREE from 'three'
+import { describe, expect, it, vi } from 'vitest'
+import { installDepthOfFieldShader } from '@/render3d/depthOfFieldShader'
+import {
+  BACKDROP_BLEND_MODES,
+  backdropBlendModeIndex,
+  captureBackdropForMaterial,
+  disposeBackdropBlendMode,
+  injectBackdropBlendShader,
+  setBackdropBlendMode,
+} from '@/render3d/layerBlendMode'
+
+describe('backdrop-aware layer blending', () => {
+  it('assigns every authored blend mode a stable shader index', () => {
+    expect(BACKDROP_BLEND_MODES).toEqual([
+      'normal',
+      'multiply',
+      'screen',
+      'overlay',
+      'darken',
+      'lighten',
+      'color-dodge',
+      'color-burn',
+      'hard-light',
+      'soft-light',
+      'difference',
+      'exclusion',
+      'hue',
+      'saturation',
+      'color',
+      'luminosity',
+    ])
+    BACKDROP_BLEND_MODES.forEach((mode, index) => {
+      expect(backdropBlendModeIndex(mode)).toBe(index)
+    })
+  })
+
+  it('injects destination sampling and the complete CSS blend family', () => {
+    const fragmentShader = injectBackdropBlendShader(`
+#include <common>
+void main() {
+  gl_FragColor = vec4(1.0);
+  #include <dithering_fragment>
+}
+`)
+
+    expect(fragmentShader).toContain('uniform sampler2D hmBlendBackdrop')
+    expect(fragmentShader).toContain('texture2D(hmBlendBackdrop, hmBlendUv)')
+    expect(fragmentShader).toContain('hmBlendOverlayChannel')
+    expect(fragmentShader).toContain('hmBlendHardLightChannel')
+    expect(fragmentShader).toContain('hmBlendSoftLightChannel')
+    expect(fragmentShader).toContain('hmBlendSetSat')
+    expect(fragmentShader).toContain('hmBlendSetLum')
+    expect(fragmentShader).toContain('hmCompositeAlpha')
+  })
+
+  it('composes with the existing depth-of-field shader hook', () => {
+    const material = new THREE.MeshBasicMaterial()
+    installDepthOfFieldShader(material)
+    setBackdropBlendMode(material, 'overlay')
+
+    const shader = {
+      uniforms: {},
+      vertexShader: '',
+      fragmentShader: `
+#include <common>
+#include <map_pars_fragment>
+void main() {
+  #include <map_fragment>
+  gl_FragColor = vec4(1.0);
+  #include <dithering_fragment>
+}
+`,
+    } as unknown as Parameters<typeof material.onBeforeCompile>[0]
+    material.onBeforeCompile(
+      shader,
+      {} as Parameters<typeof material.onBeforeCompile>[1],
+    )
+
+    expect(shader.uniforms).toHaveProperty('hmDofEnabled')
+    expect(shader.uniforms).toHaveProperty('hmBlendBackdrop')
+    expect(shader.uniforms).toHaveProperty('hmBlendViewport')
+    expect(shader.uniforms).toHaveProperty('hmBlendMode')
+    expect(shader.uniforms).toHaveProperty('hmBlendTargetIsLinear')
+    expect(shader.fragmentShader).toContain('hmDofEnabled')
+    expect(shader.fragmentShader).toContain('hmBlendCss')
+    expect(shader.fragmentShader).toContain('sRGBTransferOETF')
+    expect(shader.fragmentShader).toContain('sRGBTransferEOTF')
+    expect(material.blending).toBe(THREE.NoBlending)
+
+    setBackdropBlendMode(material, 'normal')
+    expect(material.blending).toBe(THREE.NormalBlending)
+    disposeBackdropBlendMode(material)
+    expect(material.userData.hyperMotionBackdropBlend).toBeUndefined()
+  })
+
+  it('copies the active framebuffer at its physical render size', () => {
+    const material = new THREE.MeshBasicMaterial()
+    setBackdropBlendMode(material, 'difference')
+    const copyFramebufferToTexture = vi.fn()
+    const renderer = {
+      getRenderTarget: () => ({
+        width: 640,
+        height: 360,
+        texture: {
+          type: THREE.HalfFloatType,
+          colorSpace: THREE.NoColorSpace,
+        },
+      }),
+      getDrawingBufferSize: vi.fn(),
+      copyFramebufferToTexture,
+    } as unknown as THREE.WebGLRenderer
+
+    captureBackdropForMaterial(renderer, material)
+
+    expect(copyFramebufferToTexture).toHaveBeenCalledOnce()
+    const texture = copyFramebufferToTexture.mock.calls[0]?.[0] as
+      | THREE.FramebufferTexture
+      | undefined
+    expect(texture?.image).toMatchObject({ width: 640, height: 360 })
+    expect(texture?.type).toBe(THREE.HalfFloatType)
+
+    const shader = {
+      uniforms: {},
+      vertexShader: '',
+      fragmentShader:
+        '#include <common>\nvoid main(){#include <dithering_fragment>}',
+    } as unknown as Parameters<typeof material.onBeforeCompile>[0]
+    material.onBeforeCompile(
+      shader,
+      {} as Parameters<typeof material.onBeforeCompile>[1],
+    )
+    expect(
+      (shader.uniforms.hmBlendTargetIsLinear as { value: number }).value,
+    ).toBe(1)
+  })
+
+  it('keeps the direct drawing buffer in the display-sRGB blend space', () => {
+    const material = new THREE.MeshBasicMaterial()
+    setBackdropBlendMode(material, 'soft-light')
+    const copyFramebufferToTexture = vi.fn()
+    const renderer = {
+      outputColorSpace: THREE.SRGBColorSpace,
+      getRenderTarget: () => null,
+      getDrawingBufferSize: (size: THREE.Vector2) => size.set(960, 540),
+      copyFramebufferToTexture,
+    } as unknown as THREE.WebGLRenderer
+
+    captureBackdropForMaterial(renderer, material)
+
+    const texture = copyFramebufferToTexture.mock.calls[0]?.[0] as
+      | THREE.FramebufferTexture
+      | undefined
+    expect(texture?.image).toMatchObject({ width: 960, height: 540 })
+    const shader = {
+      uniforms: {},
+      vertexShader: '',
+      fragmentShader:
+        '#include <common>\nvoid main(){#include <dithering_fragment>}',
+    } as unknown as Parameters<typeof material.onBeforeCompile>[0]
+    material.onBeforeCompile(
+      shader,
+      {} as Parameters<typeof material.onBeforeCompile>[1],
+    )
+    expect(
+      (shader.uniforms.hmBlendTargetIsLinear as { value: number }).value,
+    ).toBe(0)
+  })
+})

--- a/src/render3d/layerBlendMode.ts
+++ b/src/render3d/layerBlendMode.ts
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import * as THREE from 'three'
+import type { BlendMode } from '@/scene'
+
+const BACKDROP_BLEND_SHADER_KEY = 'hypermotion-backdrop-blend-v1'
+
+export const BACKDROP_BLEND_MODES = [
+  'normal',
+  'multiply',
+  'screen',
+  'overlay',
+  'darken',
+  'lighten',
+  'color-dodge',
+  'color-burn',
+  'hard-light',
+  'soft-light',
+  'difference',
+  'exclusion',
+  'hue',
+  'saturation',
+  'color',
+  'luminosity',
+] as const satisfies readonly BlendMode[]
+
+type BlendUniform = { value: number }
+type TextureUniform = { value: THREE.Texture }
+type VectorUniform = { value: THREE.Vector2 }
+
+interface BackdropBlendUniforms {
+  hmBlendBackdrop: TextureUniform
+  hmBlendViewport: VectorUniform
+  hmBlendMode: BlendUniform
+  hmBlendTargetIsLinear: BlendUniform
+}
+
+interface BackdropBlendInstallation {
+  key: string
+  compile: THREE.MeshBasicMaterial['onBeforeCompile']
+  texture: THREE.FramebufferTexture
+  uniforms: BackdropBlendUniforms
+}
+
+const drawingBufferSize = new THREE.Vector2()
+
+export function backdropBlendModeIndex(mode: BlendMode | undefined): number {
+  return Math.max(0, BACKDROP_BLEND_MODES.indexOf(mode ?? 'normal'))
+}
+
+/**
+ * Install a destination-aware blend stage after the material's existing map,
+ * depth-of-field, output-colour, and dithering stages.
+ *
+ * WebGL's fixed blend factors cannot express Overlay, Soft Light, Color Dodge,
+ * or the HSL-family modes because those formulas must read the destination
+ * colour. The mesh copies the framebuffer immediately before it draws, then
+ * this shader combines that backdrop with the Paper/layer texture.
+ */
+export function setBackdropBlendMode(
+  material: THREE.MeshBasicMaterial,
+  mode: BlendMode | undefined,
+): void {
+  const modeIndex = backdropBlendModeIndex(mode)
+  const installation =
+    modeIndex > 0 || material.userData.hyperMotionBackdropBlend
+      ? installBackdropBlendShader(material)
+      : null
+  if (installation) installation.uniforms.hmBlendMode.value = modeIndex
+
+  const previousMode = material.userData.hyperMotionBackdropBlendMode
+  if (previousMode === modeIndex) return
+  material.userData.hyperMotionBackdropBlendMode = modeIndex
+  material.transparent = true
+  material.premultipliedAlpha = false
+  // The advanced shader already emits the source-over-composited framebuffer
+  // pixel, so another fixed-function blend would apply alpha twice.
+  material.blending =
+    modeIndex > 0 ? THREE.NoBlending : THREE.NormalBlending
+  material.needsUpdate = true
+}
+
+export function captureBackdropForMaterial(
+  renderer: THREE.WebGLRenderer,
+  material: THREE.MeshBasicMaterial,
+): void {
+  const installation = material.userData
+    .hyperMotionBackdropBlend as BackdropBlendInstallation | undefined
+  if (!installation || installation.uniforms.hmBlendMode.value <= 0) return
+
+  const renderTarget = renderer.getRenderTarget()
+  if (!renderTarget) renderer.getDrawingBufferSize(drawingBufferSize)
+  const width = renderTarget ? renderTarget.width : drawingBufferSize.x
+  const height = renderTarget ? renderTarget.height : drawingBufferSize.y
+  const type = renderTarget?.texture.type ?? THREE.UnsignedByteType
+  const targetColorSpace =
+    renderTarget?.texture.colorSpace ?? renderer.outputColorSpace
+  installation.uniforms.hmBlendTargetIsLinear.value =
+    targetColorSpace === THREE.LinearSRGBColorSpace ||
+    targetColorSpace === THREE.NoColorSpace
+      ? 1
+      : 0
+  const texture = installation.texture
+  const sizeChanged =
+    texture.image.width !== width || texture.image.height !== height
+  const typeChanged = texture.type !== type
+
+  if (sizeChanged || typeChanged) {
+    texture.dispose()
+    texture.image.width = Math.max(1, width)
+    texture.image.height = Math.max(1, height)
+    texture.type = type
+    texture.needsUpdate = true
+  }
+  installation.uniforms.hmBlendViewport.value.set(
+    Math.max(1, width),
+    Math.max(1, height),
+  )
+  renderer.copyFramebufferToTexture(texture)
+}
+
+export function disposeBackdropBlendMode(
+  material: THREE.MeshBasicMaterial,
+): void {
+  const installation = material.userData
+    .hyperMotionBackdropBlend as BackdropBlendInstallation | undefined
+  installation?.texture.dispose()
+  delete material.userData.hyperMotionBackdropBlend
+  delete material.userData.hyperMotionBackdropBlendMode
+}
+
+function installBackdropBlendShader(
+  material: THREE.MeshBasicMaterial,
+): BackdropBlendInstallation {
+  const current = material.userData
+    .hyperMotionBackdropBlend as BackdropBlendInstallation | undefined
+  if (
+    current?.key === BACKDROP_BLEND_SHADER_KEY &&
+    current.compile === material.onBeforeCompile
+  ) {
+    return current
+  }
+
+  const texture = new THREE.FramebufferTexture(1, 1)
+  texture.name = 'Hyper Motion layer blend backdrop'
+  const uniforms: BackdropBlendUniforms = {
+    hmBlendBackdrop: { value: texture },
+    hmBlendViewport: { value: new THREE.Vector2(1, 1) },
+    hmBlendMode: { value: 0 },
+    hmBlendTargetIsLinear: { value: 0 },
+  }
+  const compilePrevious = material.onBeforeCompile
+  const previousCacheKey = material.customProgramCacheKey
+  const compile: THREE.MeshBasicMaterial['onBeforeCompile'] = (
+    shader,
+    renderer,
+  ) => {
+    compilePrevious(shader, renderer)
+    Object.assign(shader.uniforms, uniforms)
+    shader.fragmentShader = injectBackdropBlendShader(shader.fragmentShader)
+  }
+  const installation: BackdropBlendInstallation = {
+    key: BACKDROP_BLEND_SHADER_KEY,
+    compile,
+    texture,
+    uniforms,
+  }
+  current?.texture.dispose()
+  material.onBeforeCompile = compile
+  material.customProgramCacheKey = () =>
+    `${previousCacheKey.call(material)}:${BACKDROP_BLEND_SHADER_KEY}`
+  material.userData.hyperMotionBackdropBlend = installation
+  material.needsUpdate = true
+  return installation
+}
+
+export function injectBackdropBlendShader(fragmentShader: string): string {
+  return fragmentShader
+    .replace(
+      '#include <common>',
+      `#include <common>
+
+uniform sampler2D hmBlendBackdrop;
+uniform vec2 hmBlendViewport;
+uniform float hmBlendMode;
+uniform float hmBlendTargetIsLinear;
+
+float hmBlendLum(vec3 color) {
+  return dot(color, vec3(0.3, 0.59, 0.11));
+}
+
+float hmBlendSat(vec3 color) {
+  return max(max(color.r, color.g), color.b) -
+    min(min(color.r, color.g), color.b);
+}
+
+vec3 hmBlendClipColor(vec3 color) {
+  float lum = hmBlendLum(color);
+  float minimum = min(min(color.r, color.g), color.b);
+  float maximum = max(max(color.r, color.g), color.b);
+  if (minimum < 0.0) {
+    color = vec3(lum) +
+      (color - vec3(lum)) * lum / max(lum - minimum, 0.00001);
+  }
+  if (maximum > 1.0) {
+    color = vec3(lum) +
+      (color - vec3(lum)) * (1.0 - lum) /
+      max(maximum - lum, 0.00001);
+  }
+  return clamp(color, 0.0, 1.0);
+}
+
+vec3 hmBlendSetLum(vec3 color, float lum) {
+  return hmBlendClipColor(color + vec3(lum - hmBlendLum(color)));
+}
+
+vec3 hmBlendSetSat(vec3 color, float saturation) {
+  float minimum = min(min(color.r, color.g), color.b);
+  float maximum = max(max(color.r, color.g), color.b);
+  if (maximum <= minimum + 0.00001) return vec3(0.0);
+  return (color - vec3(minimum)) * saturation / (maximum - minimum);
+}
+
+float hmBlendOverlayChannel(float backdrop, float source) {
+  return backdrop <= 0.5
+    ? 2.0 * backdrop * source
+    : 1.0 - 2.0 * (1.0 - backdrop) * (1.0 - source);
+}
+
+float hmBlendHardLightChannel(float backdrop, float source) {
+  return source <= 0.5
+    ? 2.0 * backdrop * source
+    : 1.0 - 2.0 * (1.0 - backdrop) * (1.0 - source);
+}
+
+float hmBlendSoftLightD(float backdrop) {
+  return backdrop <= 0.25
+    ? ((16.0 * backdrop - 12.0) * backdrop + 4.0) * backdrop
+    : sqrt(max(backdrop, 0.0));
+}
+
+float hmBlendSoftLightChannel(float backdrop, float source) {
+  return source <= 0.5
+    ? backdrop -
+      (1.0 - 2.0 * source) * backdrop * (1.0 - backdrop)
+    : backdrop +
+      (2.0 * source - 1.0) * (hmBlendSoftLightD(backdrop) - backdrop);
+}
+
+vec3 hmBlendCss(vec3 backdrop, vec3 source, float mode) {
+  if (mode < 1.5) return backdrop * source;
+  if (mode < 2.5) return backdrop + source - backdrop * source;
+  if (mode < 3.5) {
+    return vec3(
+      hmBlendOverlayChannel(backdrop.r, source.r),
+      hmBlendOverlayChannel(backdrop.g, source.g),
+      hmBlendOverlayChannel(backdrop.b, source.b)
+    );
+  }
+  if (mode < 4.5) return min(backdrop, source);
+  if (mode < 5.5) return max(backdrop, source);
+  if (mode < 6.5) {
+    return min(
+      vec3(1.0),
+      backdrop / max(vec3(0.00001), vec3(1.0) - source)
+    );
+  }
+  if (mode < 7.5) {
+    return vec3(1.0) - min(
+      vec3(1.0),
+      (vec3(1.0) - backdrop) / max(source, vec3(0.00001))
+    );
+  }
+  if (mode < 8.5) {
+    return vec3(
+      hmBlendHardLightChannel(backdrop.r, source.r),
+      hmBlendHardLightChannel(backdrop.g, source.g),
+      hmBlendHardLightChannel(backdrop.b, source.b)
+    );
+  }
+  if (mode < 9.5) {
+    return vec3(
+      hmBlendSoftLightChannel(backdrop.r, source.r),
+      hmBlendSoftLightChannel(backdrop.g, source.g),
+      hmBlendSoftLightChannel(backdrop.b, source.b)
+    );
+  }
+  if (mode < 10.5) return abs(backdrop - source);
+  if (mode < 11.5) {
+    return backdrop + source - 2.0 * backdrop * source;
+  }
+  if (mode < 12.5) {
+    return hmBlendSetLum(
+      hmBlendSetSat(source, hmBlendSat(backdrop)),
+      hmBlendLum(backdrop)
+    );
+  }
+  if (mode < 13.5) {
+    return hmBlendSetLum(
+      hmBlendSetSat(backdrop, hmBlendSat(source)),
+      hmBlendLum(backdrop)
+    );
+  }
+  if (mode < 14.5) {
+    return hmBlendSetLum(source, hmBlendLum(backdrop));
+  }
+  return hmBlendSetLum(backdrop, hmBlendLum(source));
+}`,
+    )
+    .replace(
+      '#include <dithering_fragment>',
+      `#include <dithering_fragment>
+
+if (hmBlendMode > 0.5) {
+  vec2 hmBlendUv =
+    gl_FragCoord.xy / max(hmBlendViewport, vec2(1.0));
+  vec4 hmBackdropPixel = texture2D(hmBlendBackdrop, hmBlendUv);
+  float hmBackdropAlpha = clamp(hmBackdropPixel.a, 0.0, 1.0);
+  float hmSourceAlpha = clamp(gl_FragColor.a, 0.0, 1.0);
+  vec3 hmBackdropColor = hmBackdropAlpha > 0.00001
+    ? hmBackdropPixel.rgb / hmBackdropAlpha
+    : vec3(0.0);
+  vec3 hmSourceColor = max(gl_FragColor.rgb, vec3(0.0));
+  if (hmBlendTargetIsLinear > 0.5) {
+    // CSS/Canvas blend modes operate in the display sRGB working space.
+    // EffectComposer's half-float targets are linear, so temporarily encode
+    // both straight colors for identical preview/export results.
+    hmBackdropColor = sRGBTransferOETF(
+      vec4(max(hmBackdropColor, vec3(0.0)), 1.0)
+    ).rgb;
+    hmSourceColor = sRGBTransferOETF(
+      vec4(hmSourceColor, 1.0)
+    ).rgb;
+  }
+  hmBackdropColor = clamp(hmBackdropColor, 0.0, 1.0);
+  hmSourceColor = clamp(hmSourceColor, 0.0, 1.0);
+  vec3 hmBlendedColor = hmBlendCss(
+    hmBackdropColor,
+    hmSourceColor,
+    hmBlendMode
+  );
+  vec3 hmBlendSource =
+    (1.0 - hmBackdropAlpha) * hmSourceColor +
+    hmBackdropAlpha * hmBlendedColor;
+  vec3 hmCompositeColor =
+    hmSourceAlpha * hmBlendSource +
+    (1.0 - hmSourceAlpha) * hmBackdropPixel.rgb;
+  float hmCompositeAlpha =
+    hmSourceAlpha + hmBackdropAlpha * (1.0 - hmSourceAlpha);
+  if (hmBlendTargetIsLinear > 0.5 && hmCompositeAlpha > 0.00001) {
+    vec3 hmCompositeStraight = clamp(
+      hmCompositeColor / hmCompositeAlpha,
+      0.0,
+      1.0
+    );
+    hmCompositeColor = sRGBTransferEOTF(
+      vec4(hmCompositeStraight, 1.0)
+    ).rgb * hmCompositeAlpha;
+  }
+  gl_FragColor = vec4(hmCompositeColor, hmCompositeAlpha);
+}`,
+    )
+}

--- a/src/render3d/postEffects.test.ts
+++ b/src/render3d/postEffects.test.ts
@@ -8,6 +8,7 @@ import {
   CHROMATIC_ABERRATION_SHADER,
   PostEffectsIdleQualityController,
   ScenePostEffectsRenderer,
+  VHS_SHADER,
   cameraPostEffectsActive,
   cameraPostEffectsEnabled,
   cameraPostEffectsInteractionChanged,
@@ -28,6 +29,11 @@ describe('camera post effects', () => {
       bloomStrength: 0.8,
       bloomRadius: 0.35,
       bloomThreshold: 0.75,
+      vhsEnabled: false,
+      vhsIntensity: 0.65,
+      vhsNoise: 0.35,
+      vhsScanlines: 0.5,
+      vhsColorBleed: 3,
     })
 
     expect(
@@ -39,6 +45,11 @@ describe('camera post effects', () => {
         bloomStrength: 12,
         bloomRadius: -1,
         bloomThreshold: 2,
+        vhsEnabled: true,
+        vhsIntensity: 9,
+        vhsNoise: -2,
+        vhsScanlines: Number.NaN,
+        vhsColorBleed: 80,
       }),
     ).toEqual({
       chromaticAberrationEnabled: true,
@@ -49,6 +60,11 @@ describe('camera post effects', () => {
       bloomStrength: 4,
       bloomRadius: 0,
       bloomThreshold: 1,
+      vhsEnabled: true,
+      vhsIntensity: 1,
+      vhsNoise: 0,
+      vhsScanlines: 0.5,
+      vhsColorBleed: 32,
     })
   })
 
@@ -62,6 +78,8 @@ describe('camera post effects', () => {
         chromaticAberrationAmount: 0,
         bloomEnabled: true,
         bloomStrength: 0,
+        vhsEnabled: true,
+        vhsIntensity: 0,
       }),
     ).toBe(false)
     expect(
@@ -76,6 +94,12 @@ describe('camera post effects', () => {
         bloomEnabled: true,
       }),
     ).toBe(true)
+    expect(
+      cameraPostEffectsActive({
+        ...disabled,
+        vhsEnabled: true,
+      }),
+    ).toBe(true)
   })
 
   it('ties resource lifetime to authored toggles, not animated zeroes', () => {
@@ -88,12 +112,18 @@ describe('camera post effects', () => {
       bloomEnabled: true,
       bloomStrength: 0,
     })
+    const zeroVhs = normalizeCameraPostEffects({
+      vhsEnabled: true,
+      vhsIntensity: 0,
+    })
 
     expect(cameraPostEffectsEnabled(disabled)).toBe(false)
     expect(cameraPostEffectsEnabled(zeroChromatic)).toBe(true)
     expect(cameraPostEffectsEnabled(zeroBloom)).toBe(true)
+    expect(cameraPostEffectsEnabled(zeroVhs)).toBe(true)
     expect(cameraPostEffectsActive(zeroChromatic)).toBe(false)
     expect(cameraPostEffectsActive(zeroBloom)).toBe(false)
+    expect(cameraPostEffectsActive(zeroVhs)).toBe(false)
   })
 
   it('converts composition-pixel separation into aspect-correct UV offsets', () => {
@@ -179,6 +209,7 @@ describe('camera post effects', () => {
       chromaticAberrationEnabled: true,
     })
     const after = { ...before, chromaticAberrationAmount: 12 }
+    const vhsAfter = { ...before, vhsNoise: 0.8 }
 
     expect(cameraPostEffectsInteractionChanged(before, before, 1, 1)).toBe(
       false,
@@ -186,6 +217,9 @@ describe('camera post effects', () => {
     expect(cameraPostEffectsInteractionChanged(before, after, 1, 1)).toBe(
       true,
     )
+    expect(
+      cameraPostEffectsInteractionChanged(before, vhsAfter, 1, 1),
+    ).toBe(true)
     expect(cameraPostEffectsInteractionChanged(before, before, 1, 1.25)).toBe(
       true,
     )
@@ -267,6 +301,11 @@ describe('camera post effects', () => {
     api.setNodeProperty(camera.id, 'bloomStrength', 1.1)
     api.setNodeProperty(camera.id, 'bloomRadius', 0.4)
     api.setNodeProperty(camera.id, 'bloomThreshold', 0.7)
+    api.setNodeProperty(camera.id, 'vhsEnabled', true)
+    api.setNodeProperty(camera.id, 'vhsIntensity', 0.6)
+    api.setNodeProperty(camera.id, 'vhsNoise', 0.3)
+    api.setNodeProperty(camera.id, 'vhsScanlines', 0.4)
+    api.setNodeProperty(camera.id, 'vhsColorBleed', 4)
     const authored = api.getActiveCamera()
     if (!authored) throw new Error('Expected the updated camera')
 
@@ -278,6 +317,10 @@ describe('camera post effects', () => {
         bloomStrength: 2,
         bloomRadius: 0.6,
         bloomThreshold: 0.25,
+        vhsIntensity: 0.9,
+        vhsNoise: 0.7,
+        vhsScanlines: 0.8,
+        vhsColorBleed: 7,
       },
       { width: 960, height: 540 },
     )
@@ -289,6 +332,11 @@ describe('camera post effects', () => {
       bloomStrength: 2,
       bloomRadius: 0.6,
       bloomThreshold: 0.25,
+      vhsEnabled: true,
+      vhsIntensity: 0.9,
+      vhsNoise: 0.7,
+      vhsScanlines: 0.8,
+      vhsColorBleed: 7,
     })
   })
 
@@ -320,5 +368,21 @@ describe('camera post effects', () => {
     expect(CHROMATIC_ABERRATION_SHADER.fragmentShader).toContain(
       '#include <colorspace_fragment>',
     )
+  })
+
+  it('builds VHS variation only from scene time and composition pixels', () => {
+    expect(VHS_SHADER.uniforms).toHaveProperty('hmTime')
+    expect(VHS_SHADER.uniforms).toHaveProperty('hmResolution')
+    expect(VHS_SHADER.fragmentShader).toContain(
+      'floor(sceneTime * 60.0 + 0.0001)',
+    )
+    expect(VHS_SHADER.fragmentShader).toContain('floor(vUv * resolution)')
+    expect(VHS_SHADER.fragmentShader).toContain(
+      'hmColorBleedPx * amount / resolution.x',
+    )
+    expect(VHS_SHADER.fragmentShader).toContain('hash21')
+    expect(VHS_SHADER.fragmentShader).not.toContain('random(')
+    expect(VHS_SHADER.fragmentShader).not.toContain('tonemapping_fragment')
+    expect(VHS_SHADER.fragmentShader).not.toContain('colorspace_fragment')
   })
 })

--- a/src/render3d/postEffects.ts
+++ b/src/render3d/postEffects.ts
@@ -15,6 +15,11 @@ export interface CameraPostEffectsInput {
   bloomStrength?: number
   bloomRadius?: number
   bloomThreshold?: number
+  vhsEnabled?: boolean
+  vhsIntensity?: number
+  vhsNoise?: number
+  vhsScanlines?: number
+  vhsColorBleed?: number
 }
 
 export interface CameraPostEffectsState {
@@ -29,6 +34,15 @@ export interface CameraPostEffectsState {
   bloomRadius: number
   /** Minimum normalized luminance that contributes to bloom. */
   bloomThreshold: number
+  vhsEnabled: boolean
+  /** Overall analog tape contribution, in the range 0...1. */
+  vhsIntensity: number
+  /** Fine luminance noise contribution, in the range 0...1. */
+  vhsNoise: number
+  /** Alternating horizontal scanline contrast, in the range 0...1. */
+  vhsScanlines: number
+  /** Horizontal red/blue channel bleed in composition pixels. */
+  vhsColorBleed: number
 }
 
 const EFFECT_EPSILON = 0.001
@@ -63,6 +77,11 @@ export function normalizeCameraPostEffects(
     bloomStrength: clampFinite(input.bloomStrength, 0, 4, 0.8),
     bloomRadius: clampFinite(input.bloomRadius, 0, 1, 0.35),
     bloomThreshold: clampFinite(input.bloomThreshold, 0, 1, 0.75),
+    vhsEnabled: input.vhsEnabled === true,
+    vhsIntensity: clampFinite(input.vhsIntensity, 0, 1, 0.65),
+    vhsNoise: clampFinite(input.vhsNoise, 0, 1, 0.35),
+    vhsScanlines: clampFinite(input.vhsScanlines, 0, 1, 0.5),
+    vhsColorBleed: clampFinite(input.vhsColorBleed, 0, 32, 3),
   }
 }
 
@@ -73,7 +92,8 @@ export function cameraPostEffectsActive(
   return (
     (effects.chromaticAberrationEnabled &&
       effects.chromaticAberrationAmount > EFFECT_EPSILON) ||
-    (effects.bloomEnabled && effects.bloomStrength > EFFECT_EPSILON)
+    (effects.bloomEnabled && effects.bloomStrength > EFFECT_EPSILON) ||
+    (effects.vhsEnabled && effects.vhsIntensity > EFFECT_EPSILON)
   )
 }
 
@@ -81,7 +101,11 @@ export function cameraPostEffectsActive(
 export function cameraPostEffectsEnabled(
   effects: CameraPostEffectsState,
 ): boolean {
-  return effects.chromaticAberrationEnabled || effects.bloomEnabled
+  return (
+    effects.chromaticAberrationEnabled ||
+    effects.bloomEnabled ||
+    effects.vhsEnabled
+  )
 }
 
 /**
@@ -105,7 +129,12 @@ export function cameraPostEffectsInteractionChanged(
     previousEffects.bloomEnabled !== nextEffects.bloomEnabled ||
     previousEffects.bloomStrength !== nextEffects.bloomStrength ||
     previousEffects.bloomRadius !== nextEffects.bloomRadius ||
-    previousEffects.bloomThreshold !== nextEffects.bloomThreshold
+    previousEffects.bloomThreshold !== nextEffects.bloomThreshold ||
+    previousEffects.vhsEnabled !== nextEffects.vhsEnabled ||
+    previousEffects.vhsIntensity !== nextEffects.vhsIntensity ||
+    previousEffects.vhsNoise !== nextEffects.vhsNoise ||
+    previousEffects.vhsScanlines !== nextEffects.vhsScanlines ||
+    previousEffects.vhsColorBleed !== nextEffects.vhsColorBleed
   )
 }
 
@@ -116,11 +145,16 @@ export function cameraPostEffectsInteractionChanged(
 export class PostEffectsIdleQualityController {
   private realtime = false
   private timer: ReturnType<typeof setTimeout> | null = null
+  private readonly onIdle: () => void
+  private readonly delayMs: number
 
   constructor(
-    private readonly onIdle: () => void,
-    private readonly delayMs = POST_EFFECTS_IDLE_QUALITY_DELAY_MS,
-  ) {}
+    onIdle: () => void,
+    delayMs = POST_EFFECTS_IDLE_QUALITY_DELAY_MS,
+  ) {
+    this.onIdle = onIdle
+    this.delayMs = delayMs
+  }
 
   noteInteraction(): void {
     this.realtime = true
@@ -265,6 +299,136 @@ export const CHROMATIC_ABERRATION_SHADER = {
 } as const
 
 /**
+ * Deterministic analog-tape treatment. All temporal variation comes from the
+ * authored scene playhead; a paused frame and the matching exported frame
+ * therefore resolve to the same wobble, tear, grain, and rolling noise band.
+ *
+ * This pass intentionally stays in linear color space. OutputPass, or the
+ * following chromatic-aberration pass, owns tone mapping and display encoding.
+ */
+export const VHS_SHADER = {
+  name: 'HyperMotionVHS',
+  uniforms: {
+    tDiffuse: { value: null as THREE.Texture | null },
+    hmResolution: { value: new THREE.Vector2(1, 1) },
+    hmTime: { value: 0 },
+    hmIntensity: { value: 0 },
+    hmNoise: { value: 0.35 },
+    hmScanlines: { value: 0.5 },
+    hmColorBleedPx: { value: 3 },
+  },
+  vertexShader: /* glsl */ `
+    varying vec2 vUv;
+
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */ `
+    uniform sampler2D tDiffuse;
+    uniform vec2 hmResolution;
+    uniform float hmTime;
+    uniform float hmIntensity;
+    uniform float hmNoise;
+    uniform float hmScanlines;
+    uniform float hmColorBleedPx;
+    varying vec2 vUv;
+
+    float hash21(vec2 p) {
+      p = fract(p * vec2(123.34, 456.21));
+      p += dot(p, p + 45.32);
+      return fract(p.x * p.y);
+    }
+
+    vec4 sampleWithinFrame(vec2 uv) {
+      vec2 lowerBound = step(vec2(0.0), uv);
+      vec2 upperBound = step(uv, vec2(1.0));
+      float coverage =
+        lowerBound.x * lowerBound.y * upperBound.x * upperBound.y;
+      return texture2D(tDiffuse, clamp(uv, vec2(0.0), vec2(1.0))) * coverage;
+    }
+
+    void main() {
+      vec2 resolution = max(hmResolution, vec2(1.0));
+      float amount = clamp(hmIntensity, 0.0, 1.0);
+      float sceneTime = max(hmTime, 0.0);
+      float temporalFrame = floor(sceneTime * 60.0 + 0.0001);
+      vec2 pixel = floor(vUv * resolution);
+      float tapeRow = floor(pixel.y / 3.0);
+
+      // Two low-frequency tracking waves plus sparse horizontal tears.
+      float wobblePx =
+        sin(vUv.y * 42.0 + sceneTime * 3.1) * 1.4 +
+        sin(vUv.y * 127.0 - sceneTime * 1.7) * 0.65;
+      float tearGate = step(
+        0.94,
+        hash21(vec2(floor(sceneTime * 7.0), tapeRow))
+      );
+      wobblePx +=
+        (hash21(vec2(tapeRow, temporalFrame)) - 0.5) *
+        14.0 *
+        tearGate;
+
+      // Occasional whole-frame vertical tracking kick.
+      float verticalGate = step(
+        0.975,
+        hash21(vec2(floor(sceneTime * 4.0), 17.0))
+      );
+      float verticalKickPx =
+        verticalGate * sin(sceneTime * 90.0) * 6.0;
+      vec2 signalUv = vUv + vec2(
+        wobblePx * amount / resolution.x,
+        verticalKickPx * amount / resolution.y
+      );
+
+      // Tape color bleed stays horizontal and composition-pixel based.
+      vec2 bleedUv = vec2(
+        hmColorBleedPx * amount / resolution.x,
+        0.0
+      );
+      vec4 redSample = sampleWithinFrame(signalUv + bleedUv);
+      vec4 centerSample = sampleWithinFrame(signalUv);
+      vec4 blueSample = sampleWithinFrame(signalUv - bleedUv);
+      float alpha = max(
+        centerSample.a,
+        max(redSample.a, blueSample.a)
+      );
+      vec3 color = vec3(
+        redSample.r,
+        centerSample.g,
+        blueSample.b
+      );
+
+      // Slight tape desaturation, alternating scanlines, and frame-stable grain.
+      float luma = dot(color, vec3(0.299, 0.587, 0.114));
+      color = mix(color, vec3(luma), amount * 0.12);
+      float scanline = mod(pixel.y, 2.0);
+      color *= 1.0 - scanline * hmScanlines * amount * 0.18;
+
+      float grain =
+        hash21(pixel + vec2(temporalFrame, temporalFrame * 0.37)) - 0.5;
+      color += grain * hmNoise * amount * 0.16 * alpha;
+
+      // A noisy tracking band rolls through the image in authored scene time.
+      float bandCenter = fract(sceneTime * 0.12);
+      float bandDistance = abs(signalUv.y - bandCenter);
+      bandDistance = min(bandDistance, 1.0 - bandDistance);
+      float band = 1.0 - smoothstep(0.0, 0.055, bandDistance);
+      float bandNoise =
+        hash21(vec2(pixel.x * 0.25 + temporalFrame, tapeRow)) - 0.5;
+      color += bandNoise * hmNoise * amount * band * 0.22 * alpha;
+      color *= 1.0 - band * amount * 0.08;
+
+      float flicker =
+        1.0 +
+        (hash21(vec2(temporalFrame, 91.0)) - 0.5) * amount * 0.035;
+      gl_FragColor = vec4(max(color * flicker, vec3(0.0)), alpha);
+    }
+  `,
+} as const
+
+/**
  * Persistent post-processing graph for one Three viewport.
  *
  * The graph is allocated lazily by ThreeSceneViewport only when at least one
@@ -277,6 +441,7 @@ export class ScenePostEffectsRenderer {
   private readonly composer: EffectComposer
   private readonly renderPass: RenderPass
   private bloomPass: UnrealBloomPass | null = null
+  private readonly vhsPass: ShaderPass
   private readonly chromaticPass: ShaderPass
   private readonly outputPass: OutputPass
   private width = 0
@@ -294,10 +459,12 @@ export class ScenePostEffectsRenderer {
   ) {
     this.composer = new EffectComposer(renderer)
     this.renderPass = new RenderPass(scene, camera)
+    this.vhsPass = new ShaderPass(VHS_SHADER)
     this.chromaticPass = new ShaderPass(CHROMATIC_ABERRATION_SHADER)
     this.outputPass = new OutputPass()
 
     this.composer.addPass(this.renderPass)
+    this.composer.addPass(this.vhsPass)
     this.composer.addPass(this.chromaticPass)
     this.composer.addPass(this.outputPass)
     this.resize(width, height, pixelRatio)
@@ -323,6 +490,7 @@ export class ScenePostEffectsRenderer {
       safeWidth,
       safeHeight,
     )
+    this.vhsPass.uniforms.hmResolution.value.set(safeWidth, safeHeight)
   }
 
   configure(
@@ -330,6 +498,7 @@ export class ScenePostEffectsRenderer {
     width: number,
     height: number,
     pixelRatio: number,
+    playhead = 0,
   ): void {
     // Tear Bloom down before a resize so disabling its authored toggle never
     // reallocates eleven scratch targets just before disposing them.
@@ -341,6 +510,16 @@ export class ScenePostEffectsRenderer {
       effects.chromaticAberrationAmount > EFFECT_EPSILON
     const bloomEnabled =
       effects.bloomEnabled && effects.bloomStrength > EFFECT_EPSILON
+    const vhsEnabled =
+      effects.vhsEnabled && effects.vhsIntensity > EFFECT_EPSILON
+
+    this.vhsPass.enabled = vhsEnabled
+    this.vhsPass.uniforms.hmTime.value =
+      Number.isFinite(playhead) ? Math.max(0, playhead) : 0
+    this.vhsPass.uniforms.hmIntensity.value = effects.vhsIntensity
+    this.vhsPass.uniforms.hmNoise.value = effects.vhsNoise
+    this.vhsPass.uniforms.hmScanlines.value = effects.vhsScanlines
+    this.vhsPass.uniforms.hmColorBleedPx.value = effects.vhsColorBleed
 
     this.chromaticPass.enabled = chromaticEnabled
     this.chromaticPass.uniforms.hmAmountPx.value =
@@ -373,6 +552,7 @@ export class ScenePostEffectsRenderer {
     if (this.disposed) return
     this.disposed = true
     this.releaseBloomPass()
+    this.vhsPass.dispose()
     this.chromaticPass.dispose()
     this.outputPass.dispose()
     this.composer.dispose()

--- a/src/render3d/scene3d.ts
+++ b/src/render3d/scene3d.ts
@@ -2,7 +2,12 @@
 
 import type { AnimatedValue } from '@/anim'
 import type { Rect, SolvedLayout } from '@/layout'
-import type { CameraNode, Node, NodeId, SceneAPI } from '@/scene'
+import type {
+  CameraNode,
+  Node,
+  NodeId,
+  SceneAPI,
+} from '@/scene'
 import {
   add3,
   cross3,
@@ -329,6 +334,15 @@ export function resolveCamera3D(
       animated?.bloomRadius ?? camera.bloomRadius,
     bloomThreshold:
       animated?.bloomThreshold ?? camera.bloomThreshold,
+    vhsEnabled: camera.vhsEnabled,
+    vhsIntensity:
+      animated?.vhsIntensity ?? camera.vhsIntensity,
+    vhsNoise:
+      animated?.vhsNoise ?? camera.vhsNoise,
+    vhsScanlines:
+      animated?.vhsScanlines ?? camera.vhsScanlines,
+    vhsColorBleed:
+      animated?.vhsColorBleed ?? camera.vhsColorBleed,
   })
   const fieldOfView =
     animated?.fieldOfView ??
@@ -562,6 +576,7 @@ export function buildWorldPlanes(
     ? collectTargetPathNodeIds(context, targetNodeIds)
     : null
   const planes: Plane3D[] = []
+  let paintOrder = 0
   const getNode = (nodeId: NodeId): Node | null =>
     context.nodesById.get(nodeId) ?? null
   const segmentTextNodeIds = context.segmentTextNodeIds
@@ -717,7 +732,7 @@ export function buildWorldPlanes(
         rect,
         renderKind: segmentText ? 'segment-text' : 'canvas',
         contentMode,
-        paintOrder: planes.length,
+        paintOrder: paintOrder++,
         // Opacity belongs to the emitted plane, irrespective of whether its
         // pixels come from the node itself or a flattened subtree. Baking a
         // subtree root's animated opacity into a CanvasTexture forced a full

--- a/src/scene/cameraDof.test.ts
+++ b/src/scene/cameraDof.test.ts
@@ -40,6 +40,11 @@ describe('camera lens and post-effects model', () => {
       storedCamera.delete('bloomStrength')
       storedCamera.delete('bloomRadius')
       storedCamera.delete('bloomThreshold')
+      storedCamera.delete('vhsEnabled')
+      storedCamera.delete('vhsIntensity')
+      storedCamera.delete('vhsNoise')
+      storedCamera.delete('vhsScanlines')
+      storedCamera.delete('vhsColorBleed')
     })
 
     expect(api.getActiveCamera()).toMatchObject({
@@ -57,6 +62,11 @@ describe('camera lens and post-effects model', () => {
       bloomStrength: 0.8,
       bloomRadius: 0.35,
       bloomThreshold: 0.75,
+      vhsEnabled: false,
+      vhsIntensity: 0.65,
+      vhsNoise: 0.35,
+      vhsScanlines: 0.5,
+      vhsColorBleed: 3,
     })
   })
 
@@ -71,6 +81,11 @@ describe('camera lens and post-effects model', () => {
       api.setNodeProperty(camera.id, 'bloomStrength', 1.4)
       api.setNodeProperty(camera.id, 'bloomRadius', 0.6)
       api.setNodeProperty(camera.id, 'bloomThreshold', 0.42)
+      api.setNodeProperty(camera.id, 'vhsEnabled', true)
+      api.setNodeProperty(camera.id, 'vhsIntensity', 0.8)
+      api.setNodeProperty(camera.id, 'vhsNoise', 0.7)
+      api.setNodeProperty(camera.id, 'vhsScanlines', 0.6)
+      api.setNodeProperty(camera.id, 'vhsColorBleed', 6)
     })
 
     expect(api.getActiveCamera()).toMatchObject({
@@ -81,6 +96,11 @@ describe('camera lens and post-effects model', () => {
       bloomStrength: 1.4,
       bloomRadius: 0.6,
       bloomThreshold: 0.42,
+      vhsEnabled: true,
+      vhsIntensity: 0.8,
+      vhsNoise: 0.7,
+      vhsScanlines: 0.6,
+      vhsColorBleed: 6,
     })
   })
 
@@ -131,6 +151,11 @@ describe('camera lens and post-effects model', () => {
       bloomStrength: 1.25,
       bloomRadius: 0.55,
       bloomThreshold: 0.6,
+      vhsEnabled: true,
+      vhsIntensity: 0.9,
+      vhsNoise: 0.4,
+      vhsScanlines: 0.75,
+      vhsColorBleed: 5,
     })
 
     expect(values).toEqual([
@@ -139,6 +164,10 @@ describe('camera lens and post-effects model', () => {
       { propertyId: 'camera.bloomStrength', value: 1.25 },
       { propertyId: 'camera.bloomRadius', value: 0.55 },
       { propertyId: 'camera.bloomThreshold', value: 0.6 },
+      { propertyId: 'camera.vhsIntensity', value: 0.9 },
+      { propertyId: 'camera.vhsNoise', value: 0.4 },
+      { propertyId: 'camera.vhsScanlines', value: 0.75 },
+      { propertyId: 'camera.vhsColorBleed', value: 5 },
     ])
     expect(PROPERTIES['camera.chromaticAberrationAmount'].defaultValue).toBe(4)
     expect(PROPERTIES['camera.chromaticAberrationAngle'].interpolation).toBe(
@@ -147,6 +176,10 @@ describe('camera lens and post-effects model', () => {
     expect(PROPERTIES['camera.bloomStrength'].defaultValue).toBe(0.8)
     expect(PROPERTIES['camera.bloomRadius'].defaultValue).toBe(0.35)
     expect(PROPERTIES['camera.bloomThreshold'].defaultValue).toBe(0.75)
+    expect(PROPERTIES['camera.vhsIntensity'].defaultValue).toBe(0.65)
+    expect(PROPERTIES['camera.vhsNoise'].defaultValue).toBe(0.35)
+    expect(PROPERTIES['camera.vhsScanlines'].defaultValue).toBe(0.5)
+    expect(PROPERTIES['camera.vhsColorBleed'].defaultValue).toBe(3)
   })
 
   it('evaluates physical aperture tracks without mutating static camera values', () => {
@@ -196,6 +229,10 @@ describe('camera lens and post-effects model', () => {
       ['bloom-strength', 'camera.bloomStrength', 0.4, 1.6],
       ['bloom-radius', 'camera.bloomRadius', 0.1, 0.7],
       ['bloom-threshold', 'camera.bloomThreshold', 0.2, 0.8],
+      ['vhs-intensity', 'camera.vhsIntensity', 0.2, 0.8],
+      ['vhs-noise', 'camera.vhsNoise', 0.1, 0.7],
+      ['vhs-scanlines', 'camera.vhsScanlines', 0.3, 0.9],
+      ['vhs-color-bleed', 'camera.vhsColorBleed', 2, 8],
     ].map(([id, propertyId, start, end]) => ({
       id: String(id),
       nodeId: camera.id,
@@ -214,19 +251,28 @@ describe('camera lens and post-effects model', () => {
     engine.attach(api)
     engine.seek(0.5)
 
-    expect(engine.getSnapshot()[camera.id]).toMatchObject({
+    const animatedPostEffects = engine.getSnapshot()[camera.id]
+    expect(animatedPostEffects).toMatchObject({
       chromaticAberrationAmount: 6,
       chromaticAberrationAngle: 45,
       bloomStrength: 1,
       bloomRadius: 0.4,
       bloomThreshold: 0.5,
+      vhsIntensity: 0.5,
+      vhsNoise: 0.4,
+      vhsColorBleed: 5,
     })
+    expect(animatedPostEffects?.vhsScanlines).toBeCloseTo(0.6)
     expect(api.getActiveCamera()).toMatchObject({
       chromaticAberrationAmount: 4,
       chromaticAberrationAngle: 0,
       bloomStrength: 0.8,
       bloomRadius: 0.35,
       bloomThreshold: 0.75,
+      vhsIntensity: 0.65,
+      vhsNoise: 0.35,
+      vhsScanlines: 0.5,
+      vhsColorBleed: 3,
     })
   })
 

--- a/src/scene/doc.ts
+++ b/src/scene/doc.ts
@@ -17,6 +17,7 @@ import type {
   Scene,
   Section,
   SceneMeta,
+  ShaderNode,
   Size,
   TextNode,
   Track,
@@ -31,8 +32,17 @@ import {
   DEFAULT_CAMERA_SCROLL_SENSITIVITY,
   normalizeCameraScrollSensitivity,
 } from '@/scene/types'
+import {
+  getPaperShaderDefinition,
+  normalizePaperShaderColors,
+  normalizePaperShaderParams,
+  normalizePaperShaderSourceImage,
+  normalizePaperShaderSourceNodeId,
+  normalizePaperShaderType,
+} from '@/scene/paperShaders'
 import { normalizeTextAnimation } from '@/anim/textAnimations'
 import { emptyVectorDocument } from '@/scene/vector/model'
+import { removeLegacy3DObjects } from '@/scene/removeLegacy3DObjects'
 
 /**
  * Persistent, undoable UI state — track groups, keyframe groups,
@@ -229,6 +239,17 @@ export interface NodeBaseMutable {
   src: string
   fit: 'cover' | 'contain' | 'fill' | 'none'
   importWarning: string
+  // shader-kind fields — common and generic Paper shader authoring parameters.
+  shaderType: ShaderNode['shaderType']
+  colors: string[]
+  params: ShaderNode['params']
+  sourceNodeId: NodeId | undefined
+  sourceImage: string | undefined
+  speed: number
+  scale: number
+  distortion: number
+  swirl: number
+  grain: number
   // vector-kind fields
   viewBox: VectorViewBox
   vector: VectorDocument
@@ -287,6 +308,11 @@ export interface NodeBaseMutable {
   bloomStrength: number
   bloomRadius: number
   bloomThreshold: number
+  vhsEnabled: boolean
+  vhsIntensity: number
+  vhsNoise: number
+  vhsScanlines: number
+  vhsColorBleed: number
   showFocusPlane: boolean
   /** Stack of layout guides — only meaningful on FrameNode. */
   layoutGuides: import('@/scene/types').LayoutGuide[]
@@ -369,7 +395,7 @@ const VECTOR_DEFAULT_APPEARANCE: Appearance = {
 function defaultAppearanceForKind(kind: NodeKind): Appearance {
   if (kind === 'text') return TEXT_DEFAULT_APPEARANCE
   if (kind === 'video' || kind === 'audio') return MEDIA_DEFAULT_APPEARANCE
-  if (kind === 'vector') return VECTOR_DEFAULT_APPEARANCE
+  if (kind === 'vector' || kind === 'shader') return VECTOR_DEFAULT_APPEARANCE
   return DEFAULT_APPEARANCE
 }
 
@@ -380,7 +406,11 @@ function normalizeAppearanceForKind(kind: NodeKind, raw: unknown): Appearance {
     blendMode: normalizeBlendMode(appearance.blendMode),
     effects: appearance.effects ?? [],
   }
-  if (kind === 'video' || kind === 'audio' || kind === 'vector') {
+  if (
+    kind === 'video' ||
+    kind === 'audio' ||
+    kind === 'vector'
+  ) {
     return {
       ...normalized,
       fill: null,
@@ -473,6 +503,7 @@ function normalizeLayout(raw: unknown): Layout {
 }
 
 const DEFAULT_SIZE: Size = { width: 100, height: 100 }
+const DEFAULT_SHADER_SIZE: Size = { width: 640, height: 360 }
 
 const DEFAULT_VARIANT_TRANSITION: import('@/scene/types').VariantTransition = {
   duration: 0.3,
@@ -486,6 +517,7 @@ const DEFAULT_VARIANT_TRANSITION: import('@/scene/types').VariantTransition = {
 // ---------------------------------------------------------------------------
 
 export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
+  removeLegacy3DObjects(doc)
   const scene = doc.getMap<unknown>('scene')
 
   // Lazy-init the sub-maps on first access so a freshly loaded doc from
@@ -603,6 +635,81 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
               }
             : {}),
         } as Node
+      case 'shader':
+        {
+          const shaderType = normalizePaperShaderType(y.get('shaderType'))
+          const definition = getPaperShaderDefinition(shaderType)
+          const rawParams = isPlainRecord(y.get('params'))
+            ? y.get('params') as Record<string, unknown>
+            : undefined
+          const distortion = clampFiniteNumber(
+            y.get('distortion'),
+            0,
+            1,
+            shaderType === 'mesh-gradient' ? 0.8 : 0,
+          )
+          const swirl = clampFiniteNumber(
+            y.get('swirl'),
+            0,
+            1,
+            shaderType === 'mesh-gradient' ? 0.1 : 0,
+          )
+          const grain = clampFiniteNumber(
+            y.get('grain'),
+            0,
+            1,
+            shaderType === 'mesh-gradient' ? 0.08 : 0,
+          )
+          const params = normalizePaperShaderParams(
+            rawParams,
+            definition.defaults.params,
+          )
+          // Mesh Gradient shipped before the generic params bag. Migrate each
+          // missing field independently so partially-upgraded scenes preserve
+          // their authored legacy values.
+          if (shaderType === 'mesh-gradient') {
+            params.distortion = hasOwn(rawParams, 'distortion')
+              ? clampFiniteNumber(rawParams?.distortion, 0, 1, distortion)
+              : distortion
+            params.swirl = hasOwn(rawParams, 'swirl')
+              ? clampFiniteNumber(rawParams?.swirl, 0, 1, swirl)
+              : swirl
+            params.grainOverlay = hasOwn(rawParams, 'grainOverlay')
+              ? clampFiniteNumber(rawParams?.grainOverlay, 0, 1, grain)
+              : grain
+          }
+          const sourceNodeId = normalizePaperShaderSourceNodeId(
+            y.get('sourceNodeId'),
+          )
+          const sourceImage = normalizePaperShaderSourceImage(
+            y.get('sourceImage'),
+          )
+          return {
+            ...base,
+            kind,
+            size: (y.get('size') as Size) ?? DEFAULT_SHADER_SIZE,
+            shaderType,
+            colors: normalizePaperShaderColors(y.get('colors'), shaderType),
+            params,
+            ...(sourceNodeId ? { sourceNodeId } : {}),
+            ...(sourceImage ? { sourceImage } : {}),
+            speed: clampFiniteNumber(
+              y.get('speed'),
+              0,
+              2,
+              definition.defaults.speed,
+            ),
+            scale: clampFiniteNumber(
+              y.get('scale'),
+              0.1,
+              4,
+              definition.defaults.scale,
+            ),
+            distortion,
+            swirl,
+            grain,
+          } as ShaderNode
+        }
       case 'vector':
         return {
           ...base,
@@ -817,6 +924,16 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
             (y.get('bloomRadius') as number | undefined) ?? 0.35,
           bloomThreshold:
             (y.get('bloomThreshold') as number | undefined) ?? 0.75,
+          vhsEnabled:
+            (y.get('vhsEnabled') as boolean | undefined) ?? false,
+          vhsIntensity:
+            (y.get('vhsIntensity') as number | undefined) ?? 0.65,
+          vhsNoise:
+            (y.get('vhsNoise') as number | undefined) ?? 0.35,
+          vhsScanlines:
+            (y.get('vhsScanlines') as number | undefined) ?? 0.5,
+          vhsColorBleed:
+            (y.get('vhsColorBleed') as number | undefined) ?? 3,
           showFocusPlane: (y.get('showFocusPlane') as boolean | undefined) ?? false,
         } as CameraNode
       }
@@ -922,12 +1039,24 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
       const id = genId()
       doc.transact(() => {
         const y = new Y.Map<unknown>()
+        const requestedShaderType =
+          kind === 'shader'
+            ? normalizePaperShaderType(
+                (props as Partial<ShaderNode> | undefined)?.shaderType,
+              )
+            : null
+        const generatedName = requestedShaderType
+          ? getPaperShaderDefinition(requestedShaderType).label
+          : defaultName(kind)
         y.set('id', id)
         y.set('kind', kind)
-        y.set('name', props?.name ?? defaultName(kind))
+        y.set('name', props?.name ?? generatedName)
         y.set('parent', parent)
         y.set('children', new Y.Array<NodeId>())
-        y.set('transform', (props as Partial<FrameNode>)?.transform ?? DEFAULT_TRANSFORM)
+        y.set('transform', {
+          ...DEFAULT_TRANSFORM,
+          ...((props as Partial<FrameNode>)?.transform ?? {}),
+        })
         // Text and media paint through their own content, not through a
         // colored wrapper box. Any caller-supplied appearance wins.
         const defaultAppearance = defaultAppearanceForKind(kind)
@@ -970,6 +1099,67 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
         }
         if (kind === 'rect' || kind === 'ellipse' || kind === 'image' || kind === 'vector') {
           y.set('size', (props as Partial<FrameNode>)?.size ?? DEFAULT_SIZE)
+        }
+        if (kind === 'shader') {
+          const sp = props as Partial<ShaderNode> | undefined
+          const shaderType = requestedShaderType ?? 'mesh-gradient'
+          const definition = getPaperShaderDefinition(shaderType)
+          const params = normalizePaperShaderParams(
+            sp?.params,
+            definition.defaults.params,
+          )
+          const distortion = clampFiniteNumber(
+            sp?.distortion ??
+              (shaderType === 'mesh-gradient' ? params.distortion : undefined),
+            0,
+            1,
+            shaderType === 'mesh-gradient' ? 0.8 : 0,
+          )
+          const swirl = clampFiniteNumber(
+            sp?.swirl ??
+              (shaderType === 'mesh-gradient' ? params.swirl : undefined),
+            0,
+            1,
+            shaderType === 'mesh-gradient' ? 0.1 : 0,
+          )
+          const grain = clampFiniteNumber(
+            sp?.grain ??
+              (shaderType === 'mesh-gradient'
+                ? params.grainOverlay
+                : undefined),
+            0,
+            1,
+            shaderType === 'mesh-gradient' ? 0.08 : 0,
+          )
+          if (shaderType === 'mesh-gradient') {
+            params.distortion = distortion
+            params.swirl = swirl
+            params.grainOverlay = grain
+          }
+          y.set('size', sp?.size ?? DEFAULT_SHADER_SIZE)
+          y.set('shaderType', shaderType)
+          y.set(
+            'colors',
+            normalizePaperShaderColors(sp?.colors, shaderType),
+          )
+          y.set('params', params)
+          const sourceNodeId = normalizePaperShaderSourceNodeId(
+            sp?.sourceNodeId,
+          )
+          const sourceImage = normalizePaperShaderSourceImage(sp?.sourceImage)
+          if (sourceNodeId) y.set('sourceNodeId', sourceNodeId)
+          if (sourceImage) y.set('sourceImage', sourceImage)
+          y.set(
+            'speed',
+            clampFiniteNumber(sp?.speed, 0, 2, definition.defaults.speed),
+          )
+          y.set(
+            'scale',
+            clampFiniteNumber(sp?.scale, 0.1, 4, definition.defaults.scale),
+          )
+          y.set('distortion', distortion)
+          y.set('swirl', swirl)
+          y.set('grain', grain)
         }
         if (kind === 'vector') {
           const vp = props as Partial<VectorNode> | undefined
@@ -1134,6 +1324,11 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
           y.set('bloomStrength', cp?.bloomStrength ?? 0.8)
           y.set('bloomRadius', cp?.bloomRadius ?? 0.35)
           y.set('bloomThreshold', cp?.bloomThreshold ?? 0.75)
+          y.set('vhsEnabled', cp?.vhsEnabled ?? false)
+          y.set('vhsIntensity', cp?.vhsIntensity ?? 0.65)
+          y.set('vhsNoise', cp?.vhsNoise ?? 0.35)
+          y.set('vhsScanlines', cp?.vhsScanlines ?? 0.5)
+          y.set('vhsColorBleed', cp?.vhsColorBleed ?? 3)
           y.set('showFocusPlane', cp?.showFocusPlane ?? false)
         }
 
@@ -1187,6 +1382,44 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
     setNodeProperty: (nodeId, key, value) => {
       const y = ensureNode(nodeId)
       doc.transact(() => {
+        if (y.get('kind') === 'shader') {
+          const shaderType = normalizePaperShaderType(y.get('shaderType'))
+          if (
+            shaderType === 'mesh-gradient' &&
+            (key === 'distortion' || key === 'swirl' || key === 'grain')
+          ) {
+            const definition = getPaperShaderDefinition(shaderType)
+            const params = normalizePaperShaderParams(
+              y.get('params'),
+              definition.defaults.params,
+            )
+            const normalized = clampFiniteNumber(value, 0, 1, 0)
+            params[key === 'grain' ? 'grainOverlay' : key] = normalized
+            y.set('params', params)
+            y.set(key, normalized)
+            return
+          }
+          if (key === 'params') {
+            const definition = getPaperShaderDefinition(shaderType)
+            const params = normalizePaperShaderParams(
+              value,
+              definition.defaults.params,
+            )
+            y.set('params', params)
+            if (shaderType === 'mesh-gradient') {
+              y.set(
+                'distortion',
+                clampFiniteNumber(params.distortion, 0, 1, 0.8),
+              )
+              y.set('swirl', clampFiniteNumber(params.swirl, 0, 1, 0.1))
+              y.set(
+                'grain',
+                clampFiniteNumber(params.grainOverlay, 0, 1, 0.08),
+              )
+            }
+            return
+          }
+        }
         y.set(key, value)
       })
     },
@@ -1254,9 +1487,13 @@ export function createSceneAPI(doc: Y.Doc = new Y.Doc()): SceneAPI {
         if (!s || typeof s.id !== 'string') return
         const raw = s as Section & { duration?: number }
         const start = Number.isFinite(raw.start) ? raw.start : 0
+        const legacyDuration =
+          typeof raw.duration === 'number' && Number.isFinite(raw.duration)
+            ? raw.duration
+            : 0
         const end = Number.isFinite(raw.end)
           ? raw.end
-          : start + (Number.isFinite(raw.duration) ? raw.duration : 0)
+          : start + legacyDuration
         out.push({
           ...raw,
           start,
@@ -1493,6 +1730,30 @@ function finiteNumber(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function hasOwn(
+  value: Record<string, unknown> | undefined,
+  key: string,
+): boolean {
+  return value !== undefined && Object.prototype.hasOwnProperty.call(value, key)
+}
+
+function clampFiniteNumber(
+  value: unknown,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  return Math.max(min, Math.min(max, finiteNumber(value, fallback)))
+}
+
 function clamp01(value: unknown): number {
   return Math.max(0, Math.min(1, finiteNumber(value, 0)))
 }
@@ -1505,6 +1766,7 @@ function defaultName(kind: NodeKind): string {
     case 'vector': return 'Vector'
     case 'text': return 'Text'
     case 'image': return 'Image'
+    case 'shader': return 'Mesh Gradient'
     case 'video': return 'Video'
     case 'audio': return 'Audio'
     case 'component': return 'Component'

--- a/src/scene/file.ts
+++ b/src/scene/file.ts
@@ -2,6 +2,7 @@
 
 import * as Y from 'yjs'
 import { createSceneAPI, snapshotScene, type SceneAPI } from '@/scene/doc'
+import { removeLegacy3DObjects } from '@/scene/removeLegacy3DObjects'
 import type { NodeId, Scene } from '@/scene/types'
 
 /**
@@ -40,6 +41,7 @@ export function sceneToBytes(doc: Y.Doc): Uint8Array {
  */
 export function applyBytesToScene(doc: Y.Doc, bytes: Uint8Array): void {
   Y.applyUpdate(doc, bytes)
+  removeLegacy3DObjects(doc)
 }
 
 /**
@@ -63,6 +65,7 @@ export function applyBytesToScene(doc: Y.Doc, bytes: Uint8Array): void {
 export function loadSceneIntoDoc(targetDoc: Y.Doc, bytes: Uint8Array): void {
   const sideDoc = new Y.Doc()
   Y.applyUpdate(sideDoc, bytes)
+  removeLegacy3DObjects(sideDoc)
 
   const sideScene = sideDoc.getMap('scene')
   const targetScene = targetDoc.getMap('scene')

--- a/src/scene/paperShaders.ts
+++ b/src/scene/paperShaders.ts
@@ -1,0 +1,741 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Stable scene identifiers for every shader exported by
+ * `@paper-design/shaders-react@0.0.77`.
+ *
+ * These ids are persisted in `.hype` files, so they must not be renamed when
+ * a UI label changes. Add aliases during migration instead of changing an id.
+ */
+export const PAPER_SHADER_TYPES = [
+  'mesh-gradient',
+  'smoke-ring',
+  'neuro-noise',
+  'dot-orbit',
+  'dot-grid',
+  'simplex-noise',
+  'metaballs',
+  'waves',
+  'perlin-noise',
+  'voronoi',
+  'warp',
+  'god-rays',
+  'spiral',
+  'swirl',
+  'dithering',
+  'grain-gradient',
+  'pulsing-border',
+  'color-panels',
+  'static-mesh-gradient',
+  'static-radial-gradient',
+  'paper-texture',
+  'fluted-glass',
+  'water',
+  'image-dithering',
+  'halftone-dots',
+  'halftone-cmyk',
+  'heatmap',
+  'liquid-metal',
+  'gem-smoke',
+] as const
+
+export type PaperShaderType = (typeof PAPER_SHADER_TYPES)[number]
+export type PaperShaderCategory = 'generated' | 'image-filter' | 'shape'
+
+export type PaperShaderParamValue =
+  | string
+  | number
+  | boolean
+  | null
+  | PaperShaderParamValue[]
+  | { [key: string]: PaperShaderParamValue }
+
+export type PaperShaderParams = Record<string, PaperShaderParamValue>
+
+export interface PaperShaderDefaults {
+  /** Empty when the shader uses named colors instead of a color array. */
+  colors: readonly string[]
+  /** Scene-time multiplier. Zero freezes the shader. */
+  speed: number
+  /** Paper's global graphic scale. */
+  scale: number
+  /** Shader-specific Paper props, excluding image/frame/colors/speed/scale. */
+  params: Readonly<PaperShaderParams>
+}
+
+export interface PaperShaderDefinition {
+  /** Stable persisted id. `type` is retained as a UI-friendly synonym. */
+  id: PaperShaderType
+  type: PaperShaderType
+  label: string
+  category: PaperShaderCategory
+  /** The shader cannot produce its intended result without an image source. */
+  requiresImage: boolean
+  /** The shader accepts either `sourceNodeId` or `sourceImage`. */
+  acceptsImage: boolean
+  /** Maximum accepted length of the common `colors` array. */
+  maxColors: number
+  defaults: PaperShaderDefaults
+}
+
+export const DEFAULT_PAPER_SHADER_TYPE: PaperShaderType = 'mesh-gradient'
+export const PAPER_SHADER_HEX_COLOR =
+  /^#(?:[0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+
+const PAPER_SHADER_TYPE_SET: ReadonlySet<string> = new Set(PAPER_SHADER_TYPES)
+
+const DEFAULT_SIZING_PARAMS = {
+  fit: 'contain',
+  rotation: 0,
+  offsetX: 0,
+  offsetY: 0,
+  originX: 0.5,
+  originY: 0.5,
+} as const
+
+function definition(
+  id: PaperShaderType,
+  label: string,
+  category: PaperShaderCategory,
+  options: {
+    requiresImage?: boolean
+    acceptsImage?: boolean
+    maxColors?: number
+    colors?: readonly string[]
+    speed?: number
+    scale?: number
+    params?: PaperShaderParams
+  } = {},
+): PaperShaderDefinition {
+  return {
+    id,
+    type: id,
+    label,
+    category,
+    requiresImage: options.requiresImage ?? false,
+    acceptsImage: options.acceptsImage ?? false,
+    maxColors: options.maxColors ?? 10,
+    defaults: {
+      colors: options.colors ?? [],
+      speed: options.speed ?? 0,
+      scale: options.scale ?? 1,
+      params: options.params ?? {},
+    },
+  }
+}
+
+/**
+ * UI-ready catalog in the same order as Paper's React package: generated
+ * shaders first, followed by image filters and image/shape effects.
+ */
+export const PAPER_SHADER_CATALOG: readonly PaperShaderDefinition[] = [
+  definition('mesh-gradient', 'Mesh Gradient', 'generated', {
+    colors: ['#e0eaff', '#241d9a', '#f75092', '#9f50d3'],
+    speed: 0.6,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      distortion: 0.8,
+      swirl: 0.1,
+      grainMixer: 0,
+      grainOverlay: 0.08,
+    },
+  }),
+  definition('smoke-ring', 'Smoke Ring', 'generated', {
+    colors: ['#ffffff'],
+    speed: 0.5,
+    scale: 0.8,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      colorBack: '#000000',
+      noiseScale: 3,
+      noiseIterations: 8,
+      radius: 0.25,
+      thickness: 0.65,
+      innerShape: 0.7,
+    },
+  }),
+  definition('neuro-noise', 'Neuro Noise', 'generated', {
+    speed: 1,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'none',
+      colorFront: '#ffffff',
+      colorMid: '#47a6ff',
+      colorBack: '#000000',
+      brightness: 0.05,
+      contrast: 0.3,
+    },
+  }),
+  definition('dot-orbit', 'Dot Orbit', 'generated', {
+    colors: ['#ffc96b', '#ff6200', '#ff2f00', '#421100', '#1a0000'],
+    speed: 1.5,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'none',
+      colorBack: '#000000',
+      size: 1,
+      sizeRange: 0,
+      spreading: 1,
+      stepsPerColor: 4,
+    },
+  }),
+  definition('dot-grid', 'Dot Grid', 'generated', {
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'none',
+      colorBack: '#000000',
+      colorFill: '#ffffff',
+      colorStroke: '#ffaa00',
+      size: 2,
+      gapX: 32,
+      gapY: 32,
+      strokeWidth: 0,
+      sizeRange: 0,
+      opacityRange: 0,
+      shape: 'circle',
+    },
+  }),
+  definition('simplex-noise', 'Simplex Noise', 'generated', {
+    colors: ['#4449cf', '#ffd1e0', '#f94446', '#ffd36b', '#ffffff'],
+    speed: 0.5,
+    scale: 0.6,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'none',
+      stepsPerColor: 2,
+      softness: 0,
+    },
+  }),
+  definition('metaballs', 'Metaballs', 'generated', {
+    colors: ['#6e33cc', '#ff5500', '#ffc105', '#ffc800', '#f585ff'],
+    speed: 1,
+    maxColors: 8,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      colorBack: '#000000',
+      count: 10,
+      size: 0.83,
+    },
+  }),
+  definition('waves', 'Waves', 'generated', {
+    scale: 0.6,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'none',
+      colorFront: '#ffbb00',
+      colorBack: '#000000',
+      shape: 0,
+      frequency: 0.5,
+      amplitude: 0.5,
+      spacing: 1.2,
+      proportion: 0.1,
+      softness: 0,
+    },
+  }),
+  definition('perlin-noise', 'Perlin Noise', 'generated', {
+    speed: 0.5,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'none',
+      colorBack: '#632ad5',
+      colorFront: '#fccff7',
+      proportion: 0.35,
+      softness: 0.1,
+      octaveCount: 1,
+      persistence: 1,
+      lacunarity: 1.5,
+    },
+  }),
+  definition('voronoi', 'Voronoi', 'generated', {
+    colors: ['#ff8247', '#ffe53d'],
+    speed: 0.5,
+    scale: 0.5,
+    maxColors: 5,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'none',
+      stepsPerColor: 3,
+      colorGlow: '#ffffff',
+      colorGap: '#2e0000',
+      distortion: 0.4,
+      gap: 0.04,
+      glow: 0,
+    },
+  }),
+  definition('warp', 'Warp', 'generated', {
+    colors: ['#121212', '#9470ff', '#121212', '#8838ff'],
+    speed: 1,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'none',
+      proportion: 0.45,
+      softness: 1,
+      distortion: 0.25,
+      swirl: 0.8,
+      swirlIterations: 10,
+      shapeScale: 0.1,
+      shape: 'checks',
+    },
+  }),
+  definition('god-rays', 'God Rays', 'generated', {
+    colors: ['#a600ff6e', '#6200fff0', '#ffffff', '#33fff5'],
+    speed: 0.75,
+    maxColors: 5,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      offsetY: -0.55,
+      colorBack: '#000000',
+      colorBloom: '#0000ff',
+      density: 0.3,
+      spotty: 0.3,
+      midIntensity: 0.4,
+      midSize: 0.2,
+      intensity: 0.8,
+      bloom: 0.4,
+    },
+  }),
+  definition('spiral', 'Spiral', 'generated', {
+    speed: 1,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'none',
+      colorBack: '#001429',
+      colorFront: '#79d1ff',
+      density: 1,
+      distortion: 0,
+      strokeWidth: 0.5,
+      strokeTaper: 0,
+      strokeCap: 0,
+      noise: 0,
+      noiseFrequency: 0,
+      softness: 0,
+    },
+  }),
+  definition('swirl', 'Swirl', 'generated', {
+    colors: ['#ffd1d1', '#ff8a8a', '#660000'],
+    speed: 0.32,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      colorBack: '#330000',
+      bandCount: 4,
+      twist: 0.1,
+      center: 0.2,
+      proportion: 0.5,
+      softness: 0,
+      noiseFrequency: 0.4,
+      noise: 0.2,
+    },
+  }),
+  definition('dithering', 'Dithering', 'generated', {
+    speed: 1,
+    scale: 0.6,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'none',
+      colorBack: '#000000',
+      colorFront: '#00b2ff',
+      shape: 'sphere',
+      type: '4x4',
+      size: 2,
+    },
+  }),
+  definition('grain-gradient', 'Grain Gradient', 'generated', {
+    colors: ['#7300ff', '#eba8ff', '#00bfff', '#2a00ff'],
+    speed: 1,
+    maxColors: 7,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      colorBack: '#000000',
+      softness: 0.5,
+      intensity: 0.5,
+      noise: 0.25,
+      shape: 'corners',
+    },
+  }),
+  definition('pulsing-border', 'Pulsing Border', 'generated', {
+    colors: ['#0dc1fd', '#d915ef', '#ff3f2ecc'],
+    speed: 1,
+    scale: 0.6,
+    maxColors: 5,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      colorBack: '#000000',
+      roundness: 0.25,
+      thickness: 0.1,
+      margin: 0,
+      aspectRatio: 'auto',
+      softness: 0.75,
+      intensity: 0.2,
+      bloom: 0.25,
+      spots: 4,
+      spotSize: 0.5,
+      pulse: 0.25,
+      smoke: 0.3,
+      smokeSize: 0.6,
+    },
+  }),
+  definition('color-panels', 'Color Panels', 'generated', {
+    colors: [
+      '#ff9d00',
+      '#fd4f30',
+      '#809bff',
+      '#6d2eff',
+      '#333aff',
+      '#f15cff',
+      '#ffd557',
+    ],
+    speed: 0.5,
+    scale: 0.8,
+    maxColors: 7,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      colorBack: '#000000',
+      angle1: 0,
+      angle2: 0,
+      length: 1.1,
+      edges: false,
+      blur: 0,
+      fadeIn: 1,
+      fadeOut: 0.3,
+      gradient: 0,
+      density: 3,
+    },
+  }),
+  definition('static-mesh-gradient', 'Static Mesh Gradient', 'generated', {
+    colors: ['#ffad0a', '#6200ff', '#e2a3ff', '#ff99fd'],
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      rotation: 270,
+      positions: 2,
+      waveX: 1,
+      waveXShift: 0.6,
+      waveY: 1,
+      waveYShift: 0.21,
+      mixing: 0.93,
+      grainMixer: 0,
+      grainOverlay: 0,
+    },
+  }),
+  definition('static-radial-gradient', 'Static Radial Gradient', 'generated', {
+    colors: ['#00bbff', '#00ffe1', '#ffffff'],
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      colorBack: '#000000',
+      radius: 0.8,
+      focalDistance: 0.99,
+      focalAngle: 0,
+      falloff: 0.24,
+      mixing: 0.5,
+      distortion: 0,
+      distortionShift: 0,
+      distortionFreq: 12,
+      grainMixer: 0,
+      grainOverlay: 0,
+    },
+  }),
+  definition('paper-texture', 'Paper Texture', 'image-filter', {
+    acceptsImage: true,
+    scale: 0.6,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'cover',
+      colorFront: '#9fadbc',
+      colorBack: '#ffffff',
+      contrast: 0.3,
+      roughness: 0.4,
+      fiber: 0.3,
+      fiberSize: 0.2,
+      crumples: 0.3,
+      crumpleSize: 0.35,
+      folds: 0.65,
+      foldCount: 5,
+      fade: 0,
+      drops: 0.2,
+      seed: 5.8,
+    },
+  }),
+  definition('fluted-glass', 'Fluted Glass', 'image-filter', {
+    acceptsImage: true,
+    requiresImage: true,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'cover',
+      colorBack: '#00000000',
+      colorShadow: '#000000',
+      colorHighlight: '#ffffff',
+      shadows: 0.25,
+      size: 0.5,
+      angle: 0,
+      distortionShape: 'prism',
+      highlights: 0.1,
+      shape: 'lines',
+      distortion: 0.5,
+      shift: 0,
+      blur: 0,
+      edges: 0.25,
+      stretch: 0,
+      margin: 0,
+      grainMixer: 0,
+      grainOverlay: 0,
+    },
+  }),
+  definition('water', 'Water', 'image-filter', {
+    acceptsImage: true,
+    speed: 1,
+    scale: 0.8,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      colorBack: '#909090',
+      colorHighlight: '#ffffff',
+      highlights: 0.07,
+      layering: 0.5,
+      edges: 0.8,
+      waves: 0.3,
+      caustic: 0.1,
+      size: 1,
+    },
+  }),
+  definition('image-dithering', 'Image Dithering', 'image-filter', {
+    acceptsImage: true,
+    requiresImage: true,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'cover',
+      colorFront: '#94ffaf',
+      colorBack: '#000c38',
+      colorHighlight: '#eaff94',
+      type: '8x8',
+      size: 2,
+      colorSteps: 2,
+      originalColors: false,
+      inverted: false,
+    },
+  }),
+  definition('halftone-dots', 'Halftone Dots', 'image-filter', {
+    acceptsImage: true,
+    requiresImage: true,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'cover',
+      colorBack: '#f2f1e8',
+      colorFront: '#2b2b2b',
+      size: 0.5,
+      radius: 1.25,
+      contrast: 0.4,
+      originalColors: false,
+      inverted: false,
+      grainMixer: 0.2,
+      grainOverlay: 0.2,
+      grainSize: 0.5,
+      grid: 'hex',
+      type: 'gooey',
+    },
+  }),
+  definition('halftone-cmyk', 'Halftone CMYK', 'image-filter', {
+    acceptsImage: true,
+    requiresImage: true,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      fit: 'cover',
+      colorBack: '#fbfaf5',
+      colorC: '#00b4ff',
+      colorM: '#fc519f',
+      colorY: '#ffd800',
+      colorK: '#231f20',
+      size: 0.2,
+      contrast: 1,
+      softness: 1,
+      grainSize: 0.5,
+      grainMixer: 0,
+      grainOverlay: 0,
+      gridNoise: 0.2,
+      floodC: 0.15,
+      floodM: 0,
+      floodY: 0,
+      floodK: 0,
+      gainC: 0.3,
+      gainM: 0,
+      gainY: 0.2,
+      gainK: 0,
+      type: 'ink',
+    },
+  }),
+  definition('heatmap', 'Heatmap', 'shape', {
+    acceptsImage: true,
+    requiresImage: true,
+    colors: [
+      '#11206a',
+      '#1f3ba2',
+      '#2f63e7',
+      '#6bd7ff',
+      '#ffe679',
+      '#ff991e',
+      '#ff4c00',
+    ],
+    speed: 1,
+    scale: 0.75,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      colorBack: '#000000',
+      contour: 0.5,
+      angle: 0,
+      noise: 0,
+      innerGlow: 0.5,
+      outerGlow: 0.5,
+    },
+  }),
+  definition('liquid-metal', 'Liquid Metal', 'shape', {
+    acceptsImage: true,
+    speed: 1,
+    scale: 0.6,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      colorBack: '#aaaaac',
+      colorTint: '#ffffff',
+      distortion: 0.07,
+      repetition: 2,
+      shiftRed: 0.3,
+      shiftBlue: 0.3,
+      contour: 0.4,
+      softness: 0.1,
+      angle: 70,
+      shape: 'diamond',
+    },
+  }),
+  definition('gem-smoke', 'Gem Smoke', 'shape', {
+    acceptsImage: true,
+    colors: ['#333333', '#e7e6df'],
+    speed: 1,
+    scale: 0.6,
+    maxColors: 6,
+    params: {
+      ...DEFAULT_SIZING_PARAMS,
+      colorBack: '#f0efea',
+      colorInner: '#fafaf5',
+      outerGlow: 0.55,
+      innerGlow: 1,
+      innerDistortion: 0.8,
+      outerDistortion: 0.6,
+      offset: 0,
+      angle: 0,
+      size: 0.8,
+      shape: 'diamond',
+    },
+  }),
+]
+
+const PAPER_SHADER_BY_TYPE = new Map(
+  PAPER_SHADER_CATALOG.map((entry) => [entry.type, entry] as const),
+)
+
+export function isPaperShaderType(value: unknown): value is PaperShaderType {
+  return typeof value === 'string' && PAPER_SHADER_TYPE_SET.has(value)
+}
+
+export function normalizePaperShaderType(value: unknown): PaperShaderType {
+  return isPaperShaderType(value) ? value : DEFAULT_PAPER_SHADER_TYPE
+}
+
+export function getPaperShaderDefinition(
+  type: PaperShaderType,
+): PaperShaderDefinition {
+  return (
+    PAPER_SHADER_BY_TYPE.get(type) ??
+    PAPER_SHADER_BY_TYPE.get(DEFAULT_PAPER_SHADER_TYPE)!
+  )
+}
+
+export function normalizePaperShaderColors(
+  value: unknown,
+  type: PaperShaderType = DEFAULT_PAPER_SHADER_TYPE,
+): string[] {
+  const definition = getPaperShaderDefinition(type)
+  if (!Array.isArray(value)) return [...definition.defaults.colors]
+  const colors = value
+    .filter(
+      (color): color is string =>
+        typeof color === 'string' && PAPER_SHADER_HEX_COLOR.test(color),
+    )
+    .slice(0, definition.maxColors)
+  if (colors.length > 0 || definition.defaults.colors.length === 0) {
+    return colors
+  }
+  return [...definition.defaults.colors]
+}
+
+const MAX_PARAM_DEPTH = 6
+const MAX_PARAM_COLLECTION_LENGTH = 128
+const MAX_PARAM_STRING_LENGTH = 32_768
+const MAX_PARAM_NUMBER_MAGNITUDE = 1_000_000
+const UNSAFE_PARAM_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+function normalizeParamValue(
+  value: unknown,
+  depth: number,
+): PaperShaderParamValue | undefined {
+  if (value === null || typeof value === 'boolean') return value
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return undefined
+    return Math.max(
+      -MAX_PARAM_NUMBER_MAGNITUDE,
+      Math.min(MAX_PARAM_NUMBER_MAGNITUDE, value),
+    )
+  }
+  if (typeof value === 'string') return value.slice(0, MAX_PARAM_STRING_LENGTH)
+  if (depth >= MAX_PARAM_DEPTH) return undefined
+  if (Array.isArray(value)) {
+    const normalized: PaperShaderParamValue[] = []
+    for (const item of value.slice(0, MAX_PARAM_COLLECTION_LENGTH)) {
+      const next = normalizeParamValue(item, depth + 1)
+      if (next !== undefined) normalized.push(next)
+    }
+    return normalized
+  }
+  if (typeof value !== 'object') return undefined
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) return undefined
+  const normalized: PaperShaderParams = {}
+  for (const [key, item] of Object.entries(value).slice(
+    0,
+    MAX_PARAM_COLLECTION_LENGTH,
+  )) {
+    if (UNSAFE_PARAM_KEYS.has(key)) continue
+    const next = normalizeParamValue(item, depth + 1)
+    if (next !== undefined) normalized[key] = next
+  }
+  return normalized
+}
+
+export function normalizePaperShaderParams(
+  value: unknown,
+  defaults: Readonly<PaperShaderParams> = {},
+): PaperShaderParams {
+  const normalizedDefaults = normalizeParamValue(defaults, 0)
+  const normalizedValue = normalizeParamValue(value, 0)
+  return {
+    ...(isParamRecord(normalizedDefaults) ? normalizedDefaults : {}),
+    ...(isParamRecord(normalizedValue) ? normalizedValue : {}),
+  }
+}
+
+export function normalizePaperShaderSourceImage(
+  value: unknown,
+): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+export function normalizePaperShaderSourceNodeId(
+  value: unknown,
+): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 && trimmed.length <= 512 ? trimmed : undefined
+}
+
+function isParamRecord(
+  value: PaperShaderParamValue | undefined,
+): value is PaperShaderParams {
+  return value !== undefined && !Array.isArray(value) && typeof value === 'object'
+}

--- a/src/scene/props.ts
+++ b/src/scene/props.ts
@@ -195,6 +195,22 @@ export const PROPERTIES: Record<PropertyId, PropertyDescriptor> = {
     id: 'camera.bloomThreshold', group: 'camera', label: 'Bloom Threshold',
     layoutAffecting: false, interpolation: 'numeric', defaultValue: 0.75,
   },
+  'camera.vhsIntensity': {
+    id: 'camera.vhsIntensity', group: 'camera', label: 'VHS Intensity',
+    layoutAffecting: false, interpolation: 'numeric', defaultValue: 0.65,
+  },
+  'camera.vhsNoise': {
+    id: 'camera.vhsNoise', group: 'camera', label: 'VHS Noise',
+    layoutAffecting: false, interpolation: 'numeric', defaultValue: 0.35,
+  },
+  'camera.vhsScanlines': {
+    id: 'camera.vhsScanlines', group: 'camera', label: 'VHS Scanlines',
+    layoutAffecting: false, interpolation: 'numeric', defaultValue: 0.5,
+  },
+  'camera.vhsColorBleed': {
+    id: 'camera.vhsColorBleed', group: 'camera', label: 'VHS Color Bleed',
+    layoutAffecting: false, interpolation: 'numeric', defaultValue: 3,
+  },
 
   // appearance group — also post-layout
   'appearance.opacity': {

--- a/src/scene/removeLegacy3DObjects.test.ts
+++ b/src/scene/removeLegacy3DObjects.test.ts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+import { createSceneAPI } from '@/scene/doc'
+import { loadSceneIntoDoc, readScene, sceneToBytes } from '@/scene/file'
+import { removeLegacy3DObjects } from '@/scene/removeLegacy3DObjects'
+
+describe('removed standalone 3D objects', () => {
+  it('purges old objects, descendants, tracks, and references idempotently', () => {
+    const doc = legacyObjectDocument()
+
+    expect(removeLegacy3DObjects(doc)).toEqual(['cube', 'cube-child'])
+    expect(removeLegacy3DObjects(doc)).toEqual([])
+
+    const api = createSceneAPI(doc)
+    expect(api.getAllNodeIds().sort()).toEqual([
+      'camera',
+      'root',
+      'shader',
+      'title',
+    ])
+    expect(api.getNode('root')?.children).toEqual(['title', 'shader'])
+    expect(api.getTrack('cube-track')).toBeNull()
+    expect(api.getTrack('title-track')).not.toBeNull()
+
+    const camera = api.getNode('camera')
+    expect(camera?.kind).toBe('camera')
+    if (camera?.kind === 'camera') {
+      expect(camera.focusTargetNodeId).toBeNull()
+      expect(camera.focusMode).toBe('screen')
+    }
+
+    const shader = api.getNode('shader')
+    expect(shader?.kind).toBe('shader')
+    if (shader?.kind === 'shader') {
+      expect(shader.sourceNodeId).toBeUndefined()
+    }
+
+    expect(api.getUiState().trackGroups).toEqual({
+      keep: {
+        trackIds: ['title-track'],
+        collapsed: false,
+      },
+    })
+    expect(api.getUiState().kfGroups).toEqual({
+      keep: ['title-keyframe'],
+    })
+    expect(api.getUiState().staggerSets).toEqual({
+      keep: {
+        id: 'keep',
+        layerIds: ['title'],
+        delay: 0.1,
+        order: 'forward',
+        members: {
+          title: {
+            'appearance.opacity': ['title-keyframe'],
+          },
+        },
+      },
+    })
+  })
+
+  it('opens an old .hype document without exposing the removed node kind', () => {
+    const oldBytes = sceneToBytes(legacyObjectDocument())
+    const { doc, api } = readScene(oldBytes)
+
+    expect(api.getNode('cube')).toBeNull()
+    expect(api.getNode('cube-child')).toBeNull()
+    expect(api.getNode('root')?.children).toEqual(['title', 'shader'])
+
+    doc.destroy()
+  })
+
+  it('replaces an active editor document with a sanitized old file', () => {
+    const targetApi = createSceneAPI()
+    loadSceneIntoDoc(targetApi.doc, sceneToBytes(legacyObjectDocument()))
+
+    expect(targetApi.getNode('cube')).toBeNull()
+    expect(targetApi.getNode('cube-child')).toBeNull()
+    expect(targetApi.getNode('root')?.children).toEqual(['title', 'shader'])
+  })
+})
+
+function legacyObjectDocument(): Y.Doc {
+  const doc = new Y.Doc()
+  const scene = doc.getMap<unknown>('scene')
+  const nodes = new Y.Map<Y.Map<unknown>>()
+  const tracks = new Y.Map<Y.Map<unknown>>()
+  const uiState = new Y.Map<unknown>()
+
+  scene.set('nodes', nodes)
+  scene.set('tracks', tracks)
+  scene.set('uiState', uiState)
+  scene.set('root', 'root')
+  scene.set('activeCameraId', 'camera')
+
+  nodes.set('root', rawNode('root', 'frame', null, [
+    'title',
+    'cube',
+    'shader',
+  ]))
+  nodes.set('title', rawNode('title', 'text', 'root'))
+  nodes.set('cube', rawNode('cube', 'primitive3d', 'root', ['cube-child']))
+  nodes.set('cube-child', rawNode('cube-child', 'rect', 'cube'))
+
+  const shader = rawNode('shader', 'shader', 'root')
+  shader.set('sourceNodeId', 'cube')
+  nodes.set('shader', shader)
+
+  const camera = rawNode('camera', 'camera', null)
+  camera.set('focusMode', 'target')
+  camera.set('focusTargetNodeId', 'cube')
+  nodes.set('camera', camera)
+
+  tracks.set(
+    'cube-track',
+    rawTrack('cube-track', 'cube', 'cube-keyframe'),
+  )
+  tracks.set(
+    'title-track',
+    rawTrack('title-track', 'title', 'title-keyframe'),
+  )
+
+  uiState.set('trackGroups', {
+    remove: {
+      trackIds: ['cube-track'],
+      collapsed: false,
+    },
+    keep: {
+      trackIds: ['cube-track', 'title-track'],
+      collapsed: false,
+    },
+  })
+  uiState.set('kfGroups', {
+    remove: ['cube-keyframe'],
+    keep: ['cube-keyframe', 'title-keyframe'],
+  })
+  uiState.set('kfGroupCollapsed', {
+    remove: true,
+    keep: false,
+  })
+  uiState.set('staggerSets', {
+    remove: {
+      id: 'remove',
+      layerIds: ['cube'],
+      delay: 0.1,
+      order: 'forward',
+      members: {
+        cube: {
+          'appearance.opacity': ['cube-keyframe'],
+        },
+      },
+    },
+    keep: {
+      id: 'keep',
+      layerIds: ['cube', 'title'],
+      delay: 0.1,
+      order: 'forward',
+      members: {
+        cube: {
+          'appearance.opacity': ['cube-keyframe'],
+        },
+        title: {
+          'appearance.opacity': ['cube-keyframe', 'title-keyframe'],
+        },
+      },
+    },
+  })
+
+  return doc
+}
+
+function rawNode(
+  id: string,
+  kind: string,
+  parent: string | null,
+  children: string[] = [],
+): Y.Map<unknown> {
+  const node = new Y.Map<unknown>()
+  const childArray = new Y.Array<string>()
+  node.set('id', id)
+  node.set('kind', kind)
+  node.set('name', id)
+  node.set('parent', parent)
+  node.set('children', childArray)
+  if (children.length > 0) childArray.push(children)
+  return node
+}
+
+function rawTrack(
+  id: string,
+  nodeId: string,
+  keyframeId: string,
+): Y.Map<unknown> {
+  const track = new Y.Map<unknown>()
+  track.set('id', id)
+  track.set('nodeId', nodeId)
+  track.set('propertyId', 'appearance.opacity')
+  track.set('defaultEasing', 'linear')
+  track.set('keyframes', [{ id: keyframeId, time: 0, value: 1 }])
+  return track
+}

--- a/src/scene/removeLegacy3DObjects.ts
+++ b/src/scene/removeLegacy3DObjects.ts
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import * as Y from 'yjs'
+
+const REMOVED_NODE_KIND = 'primitive3d'
+
+/**
+ * Remove documents authored while standalone GPU objects were briefly
+ * available. This runs on raw Yjs data before the typed scene reader sees it,
+ * so old autosaves and .hype files cannot surface an unsupported node kind.
+ *
+ * The literal kind intentionally lives only in this compatibility cleanup;
+ * it is not part of the public scene model or authoring API.
+ */
+export function removeLegacy3DObjects(doc: Y.Doc): string[] {
+  const scene = doc.getMap<unknown>('scene')
+  const nodesValue = scene.get('nodes')
+  if (!(nodesValue instanceof Y.Map)) return []
+
+  const nodes = nodesValue as Y.Map<Y.Map<unknown>>
+  const removedNodeIds = new Set<string>()
+  const visitRemovedSubtree = (nodeId: string) => {
+    if (removedNodeIds.has(nodeId)) return
+    removedNodeIds.add(nodeId)
+    const node = nodes.get(nodeId)
+    if (!(node instanceof Y.Map)) return
+    for (const childId of readStringArray(node.get('children'))) {
+      visitRemovedSubtree(childId)
+    }
+  }
+
+  for (const [nodeId, node] of nodes.entries()) {
+    if (
+      node instanceof Y.Map &&
+      node.get('kind') === REMOVED_NODE_KIND
+    ) {
+      visitRemovedSubtree(nodeId)
+    }
+  }
+  if (removedNodeIds.size === 0) return []
+
+  doc.transact(() => {
+    for (const [nodeId, node] of nodes.entries()) {
+      if (!(node instanceof Y.Map) || removedNodeIds.has(nodeId)) continue
+      removeIdsFromNodeChildren(node, removedNodeIds)
+
+      if (removedNodeIds.has(String(node.get('focusTargetNodeId') ?? ''))) {
+        node.set('focusTargetNodeId', null)
+        node.set('focusMode', 'screen')
+      }
+      if (removedNodeIds.has(String(node.get('sourceNodeId') ?? ''))) {
+        node.delete('sourceNodeId')
+      }
+      if (removedNodeIds.has(String(node.get('componentSourceId') ?? ''))) {
+        node.set('componentSourceId', null)
+      }
+    }
+
+    const removedTrackIds = new Set<string>()
+    const removedKeyframeIds = new Set<string>()
+    const tracksValue = scene.get('tracks')
+    if (tracksValue instanceof Y.Map) {
+      const tracks = tracksValue as Y.Map<Y.Map<unknown>>
+      for (const [trackId, track] of tracks.entries()) {
+        if (
+          !(track instanceof Y.Map) ||
+          !removedNodeIds.has(String(track.get('nodeId') ?? ''))
+        ) {
+          continue
+        }
+        removedTrackIds.add(trackId)
+        for (const keyframe of readRecordArray(track.get('keyframes'))) {
+          if (typeof keyframe.id === 'string') {
+            removedKeyframeIds.add(keyframe.id)
+          }
+        }
+        tracks.delete(trackId)
+      }
+    }
+
+    cleanUiState(
+      scene.get('uiState'),
+      removedNodeIds,
+      removedTrackIds,
+      removedKeyframeIds,
+    )
+
+    for (const nodeId of removedNodeIds) nodes.delete(nodeId)
+    if (removedNodeIds.has(String(scene.get('root') ?? ''))) {
+      scene.set('root', '')
+    }
+    if (removedNodeIds.has(String(scene.get('activeCameraId') ?? ''))) {
+      scene.set('activeCameraId', '')
+    }
+  }, removeLegacy3DObjects)
+
+  return [...removedNodeIds]
+}
+
+function removeIdsFromNodeChildren(
+  node: Y.Map<unknown>,
+  removedNodeIds: ReadonlySet<string>,
+) {
+  const value = node.get('children')
+  const next = readStringArray(value).filter((id) => !removedNodeIds.has(id))
+  if (value instanceof Y.Array) {
+    if (next.length === value.length) return
+    value.delete(0, value.length)
+    if (next.length > 0) value.push(next)
+    return
+  }
+  if (Array.isArray(value) && next.length !== value.length) {
+    node.set('children', next)
+  }
+}
+
+function cleanUiState(
+  value: unknown,
+  removedNodeIds: ReadonlySet<string>,
+  removedTrackIds: ReadonlySet<string>,
+  removedKeyframeIds: ReadonlySet<string>,
+) {
+  if (!(value instanceof Y.Map)) return
+  const uiState = value as Y.Map<unknown>
+
+  const rawTrackGroups = uiState.get('trackGroups')
+  if (isRecord(rawTrackGroups)) {
+    const trackGroups: Record<string, unknown> = {}
+    for (const [groupId, rawGroup] of Object.entries(rawTrackGroups)) {
+      if (!isRecord(rawGroup) || !Array.isArray(rawGroup.trackIds)) continue
+      const trackIds = rawGroup.trackIds.filter(
+        (id): id is string =>
+          typeof id === 'string' && !removedTrackIds.has(id),
+      )
+      if (trackIds.length > 0) {
+        trackGroups[groupId] = { ...rawGroup, trackIds }
+      }
+    }
+    uiState.set('trackGroups', trackGroups)
+  }
+
+  const rawKeyframeGroups = uiState.get('kfGroups')
+  const keyframeGroups: Record<string, string[]> = {}
+  if (isRecord(rawKeyframeGroups)) {
+    for (const [groupId, rawIds] of Object.entries(rawKeyframeGroups)) {
+      if (!Array.isArray(rawIds)) continue
+      const ids = rawIds.filter(
+        (id): id is string =>
+          typeof id === 'string' && !removedKeyframeIds.has(id),
+      )
+      if (ids.length > 0) keyframeGroups[groupId] = ids
+    }
+    uiState.set('kfGroups', keyframeGroups)
+  }
+
+  const rawCollapsed = uiState.get('kfGroupCollapsed')
+  if (isRecord(rawKeyframeGroups) && isRecord(rawCollapsed)) {
+    uiState.set(
+      'kfGroupCollapsed',
+      Object.fromEntries(
+        Object.entries(rawCollapsed).filter(([groupId]) =>
+          Object.hasOwn(keyframeGroups, groupId),
+        ),
+      ),
+    )
+  }
+
+  const rawStaggerSets = uiState.get('staggerSets')
+  if (isRecord(rawStaggerSets)) {
+    const staggerSets: Record<string, unknown> = {}
+    for (const [setId, rawSet] of Object.entries(rawStaggerSets)) {
+      if (!isRecord(rawSet) || !Array.isArray(rawSet.layerIds)) continue
+      const layerIds = rawSet.layerIds.filter(
+        (id): id is string =>
+          typeof id === 'string' && !removedNodeIds.has(id),
+      )
+      if (layerIds.length === 0) continue
+
+      const members: Record<string, unknown> = {}
+      if (isRecord(rawSet.members)) {
+        for (const [nodeId, rawProperties] of Object.entries(rawSet.members)) {
+          if (removedNodeIds.has(nodeId) || !isRecord(rawProperties)) continue
+          members[nodeId] = Object.fromEntries(
+            Object.entries(rawProperties).map(([propertyId, rawIds]) => [
+              propertyId,
+              Array.isArray(rawIds)
+                ? rawIds.filter(
+                    (id) =>
+                      typeof id === 'string' && !removedKeyframeIds.has(id),
+                  )
+                : rawIds,
+            ]),
+          )
+        }
+      }
+      staggerSets[setId] = { ...rawSet, layerIds, members }
+    }
+    uiState.set('staggerSets', staggerSets)
+  }
+}
+
+function readStringArray(value: unknown): string[] {
+  const list = value instanceof Y.Array ? value.toArray() : value
+  return Array.isArray(list)
+    ? list.filter((item): item is string => typeof item === 'string')
+    : []
+}
+
+function readRecordArray(value: unknown): Record<string, unknown>[] {
+  const list = value instanceof Y.Array ? value.toArray() : value
+  return Array.isArray(list)
+    ? list.filter(isRecord)
+    : []
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/scene/shaderNode.test.ts
+++ b/src/scene/shaderNode.test.ts
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+import { createSceneAPI } from '@/scene/doc'
+import { readScene, sceneToBytes } from '@/scene/file'
+import {
+  PAPER_SHADER_CATALOG,
+  PAPER_SHADER_TYPES,
+  getPaperShaderDefinition,
+  normalizePaperShaderParams,
+} from '@/scene/paperShaders'
+
+const DEFAULT_COLORS = [
+  '#e0eaff',
+  '#241d9a',
+  '#f75092',
+  '#9f50d3',
+]
+
+describe('ShaderNode persistence', () => {
+  it('creates a Mesh Gradient with renderer-safe defaults', () => {
+    const api = createSceneAPI()
+    const id = api.createNode('shader', null)
+    const node = api.getNode(id)
+
+    expect(node?.kind).toBe('shader')
+    if (!node || node.kind !== 'shader') throw new Error('Expected shader')
+    expect(node).toMatchObject({
+      name: 'Mesh Gradient',
+      size: { width: 640, height: 360 },
+      shaderType: 'mesh-gradient',
+      colors: DEFAULT_COLORS,
+      speed: 0.6,
+      scale: 1,
+      distortion: 0.8,
+      swirl: 0.1,
+      grain: 0.08,
+      params: {
+        fit: 'contain',
+        distortion: 0.8,
+        swirl: 0.1,
+        grainOverlay: 0.08,
+      },
+      appearance: {
+        fill: null,
+        stroke: null,
+      },
+    })
+  })
+
+  it('catalogs every Paper React shader with five required image sources', () => {
+    expect(PAPER_SHADER_TYPES).toHaveLength(29)
+    expect(PAPER_SHADER_CATALOG.map(({ type }) => type)).toEqual([
+      ...PAPER_SHADER_TYPES,
+    ])
+    expect(
+      PAPER_SHADER_CATALOG.filter(({ requiresImage }) => requiresImage).map(
+        ({ type }) => type,
+      ),
+    ).toEqual([
+      'fluted-glass',
+      'image-dithering',
+      'halftone-dots',
+      'halftone-cmyk',
+      'heatmap',
+    ])
+    expect(getPaperShaderDefinition('liquid-metal')).toMatchObject({
+      label: 'Liquid Metal',
+      category: 'shape',
+      acceptsImage: true,
+      requiresImage: false,
+    })
+  })
+
+  it('round-trips a generic shader and its layer source', () => {
+    const api = createSceneAPI()
+    const sourceId = api.createNode('rect', null)
+    const shaderId = api.createNode('shader', null, {
+      shaderType: 'halftone-cmyk',
+      sourceNodeId: sourceId,
+      params: {
+        size: 0.35,
+        type: 'sharp',
+        originalColors: false,
+      },
+    })
+
+    const reopened = readScene(sceneToBytes(api.doc)).api.getNode(shaderId)
+    expect(reopened?.kind).toBe('shader')
+    if (!reopened || reopened.kind !== 'shader') throw new Error('Expected shader')
+    expect(reopened).toMatchObject({
+      name: 'Halftone CMYK',
+      shaderType: 'halftone-cmyk',
+      sourceNodeId: sourceId,
+      speed: 0,
+      scale: 1,
+      params: {
+        size: 0.35,
+        type: 'sharp',
+        originalColors: false,
+      },
+    })
+  })
+
+  it('bounds generic shader params to serializable values', () => {
+    expect(
+      normalizePaperShaderParams({
+        good: 12,
+        infinite: Number.POSITIVE_INFINITY,
+        huge: 2_000_000,
+        text: 'ok',
+        nested: [true, undefined, null],
+      }),
+    ).toEqual({
+      good: 12,
+      huge: 1_000_000,
+      text: 'ok',
+      nested: [true, null],
+    })
+  })
+
+  it('updates and round-trips authored shader parameters', () => {
+    const api = createSceneAPI()
+    const id = api.createNode('shader', null, {
+      size: { width: 320, height: 180 },
+      colors: ['#001122', '#aabbcc'],
+      speed: 1.25,
+      scale: 1.4,
+      distortion: 0.45,
+      swirl: 0.2,
+      grain: 0.16,
+    })
+
+    api.setNodeProperty(id, 'grain', 0.24)
+    api.setNodeProperty(id, 'colors', ['#ff0000', '#0000ff'])
+
+    const reopened = readScene(sceneToBytes(api.doc)).api.getNode(id)
+    expect(reopened?.kind).toBe('shader')
+    if (!reopened || reopened.kind !== 'shader') {
+      throw new Error('Expected reopened shader')
+    }
+    expect(reopened).toMatchObject({
+      size: { width: 320, height: 180 },
+      shaderType: 'mesh-gradient',
+      colors: ['#ff0000', '#0000ff'],
+      speed: 1.25,
+      scale: 1.4,
+      distortion: 0.45,
+      swirl: 0.2,
+      grain: 0.24,
+      params: {
+        distortion: 0.45,
+        swirl: 0.2,
+        grainOverlay: 0.24,
+      },
+    })
+  })
+
+  it('migrates legacy Mesh Gradient fields into missing params', () => {
+    const api = createSceneAPI()
+    const id = api.createNode('shader', null)
+    const nodes = api.doc.getMap('scene').get('nodes') as Y.Map<Y.Map<unknown>>
+    const stored = nodes.get(id)
+    if (!stored) throw new Error('Expected stored shader')
+    api.doc.transact(() => {
+      stored.delete('params')
+      stored.set('distortion', 0.31)
+      stored.set('swirl', 0.22)
+      stored.set('grain', 0.13)
+    })
+
+    const node = api.getNode(id)
+    if (!node || node.kind !== 'shader') throw new Error('Expected shader')
+    expect(node.params).toMatchObject({
+      distortion: 0.31,
+      swirl: 0.22,
+      grainOverlay: 0.13,
+    })
+  })
+
+  it('mirrors explicit Mesh Gradient params into legacy fields on create', () => {
+    const api = createSceneAPI()
+    const id = api.createNode('shader', null, {
+      shaderType: 'mesh-gradient',
+      params: {
+        distortion: 0.42,
+        swirl: 0.33,
+        grainOverlay: 0.14,
+      },
+    })
+
+    const node = api.getNode(id)
+    if (!node || node.kind !== 'shader') throw new Error('Expected shader')
+    expect(node).toMatchObject({
+      distortion: 0.42,
+      swirl: 0.33,
+      grain: 0.14,
+      params: {
+        distortion: 0.42,
+        swirl: 0.33,
+        grainOverlay: 0.14,
+      },
+    })
+  })
+
+  it('normalizes missing and malformed fields from older documents', () => {
+    const api = createSceneAPI()
+    const id = api.createNode('shader', null)
+    const nodes = api.doc.getMap('scene').get('nodes') as Y.Map<Y.Map<unknown>>
+    const stored = nodes.get(id)
+    if (!stored) throw new Error('Expected stored shader')
+
+    api.doc.transact(() => {
+      stored.delete('size')
+      stored.set('shaderType', 'future-shader')
+      stored.set('colors', [42, 'bogus', '#abcdef'])
+      stored.set('speed', Number.NaN)
+      stored.set('scale', 8)
+      stored.set('distortion', -1)
+      stored.set('swirl', 2)
+      stored.set('grain', 1.5)
+    })
+
+    const node = api.getNode(id)
+    if (!node || node.kind !== 'shader') throw new Error('Expected shader')
+    expect(node).toMatchObject({
+      size: { width: 640, height: 360 },
+      shaderType: 'mesh-gradient',
+      colors: ['#abcdef'],
+      speed: 0.6,
+      scale: 4,
+      distortion: 0,
+      swirl: 1,
+      grain: 1,
+    })
+  })
+})

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -1,5 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import type {
+  PaperShaderParams,
+  PaperShaderType,
+} from '@/scene/paperShaders'
+
+export type {
+  PaperShaderCategory,
+  PaperShaderDefinition,
+  PaperShaderParams,
+  PaperShaderParamValue,
+  PaperShaderType,
+} from '@/scene/paperShaders'
+
 /**
  * Scene graph types.
  *
@@ -726,6 +739,37 @@ export interface ImageNode extends NodeBase {
 }
 
 /**
+ * Generated shader layer rendered by Paper Shaders.
+ *
+ * Common parameters stay directly on the node for backward compatibility
+ * with the original Mesh Gradient schema. Shader-specific Paper props live in
+ * `params`, while image-consuming shaders can resolve either another scene
+ * layer (`sourceNodeId`) or a self-contained/path-based source (`sourceImage`).
+ */
+export interface ShaderNode extends NodeBase {
+  kind: 'shader'
+  size: Size
+  shaderType: PaperShaderType
+  /** Paper-compatible #RGB, #RRGGBB, or #RRGGBBAA colors. */
+  colors: string[]
+  /** Shader-specific JSON-serializable Paper props. */
+  params: PaperShaderParams
+  /** Optional source layer for Paper image filters and shape effects. */
+  sourceNodeId?: NodeId
+  /** Optional data URL, URL, or absolute path used as the image source. */
+  sourceImage?: string
+  /** Timeline multiplier shared by animated shaders. */
+  speed: number
+  /** Paper's global shader graphic scale. */
+  scale: number
+  /** Legacy Mesh Gradient fields retained for old scenes and callers. */
+  distortion: number
+  swirl: number
+  /** Paper MeshGradient's grainOverlay value. */
+  grain: number
+}
+
+/**
  * Video node. Visual layer backed by an HTMLVideoElement. The source
  * media is stored as a data URL on `src` for MVP (same strategy as
  * ImageNode — keeps the Yjs doc self-contained, heavy but simple).
@@ -930,6 +974,16 @@ export interface CameraNode extends NodeBase {
   bloomRadius: number
   /** Normalized luminance threshold above which pixels bloom. */
   bloomThreshold: number
+  /** Enables the camera-wide analog VHS signal treatment. */
+  vhsEnabled: boolean
+  /** Overall VHS contribution, from a clean signal at 0 to a worn tape at 1. */
+  vhsIntensity: number
+  /** Fine luminance grain mixed into the VHS signal, from 0 to 1. */
+  vhsNoise: number
+  /** Horizontal tape scanline contrast, from 0 to 1. */
+  vhsScanlines: number
+  /** Horizontal red/blue tape bleed in composition pixels. */
+  vhsColorBleed: number
   /** Whether editor helpers should draw the focus plane. */
   showFocusPlane: boolean
 }
@@ -992,6 +1046,7 @@ export type Node =
   | VectorNode
   | TextNode
   | ImageNode
+  | ShaderNode
   | VideoNode
   | AudioNode
   | ComponentNode
@@ -1160,6 +1215,10 @@ export type PropertyId =
   | 'camera.bloomStrength'
   | 'camera.bloomRadius'
   | 'camera.bloomThreshold'
+  | 'camera.vhsIntensity'
+  | 'camera.vhsNoise'
+  | 'camera.vhsScanlines'
+  | 'camera.vhsColorBleed'
   // appearance group — post-layout, cheap
   | 'appearance.opacity'
   | 'appearance.cornerRadius'

--- a/src/ui/Canvas.tsx
+++ b/src/ui/Canvas.tsx
@@ -66,6 +66,10 @@ import { SnapshotCompositor } from '@/render/SnapshotCompositor'
 import { CameraPostEffectsFallback } from '@/render/CameraPostEffectsFallback'
 import { resolveFallbackCameraPostEffects } from '@/render/cameraPostEffectsFallbackState'
 import { resolveCameraDomProjection } from '@/render/cameraDomProjection'
+import {
+  LivePaperShaderCanvas,
+  PaperShaderSourceLayer,
+} from '@/render/PaperShaderLayer'
 import type { CameraPostEffectsState } from '@/render3d/postEffects'
 import { ThreeSceneViewport } from '@/render3d/ThreeSceneViewport'
 import {
@@ -105,10 +109,20 @@ import {
 import { scrambleTextForSegment } from '@/anim/textScramble'
 import {
   cameraPreviewStore,
-  cameraTransformPreview,
   mergeCameraAnimationPreview,
 } from '@/ui/cameraPreviewStore'
-import { cameraWheelStartZ, cameraZFromWheel } from '@/ui/cameraWheel'
+import {
+  cameraDollyFromWheel,
+  cameraOrbitFromPointer,
+  cameraOrbitFromWheel,
+  cameraPanFromPointer,
+  cameraPanFromWheel,
+  cameraZFromPointerDrag,
+  resolveCameraPointerNavigation,
+  resolveCameraWheelNavigation,
+  type CameraNavigationMode,
+} from '@/ui/cameraNavigation'
+import { UNDOABLE_GESTURE_ORIGIN } from '@/scene/undo'
 import { textStaggerCurvePreviewStore } from '@/ui/textStaggerCurvePreviewStore'
 
 const MemoizedThreeSceneViewport = memo(ThreeSceneViewport)
@@ -133,6 +147,24 @@ const EMPTY_THREE_SELECTION_IDS: NodeId[] = []
 const CAMERA_CONTROL_DRAG_THRESHOLD_PX = 6
 const subscribeToNothing = () => () => {}
 const getNoCameraPreview = () => undefined
+
+type CameraControlSample = {
+  time: number
+  patch: Record<string, number>
+  mode: 'record' | 'active-track'
+}
+
+type CameraGestureSession = {
+  cameraId: NodeId
+  mode: CameraNavigationMode
+  transform: CameraNode['transform']
+  latestTransform: CameraNode['transform']
+  startPlayhead: number
+  startPerfTime: number
+  lastSampleTime: number
+  didStampStart: boolean
+  samples: CameraControlSample[]
+}
 
 /**
  * Subscribe one small render leaf to the camera engine + transient gesture
@@ -174,9 +206,32 @@ const AnimatedThreeSceneViewport = memo(function AnimatedThreeSceneViewport({
     void props.sceneVersion
     return hasNodeDrivenTextAnimation(props.api, animationIds)
   }, [animationIds, props.api, props.sceneVersion])
+  const needsPaperShaderClock = useMemo(() => {
+    void props.sceneVersion
+    return animationIds.some((id) => {
+      const node = props.api.getNode(id)
+      return (
+        node?.kind === 'shader' &&
+        node.visible &&
+        node.speed > 0.0001
+      )
+    })
+  }, [animationIds, props.api, props.sceneVersion])
   const nodeTextClockEnabled =
     props.playing === true && props.showPlanes !== false && needsNodeTextClock
-  const nodeTextPlayhead = useAnimationPlaybackClock(nodeTextClockEnabled)
+  const paperShaderClockEnabled =
+    props.playing === true &&
+    props.showPlanes !== false &&
+    needsPaperShaderClock
+  const temporalVhsEnabled =
+    props.playing === true &&
+    camera.vhsEnabled === true &&
+    (cameraAnim?.vhsIntensity ?? camera.vhsIntensity ?? 0.65) > 0.001
+  const playbackClockEnabled =
+    nodeTextClockEnabled ||
+    paperShaderClockEnabled ||
+    temporalVhsEnabled
+  const playbackClock = useAnimationPlaybackClock(playbackClockEnabled)
   const pausedPlayhead = useUI((state) =>
     state.playing ? null : state.playhead,
   )
@@ -184,8 +239,8 @@ const AnimatedThreeSceneViewport = memo(function AnimatedThreeSceneViewport({
   // Read the engine-owned time during that render instead of subscribing this
   // WebGL leaf to the slower 15 Hz UI mirror as a second render source.
   const playbackPlayhead = props.playing
-    ? nodeTextClockEnabled
-      ? nodeTextPlayhead
+    ? playbackClockEnabled
+      ? playbackClock
       : getAnimEngine().getPlayhead()
     : (pausedPlayhead ?? props.playhead ?? 0)
   return (
@@ -1024,6 +1079,8 @@ export function Canvas() {
     ],
   )
   const [isCameraManipulating, setIsCameraManipulating] = useState(false)
+  const [cameraNavigationMode, setCameraNavigationMode] =
+    useState<CameraNavigationMode | null>(null)
   const previewCameraDepthOfField = isCameraManipulating
     ? null
     : cameraDepthOfField
@@ -1037,18 +1094,34 @@ export function Canvas() {
   )
 
   const displayedCameraTransform = useCallback(
-    (node: CameraNode): CameraNode['transform'] => ({
-      ...node.transform,
-      x: liveCameraAnim?.x ?? node.transform.x,
-      y: liveCameraAnim?.y ?? node.transform.y,
-      z: liveCameraAnim?.z ?? node.transform.z,
-      rotation: liveCameraAnim?.rotation ?? node.transform.rotation,
-      rotationX: liveCameraAnim?.rotationX ?? node.transform.rotationX,
-      rotationY: liveCameraAnim?.rotationY ?? node.transform.rotationY,
-      scaleX: liveCameraAnim?.scaleX ?? node.transform.scaleX,
-      scaleY: liveCameraAnim?.scaleY ?? node.transform.scaleY,
-    }),
-    [liveCameraAnim],
+    (node: CameraNode): CameraNode['transform'] => {
+      // The normal WebGL path intentionally does not subscribe all of Canvas
+      // to every animation frame. Read the current engine and gesture preview
+      // at the input boundary so a new navigation gesture starts from the pose
+      // the user can actually see.
+      const engineValue = getAnimEngine().getSnapshot()[node.id]
+      const previewSnapshot = cameraPreviewStore.getSnapshot()
+      const previewValue =
+        previewSnapshot?.cameraId === node.id
+          ? previewSnapshot.value
+          : undefined
+      const animated = {
+        ...engineValue,
+        ...previewValue,
+      }
+      return {
+        ...node.transform,
+        x: animated.x ?? node.transform.x,
+        y: animated.y ?? node.transform.y,
+        z: animated.z ?? node.transform.z,
+        rotation: animated.rotation ?? node.transform.rotation,
+        rotationX: animated.rotationX ?? node.transform.rotationX,
+        rotationY: animated.rotationY ?? node.transform.rotationY,
+        scaleX: animated.scaleX ?? node.transform.scaleX,
+        scaleY: animated.scaleY ?? node.transform.scaleY,
+      }
+    },
+    [],
   )
 
   // --- pointer events: workspace-level click to clear / pan with H ----
@@ -1082,25 +1155,15 @@ export function Canvas() {
   const [marqueeRect, setMarqueeRect] = useState<
     (Rect & { workspaceOnly?: boolean }) | null
   >(null)
-  const cameraControlRef = useRef<{
-    pointerId: number
-    cameraId: NodeId
-    mode: 'rotate' | 'pan'
-    startX: number
-    startY: number
-    transform: CameraNode['transform']
-    latestTransform: CameraNode['transform']
-    startPlayhead: number
-    startPerfTime: number
-    lastSampleTime: number
-    didStampStart: boolean
-    moved: boolean
-    samples: Array<{
-      time: number
-      patch: Record<string, number>
-      mode: 'record' | 'active-track'
-    }>
-  } | null>(null)
+  const cameraControlRef = useRef<
+    (CameraGestureSession & {
+      pointerId: number
+      startX: number
+      startY: number
+      moved: boolean
+    })
+    | null
+  >(null)
   const focusMaskDragRef = useRef<{
     pointerId: number
     cameraId: NodeId
@@ -1150,18 +1213,6 @@ export function Canvas() {
     [stampCanvasPatch],
   )
 
-  const applyCameraControlTransform = useCallback(
-    (cameraId: NodeId, transform: CameraNode['transform']) => {
-      const current = api.getNode(cameraId)
-      if (!current || current.kind !== 'camera') return
-      api.setNodeProperty(current.id, 'transform', {
-        ...current.transform,
-        ...transform,
-      })
-    },
-    [api],
-  )
-
   const currentAnimationAuthorTime = useCallback(() => {
     const ui = useUI.getState()
     return ui.playing ? getAnimEngine().getPlayhead() : ui.playhead
@@ -1169,24 +1220,26 @@ export function Canvas() {
 
   const cameraControlPatch = useCallback(
     (
-      mode: 'rotate' | 'pan',
+      mode: CameraNavigationMode,
       transform: CameraNode['transform'],
     ): Record<string, number> =>
-      mode === 'rotate'
+      mode === 'orbit'
         ? {
             rotationX: transform.rotationX,
             rotationY: transform.rotationY,
           }
-        : {
-            x: transform.x,
-            y: transform.y,
-          },
+        : mode === 'pan'
+          ? {
+              x: transform.x,
+              y: transform.y,
+            }
+          : { z: transform.z },
     [],
   )
 
   const maybeStampCameraControlSample = useCallback(
     (
-      cameraControl: NonNullable<typeof cameraControlRef.current>,
+      cameraControl: CameraGestureSession,
       nextTransform: CameraNode['transform'],
     ) => {
       const ui = useUI.getState()
@@ -1212,7 +1265,6 @@ export function Canvas() {
           )
       const minStep = frameStep * 0.75
       if (
-        ui.playing &&
         Math.abs(sampleTime - cameraControl.lastSampleTime) < minStep
       ) {
         return
@@ -1229,6 +1281,74 @@ export function Canvas() {
       currentAnimationAuthorTime,
       frameStep,
       duration,
+    ],
+  )
+
+  const commitCameraGesture = useCallback(
+    (gesture: CameraGestureSession): boolean => {
+      const current = api.getNode(gesture.cameraId)
+      if (!current || current.kind !== 'camera') {
+        cameraPreviewStore.clear(gesture.cameraId)
+        return false
+      }
+
+      const ui = useUI.getState()
+      const releaseTime = ui.playing
+        ? currentAnimationAuthorTime()
+        : ui.recording
+          ? Math.min(
+              duration,
+              gesture.startPlayhead +
+                (performance.now() - gesture.startPerfTime) / 1000,
+            )
+          : ui.playhead
+      const finalPatch = cameraControlPatch(
+        gesture.mode,
+        gesture.latestTransform,
+      )
+
+      // Persist one field-scoped transaction for the entire gesture. This
+      // keeps undo atomic and avoids overwriting animated axes that the active
+      // navigation mode does not own.
+      api.doc.transact(() => {
+        api.setNodeProperty(current.id, 'transform', {
+          ...current.transform,
+          ...finalPatch,
+        })
+        for (const sample of gesture.samples) {
+          if (sample.mode === 'record') {
+            recordKeyframesForPatch(
+              api,
+              current.id,
+              sample.time,
+              'transform',
+              sample.patch,
+            )
+          } else {
+            stampToActiveTracksForPatch(
+              api,
+              current.id,
+              sample.time,
+              'transform',
+              sample.patch,
+            )
+          }
+        }
+        stampCanvasTransformPatch(
+          current.id,
+          finalPatch,
+          releaseTime,
+        )
+      }, UNDOABLE_GESTURE_ORIGIN)
+      cameraPreviewStore.finish(current.id)
+      return true
+    },
+    [
+      api,
+      cameraControlPatch,
+      currentAnimationAuthorTime,
+      duration,
+      stampCanvasTransformPatch,
     ],
   )
 
@@ -1526,10 +1646,60 @@ export function Canvas() {
     }
   }, [])
 
+  const startCameraNavigation = useCallback(
+    (
+      e: React.PointerEvent<HTMLElement>,
+      mode: CameraNavigationMode,
+    ): boolean => {
+      if (
+        editingTextId ||
+        !camera ||
+        camera.kind !== 'camera' ||
+        !isInsideArtboard(clientToViewport(e.clientX, e.clientY))
+      ) {
+        return false
+      }
+      const current = api.getNode(camera.id)
+      if (!current || current.kind !== 'camera') return false
+
+      const startTransform = displayedCameraTransform(current)
+      const startPlayhead = currentAnimationAuthorTime()
+      cameraControlRef.current = {
+        pointerId: e.pointerId,
+        cameraId: current.id,
+        mode,
+        startX: e.clientX,
+        startY: e.clientY,
+        transform: startTransform,
+        latestTransform: startTransform,
+        startPlayhead,
+        startPerfTime: performance.now(),
+        lastSampleTime: startPlayhead,
+        didStampStart: false,
+        moved: false,
+        samples: [],
+      }
+      setIsCameraManipulating(true)
+      setCameraNavigationMode(mode)
+      ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+      e.preventDefault()
+      e.stopPropagation()
+      return true
+    },
+    [
+      api,
+      camera,
+      clientToViewport,
+      currentAnimationAuthorTime,
+      displayedCameraTransform,
+      editingTextId,
+      isInsideArtboard,
+    ],
+  )
+
   const onFocusPickPointerDownCapture = useCallback(
     (e: React.PointerEvent<HTMLElement>) => {
-      if (e.button !== 0) return
-      if (!focusPickingCameraId && spacePanning) {
+      if (!focusPickingCameraId && spacePanning && e.button === 0) {
         panStateRef.current = {
           startX: e.clientX,
           startY: e.clientY,
@@ -1541,6 +1711,16 @@ export function Canvas() {
         e.stopPropagation()
         return
       }
+      if (!focusPickingCameraId) {
+        const cameraMode = resolveCameraPointerNavigation({
+          button: e.button,
+          altKey: e.altKey,
+          shiftKey: e.shiftKey,
+          ctrlKey: e.ctrlKey,
+        })
+        if (cameraMode && startCameraNavigation(e, cameraMode)) return
+      }
+      if (e.button !== 0) return
       if (!focusPickingCameraId) return
       const point = clientToViewport(e.clientX, e.clientY)
       const canvasPoint = clientToCanvas(e.clientX, e.clientY)
@@ -1584,6 +1764,7 @@ export function Canvas() {
       focusPickingCameraId,
       setFocusPickingCameraId,
       setSelection,
+      startCameraNavigation,
       stampCanvasCameraPatch,
       spacePanning,
       view.panX,
@@ -1921,38 +2102,7 @@ export function Canvas() {
 	            }
 	          }
 	        }
-	        if (
-	          tool === 'select' &&
-	          !e.metaKey &&
-	          !e.ctrlKey &&
-	          camera &&
-	          camera.kind === 'camera' &&
-	          selection.includes(camera.id)
-	        ) {
-	          const startTransform = displayedCameraTransform(camera)
-	          cameraControlRef.current = {
-	            pointerId: e.pointerId,
-	            cameraId: camera.id,
-	            mode: e.shiftKey ? 'pan' : 'rotate',
-	            startX: e.clientX,
-	            startY: e.clientY,
-	            transform: startTransform,
-	            latestTransform: startTransform,
-	            startPlayhead: currentAnimationAuthorTime(),
-	            startPerfTime: performance.now(),
-	            lastSampleTime: currentAnimationAuthorTime(),
-	            didStampStart: false,
-	            moved: false,
-	            samples: [],
-	          }
-	          cameraPreviewStore.set(camera.id, cameraTransformPreview(startTransform))
-	          setIsCameraManipulating(true)
-	          ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
-	          e.preventDefault()
-	          e.stopPropagation()
-	          return
-	        }
-	        // Select-tool marquee: start a rubber-band on the empty bg.
+        // Select-tool marquee: start a rubber-band on the empty bg.
         // Shift extends the existing selection; plain drag replaces.
         // We snapshot the initial selection here so pointer-move can
         // recompute union-with-marquee idempotently without losing the
@@ -2004,9 +2154,7 @@ export function Canvas() {
 	      api,
 	      setSelection,
 	      setEditingTextId,
-	      currentAnimationAuthorTime,
 		      camera,
-		      displayedCameraTransform,
 		      selection,
 		      spacePanning,
 		      view.panX,
@@ -2015,49 +2163,69 @@ export function Canvas() {
 	    ],
 	  )
 
-	  const onBackgroundPointerMove = useCallback(
-	    (e: React.PointerEvent<HTMLDivElement>) => {
-	      const cameraControl = cameraControlRef.current
-	      if (cameraControl && e.pointerId === cameraControl.pointerId) {
-	        const current = api.getNode(cameraControl.cameraId)
-	        if (!current || current.kind !== 'camera') return
-	        const dx = e.clientX - cameraControl.startX
-	        const dy = e.clientY - cameraControl.startY
-	        if (
-	          !cameraControl.moved &&
-	          Math.hypot(dx, dy) < CAMERA_CONTROL_DRAG_THRESHOLD_PX
-	        ) return
-	        cameraControl.moved = true
-	        let nextTransform: CameraNode['transform']
-	        if (cameraControl.mode === 'rotate') {
-	          const rotationX = Math.max(
-	            -89,
-	            Math.min(89, cameraControl.transform.rotationX - dy * 0.16),
-	          )
-	          const rotationY = cameraControl.transform.rotationY + dx * 0.16
-	          nextTransform = {
-	            ...cameraControl.transform,
-	            rotationX,
-	            rotationY,
-	          }
-	        } else {
-	          const divisor = Math.max(0.1, view.zoom * cameraScaleFromZ)
-	          nextTransform = {
-	            ...cameraControl.transform,
-	            x: cameraControl.transform.x - dx / divisor,
-	            y: cameraControl.transform.y - dy / divisor,
-	          }
-	        }
-	        cameraControl.latestTransform = nextTransform
-	        maybeStampCameraControlSample(cameraControl, nextTransform)
-	        cameraPreviewStore.set(
-	          cameraControl.cameraId,
-	          cameraTransformPreview(nextTransform),
-	        )
-	        e.preventDefault()
-	        return
-	      }
-	      const p = panStateRef.current
+  const onBackgroundPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const cameraControl = cameraControlRef.current
+      if (cameraControl && e.pointerId === cameraControl.pointerId) {
+        const current = api.getNode(cameraControl.cameraId)
+        if (!current || current.kind !== 'camera') return
+        const dx = e.clientX - cameraControl.startX
+        const dy = e.clientY - cameraControl.startY
+        if (
+          !cameraControl.moved &&
+          Math.hypot(dx, dy) < CAMERA_CONTROL_DRAG_THRESHOLD_PX
+        ) {
+          return
+        }
+        cameraControl.moved = true
+        const effectiveCamera = resolveCamera3D(
+          current,
+          cameraControl.transform,
+          { width: canvasWidth, height: canvasHeight },
+        )
+        const cameraApparentScale =
+          effectiveCamera.focalLength /
+          Math.max(
+            1,
+            effectiveCamera.focalLength - cameraControl.transform.z,
+          )
+        const patch =
+          cameraControl.mode === 'orbit'
+            ? cameraOrbitFromPointer({
+                startRotationX: cameraControl.transform.rotationX,
+                startRotationY: cameraControl.transform.rotationY,
+                deltaX: dx,
+                deltaY: dy,
+              })
+            : cameraControl.mode === 'pan'
+              ? cameraPanFromPointer({
+                  startX: cameraControl.transform.x,
+                  startY: cameraControl.transform.y,
+                  deltaX: dx,
+                  deltaY: dy,
+                  workspaceZoom: view.zoom,
+                  cameraApparentScale,
+                })
+              : {
+                  z: cameraZFromPointerDrag({
+                    startZ: cameraControl.transform.z,
+                    focalLength: effectiveCamera.focalLength,
+                    deltaY: dy,
+                    scrollSensitivity: current.scrollSensitivity,
+                  }),
+                }
+        const nextTransform = {
+          ...cameraControl.transform,
+          ...patch,
+        }
+        cameraControl.latestTransform = nextTransform
+        maybeStampCameraControlSample(cameraControl, nextTransform)
+        cameraPreviewStore.set(cameraControl.cameraId, patch)
+        e.preventDefault()
+        e.stopPropagation()
+        return
+      }
+      const p = panStateRef.current
       if (p) {
         setView({
           panX: p.panX + e.clientX - p.startX,
@@ -2090,67 +2258,41 @@ export function Canvas() {
         const height = Math.abs(cur.y - m.startY)
         setMarqueeRect({ x, y, width, height, workspaceOnly: m.workspaceOnly })
       }
-	    },
-	    [
-	      api,
-	      maybeStampCameraControlSample,
-	      cameraScaleFromZ,
-	      clientToCanvas,
-	      clientToViewport,
-	      setView,
-	      view.zoom,
-	    ],
-	  )
+    },
+    [
+      api,
+      canvasHeight,
+      canvasWidth,
+      maybeStampCameraControlSample,
+      clientToCanvas,
+      clientToViewport,
+      setView,
+      view.zoom,
+    ],
+  )
 
-	  const onBackgroundPointerUp = useCallback(
-	    (e: React.PointerEvent<HTMLDivElement>) => {
-	      const cameraControl = cameraControlRef.current
-		      if (cameraControl && e.pointerId === cameraControl.pointerId) {
-		        const current = api.getNode(cameraControl.cameraId)
-	        if (cameraControl.moved && current && current.kind === 'camera') {
-	          const nextTransform = cameraControl.latestTransform
-	          // Pointer-move is a transient WebGL preview. Commit the scene
-	          // document once on release so dragging the camera cannot trigger
-	          // Yoga, track recompilation, and texture invalidation per packet.
-	          api.doc.transact(() => {
-	            applyCameraControlTransform(current.id, nextTransform)
-	            for (const sample of cameraControl.samples) {
-	              if (sample.mode === 'record') {
-	                recordKeyframesForPatch(
-	                  api,
-	                  current.id,
-	                  sample.time,
-	                  'transform',
-	                  sample.patch,
-	                )
-	              } else {
-	                stampToActiveTracksForPatch(
-	                  api,
-	                  current.id,
-	                  sample.time,
-	                  'transform',
-	                  sample.patch,
-	                )
-	              }
-	            }
-	            stampCanvasTransformPatch(
-	              current.id,
-	              cameraControlPatch(cameraControl.mode, nextTransform),
-	              currentAnimationAuthorTime(),
-	            )
-	          })
-		        }
-		        cameraControlRef.current = null
-		        cameraPreviewStore.clear(cameraControl.cameraId)
-		        setIsCameraManipulating(false)
-	        try {
-	          ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
-	        } catch {
-	          /* already released */
-	        }
-	        return
-	      }
-	      if (panStateRef.current) {
+  const onBackgroundPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const cameraControl = cameraControlRef.current
+      if (cameraControl && e.pointerId === cameraControl.pointerId) {
+        if (cameraControl.moved) {
+          commitCameraGesture(cameraControl)
+        } else {
+          cameraPreviewStore.clear(cameraControl.cameraId)
+        }
+        cameraControlRef.current = null
+        setIsCameraManipulating(false)
+        setCameraNavigationMode(null)
+        try {
+          ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
+        } catch {
+          /* already released */
+        }
+        e.preventDefault()
+        e.stopPropagation()
+        return
+      }
+      if (panStateRef.current) {
         panStateRef.current = null
         ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
         return
@@ -2356,62 +2498,62 @@ export function Canvas() {
       setTool,
       solved,
       workspaceOrder,
-      applyCameraControlTransform,
-      cameraControlPatch,
-      currentAnimationAuthorTime,
-      stampCanvasTransformPatch,
+      commitCameraGesture,
       clearSelection,
     ],
   )
 
+  const onBackgroundPointerCancel = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const cameraControl = cameraControlRef.current
+      if (!cameraControl || e.pointerId !== cameraControl.pointerId) return
+      cameraControlRef.current = null
+      cameraPreviewStore.clear(cameraControl.cameraId)
+      setIsCameraManipulating(false)
+      setCameraNavigationMode(null)
+      try {
+        ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
+      } catch {
+        /* already released */
+      }
+      e.preventDefault()
+      e.stopPropagation()
+    },
+    [],
+  )
+
   const wheelFrameRef = useRef<number | null>(null)
-  const pendingWheelRef = useRef({
+  const pendingWheelRef = useRef<{
+    zoomDeltaY: number
+    zoomClientX: number
+    zoomClientY: number
+    panDeltaX: number
+    panDeltaY: number
+    cameraGesture: CameraGestureSession | null
+    cameraCommitTimer: number | null
+  }>({
     zoomDeltaY: 0,
     zoomClientX: 0,
     zoomClientY: 0,
     panDeltaX: 0,
     panDeltaY: 0,
-    cameraId: null as NodeId | null,
-    cameraZ: null as number | null,
-    cameraAuthorTime: null as number | null,
-    cameraCommitTimer: null as number | null,
+    cameraGesture: null,
+    cameraCommitTimer: null,
   })
 
   const flushPendingCameraWheel = useCallback(() => {
     const pending = pendingWheelRef.current
-    const cameraId = pending.cameraId
-    const cameraZ = pending.cameraZ
+    const gesture = pending.cameraGesture
     if (pending.cameraCommitTimer !== null) {
       window.clearTimeout(pending.cameraCommitTimer)
       pending.cameraCommitTimer = null
     }
-    if (!cameraId || cameraZ === null) return
-    const authorTime =
-      pending.cameraAuthorTime ?? currentAnimationAuthorTime()
-    pending.cameraId = null
-    pending.cameraZ = null
-    pending.cameraAuthorTime = null
-    const current = api.getNode(cameraId)
-    if (!current || current.kind !== 'camera') {
-      cameraPreviewStore.clear(cameraId)
-      return
-    }
-    // A trackpad dolly can emit dozens of packets. Keep those packets in
-    // the shared rAF preview and author one scene/track mutation after the
-    // gesture goes idle, just like pointer-based camera movement.
-    api.doc.transact(() => {
-      api.setNodeProperty(current.id, 'transform', {
-        ...current.transform,
-        z: cameraZ,
-      })
-      stampCanvasTransformPatch(current.id, { z: cameraZ }, authorTime)
-    })
-    // Keep the final transient Z for one paint while the scene update and
-    // newly-authored track reach the WebGL leaf. Clearing synchronously can
-    // reveal its previous engine snapshot for one frame and looks like the
-    // zoom jumped backwards at the end of every wheel burst.
-    cameraPreviewStore.finish(cameraId)
-  }, [api, currentAnimationAuthorTime, stampCanvasTransformPatch])
+    if (!gesture) return
+    pending.cameraGesture = null
+    commitCameraGesture(gesture)
+    setIsCameraManipulating(false)
+    setCameraNavigationMode(null)
+  }, [commitCameraGesture])
 
   useEffect(() => {
     if (!editingTextId) return
@@ -2429,7 +2571,7 @@ export function Canvas() {
     pending.panDeltaY = 0
   }, [editingTextId, flushPendingCameraWheel])
 
-  // --- wheel: cmd/ctrl + wheel = zoom, otherwise pan -------------------
+  // --- wheel: camera navigation over the artboard, workspace elsewhere ---
   useEffect(() => {
     const el = workspaceRef.current
     if (!el) return
@@ -2486,6 +2628,7 @@ export function Canvas() {
             ? Math.max(1, el.clientHeight)
             : 1
       if (e.ctrlKey || e.metaKey) {
+        if (pendingWheel.cameraGesture) flushPendingCameraWheel()
         // Trackpad pinch can deliver packets faster than the display can
         // paint. Accumulate them and commit one current-state update per
         // animation frame so WebGL never receives a backlog of stale zooms.
@@ -2497,54 +2640,105 @@ export function Canvas() {
       } else if (
         camera &&
         camera.kind === 'camera' &&
-        selection.includes(camera.id) &&
-        tool === 'select'
+        !focusPickingCameraId &&
+        isInsideArtboard(clientToViewport(e.clientX, e.clientY))
       ) {
         const current = api.getNode(camera.id)
         if (!current || current.kind !== 'camera') return
-        // Canvas deliberately avoids subscribing its whole tree to the
-        // camera's per-frame animation. Read the engine imperatively at the
-        // event boundary instead, then layer any still-visible wheel preview
-        // over it. This makes every new burst begin at what is actually on
-        // screen rather than a stale React closure/static transform.
-        const engineValue = getAnimEngine().getSnapshot()[current.id]
-        const previewSnapshot = cameraPreviewStore.getSnapshot()
-        const activePreview =
-          previewSnapshot?.cameraId === current.id
-            ? previewSnapshot.value
-            : undefined
-        const baseZ = cameraWheelStartZ({
-          pendingZ:
-            pendingWheel.cameraId === current.id &&
-            pendingWheel.cameraZ !== null
-              ? pendingWheel.cameraZ
-              : undefined,
-          previewZ: activePreview?.z,
-          animatedZ: engineValue?.z,
-          staticZ: current.transform.z,
+        const mode = resolveCameraWheelNavigation({
+          altKey: e.altKey,
+          shiftKey: e.shiftKey,
+          ctrlKey: e.ctrlKey,
+          metaKey: e.metaKey,
         })
+        if (!mode) return
+
+        const activeGesture = pendingWheel.cameraGesture
+        if (
+          activeGesture &&
+          (activeGesture.cameraId !== current.id ||
+            activeGesture.mode !== mode)
+        ) {
+          // A modifier change starts a distinct, undoable gesture and prevents
+          // one mode from accidentally persisting another mode's axes.
+          flushPendingCameraWheel()
+        }
+
+        let gesture = pendingWheel.cameraGesture
+        if (!gesture) {
+          const startTransform = displayedCameraTransform(current)
+          const startPlayhead = currentAnimationAuthorTime()
+          gesture = {
+            cameraId: current.id,
+            mode,
+            transform: startTransform,
+            latestTransform: startTransform,
+            startPlayhead,
+            startPerfTime: performance.now(),
+            lastSampleTime: startPlayhead,
+            didStampStart: false,
+            samples: [],
+          }
+          pendingWheel.cameraGesture = gesture
+        }
+
+        // Canvas deliberately avoids subscribing its whole tree to the
+        // camera's per-frame animation. Start with the current gesture pose,
+        // while still resolving animated lens settings imperatively.
+        const engineValue = getAnimEngine().getSnapshot()[current.id]
+        const baseTransform = gesture.latestTransform
         const effectiveCamera = resolveCamera3D(
           current,
-          { ...engineValue, ...activePreview },
+          { ...engineValue, ...baseTransform },
           { width: canvasWidth, height: canvasHeight },
         )
-        const nextZ = cameraZFromWheel({
-          currentZ: baseZ,
-          focalLength: effectiveCamera.focalLength,
-          deltaY: e.deltaY,
-          deltaMode: e.deltaMode,
-          pageHeight: el.clientHeight,
-          scrollSensitivity: current.scrollSensitivity,
-          fine: e.altKey,
-        })
-        pendingWheel.cameraId = current.id
-        pendingWheel.cameraZ = nextZ
-        pendingWheel.cameraAuthorTime = currentAnimationAuthorTime()
-        // Only Z belongs to this gesture. Publishing a full transform here
-        // would override the WebGL leaf's fresher animated X/Y/rotation values.
-        // The preview store already coalesces packets to one rAF, so routing it
-        // through scheduleViewCommit would add a second frame of latency.
-        cameraPreviewStore.set(current.id, { z: nextZ })
+        const cameraApparentScale =
+          effectiveCamera.focalLength /
+          Math.max(1, effectiveCamera.focalLength - baseTransform.z)
+        const patch =
+          mode === 'orbit'
+            ? cameraOrbitFromWheel({
+                currentRotationX: baseTransform.rotationX,
+                currentRotationY: baseTransform.rotationY,
+                deltaX: e.deltaX,
+                deltaY: e.deltaY,
+                deltaMode: e.deltaMode,
+                pageWidth: el.clientWidth,
+                pageHeight: el.clientHeight,
+              })
+            : mode === 'pan'
+              ? cameraPanFromWheel({
+                  currentX: baseTransform.x,
+                  currentY: baseTransform.y,
+                  deltaX: e.deltaX,
+                  deltaY: e.deltaY,
+                  deltaMode: e.deltaMode,
+                  pageWidth: el.clientWidth,
+                  pageHeight: el.clientHeight,
+                  workspaceZoom: useUI.getState().view.zoom,
+                  cameraApparentScale,
+                })
+              : cameraDollyFromWheel({
+                  currentZ: baseTransform.z,
+                  focalLength: effectiveCamera.focalLength,
+                  deltaY: e.deltaY,
+                  deltaMode: e.deltaMode,
+                  pageHeight: el.clientHeight,
+                  scrollSensitivity: current.scrollSensitivity,
+                })
+        const nextTransform = {
+          ...baseTransform,
+          ...patch,
+        }
+        gesture.latestTransform = nextTransform
+        maybeStampCameraControlSample(gesture, nextTransform)
+
+        // Publish only the axes owned by this mode. The preview store already
+        // coalesces trackpad packets to one rAF, keeping the gesture responsive
+        // without making the full editor rerender for every packet.
+        cameraPreviewStore.set(current.id, patch)
+        setIsCameraManipulating(true)
+        setCameraNavigationMode(mode)
         if (pendingWheel.cameraCommitTimer !== null) {
           window.clearTimeout(pendingWheel.cameraCommitTimer)
         }
@@ -2553,6 +2747,7 @@ export function Canvas() {
           180,
         )
       } else {
+        if (pendingWheel.cameraGesture) flushPendingCameraWheel()
         const pending = pendingWheel
         pending.panDeltaX += e.deltaX * deltaScale
         pending.panDeltaY += e.deltaY * deltaScale
@@ -2578,24 +2773,28 @@ export function Canvas() {
     camera,
     canvasHeight,
     canvasWidth,
+    clientToViewport,
     currentAnimationAuthorTime,
+    displayedCameraTransform,
     editingTextId,
+    focusPickingCameraId,
     flushPendingCameraWheel,
-    selection,
-    stampCanvasTransformPatch,
-    tool,
+    isInsideArtboard,
+    maybeStampCameraControlSample,
   ])
 
   const workspaceCursor =
     focusPickingCameraId
       ? 'crosshair'
-      : tool === 'hand' || spacePanning
-      ? panStateRef.current
+      : isCameraManipulating
         ? 'grabbing'
-        : 'grab'
-      : isDrawTool
-        ? 'crosshair'
-        : undefined
+        : tool === 'hand' || spacePanning
+          ? panStateRef.current
+            ? 'grabbing'
+            : 'grab'
+          : isDrawTool
+            ? 'crosshair'
+            : undefined
 
   // --- native drag-drop: component / image import ----------------------
   // Tracks the "a dragged file is hovering over the canvas" state so the
@@ -2752,6 +2951,7 @@ export function Canvas() {
       onPointerDown={onBackgroundPointerDown}
       onPointerMove={onBackgroundPointerMove}
       onPointerUp={onBackgroundPointerUp}
+      onPointerCancel={onBackgroundPointerCancel}
       onDoubleClick={onCanvasDoubleClick}
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
@@ -2759,6 +2959,16 @@ export function Canvas() {
       onDrop={handleDrop}
       style={{ cursor: workspaceCursor, touchAction: 'none' }}
     >
+      {solved &&
+      camera?.kind === 'camera' &&
+      threeCameraAvailable &&
+      !textEditPresentation.suspendWebglScene ? (
+        <PaperShaderSourceLayer
+          api={api}
+          layout={solved}
+          sceneVersion={version}
+        />
+      ) : null}
       {/* Single transform container for both scene paint + selection overlay.
           Placing the transform here (absolute, top-left) with explicit pan
           and scale is more predictable than transforming a flex-centered
@@ -3077,12 +3287,14 @@ export function Canvas() {
             }
           >
             {solved && (!camera || !cameraAccurateSelectionActive) && (
-              <SelectionOverlay
-                solved={solved}
-                animated={animated}
-                inherited={inherited}
-                zoom={view.zoom}
-              />
+              <div>
+                <SelectionOverlay
+                  solved={solved}
+                  animated={animated}
+                  inherited={inherited}
+                  zoom={view.zoom}
+                />
+              </div>
             )}
             {solved && (
               <DistanceOverlay
@@ -3166,6 +3378,20 @@ export function Canvas() {
           App.Shell) so it's positioned relative to the canvas
           workspace and never bleeds into the Timeline below. */}
       <FloatingDock />
+
+      {cameraNavigationMode ? (
+        <div
+          className="pointer-events-none absolute bottom-20 left-1/2 z-30 -translate-x-1/2 rounded border border-border-strong bg-panel/95 px-3 py-2 text-center text-[10px] font-medium uppercase tracking-[0.18em] text-text-muted shadow-lg backdrop-blur"
+          data-export-hide="1"
+        >
+          Camera ·{' '}
+          {cameraNavigationMode === 'orbit'
+            ? 'Orbit'
+            : cameraNavigationMode === 'pan'
+              ? 'Pan'
+              : 'Dolly'}
+        </div>
+      ) : null}
 
       {focusPickingCameraId ? (
         <div
@@ -4588,8 +4814,8 @@ function NodeView({
         // imported Figma blend modes look broken.
         isolation: node.kind === 'frame' ? 'isolate' : undefined,
         mixBlendMode:
-          node.appearance.blendMode && node.appearance.blendMode !== 'normal'
-            ? node.appearance.blendMode
+          (anim?.blendMode ?? node.appearance.blendMode) !== 'normal'
+            ? anim?.blendMode ?? node.appearance.blendMode
             : undefined,
         filter: effectFilterCss || undefined,
         overflow: clips ? 'hidden' : undefined,
@@ -4637,6 +4863,9 @@ function NodeView({
             pointerEvents: 'none',
           }}
         />
+      ) : null}
+      {node.kind === 'shader' ? (
+        <LivePaperShaderCanvas node={node} />
       ) : null}
       {node.kind === 'video' ? (
         <MediaVideo node={node} />

--- a/src/ui/FloatingDock.tsx
+++ b/src/ui/FloatingDock.tsx
@@ -1,20 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useRef, type ReactNode } from 'react'
+import { useRef, useState, type ReactNode } from 'react'
 import {
   Circle,
   Frame,
   Hand,
   ImageIcon,
   MousePointer2,
+  Sparkles,
   Square,
   Type,
   Video,
 } from 'lucide-react'
 import { useUI, type Tool } from '@/state/ui'
 import { useSceneAPI } from '@/scene'
+import {
+  getPaperShaderDefinition,
+  type PaperShaderType,
+} from '@/scene/paperShaders'
 import { importImageFiles } from '@/ui/importImage'
 import { importMediaFiles } from '@/ui/importMedia'
+import { PaperShaderPicker } from '@/ui/PaperShaderPicker'
 
 /**
  * FloatingDock — the tool palette as a floating pill at the bottom of
@@ -59,6 +65,8 @@ export function FloatingDock() {
 
   const imageInputRef = useRef<HTMLInputElement>(null)
   const mediaInputRef = useRef<HTMLInputElement>(null)
+  const [shaderPickerAnchor, setShaderPickerAnchor] =
+    useState<HTMLButtonElement | null>(null)
   const onImageFiles = async (files: FileList | null) => {
     if (!files || files.length === 0) return
     const rootId = api.getRoot()
@@ -79,7 +87,36 @@ export function FloatingDock() {
       setTool('select')
     }
   }
-
+  const insertPaperShader = (shaderType: PaperShaderType) => {
+    const rootId = api.getRoot()
+    if (!rootId) return
+    const meta = api.getMeta()
+    const definition = getPaperShaderDefinition(shaderType)
+    const width = Math.min(640, Math.max(1, meta.canvas.width))
+    const height = Math.min(360, Math.max(1, meta.canvas.height))
+    const id = api.createNode('shader', rootId, {
+      name: `Paper ${definition.label}`,
+      position: 'absolute',
+      size: { width, height },
+      shaderType,
+      colors: [...definition.defaults.colors],
+      speed: definition.defaults.speed,
+      scale: definition.defaults.scale,
+      params: { ...definition.defaults.params },
+      transform: {
+        x: (meta.canvas.width - width) / 2,
+        y: (meta.canvas.height - height) / 2,
+        z: 0,
+        rotation: 0,
+        rotationX: 0,
+        rotationY: 0,
+        scaleX: 1,
+        scaleY: 1,
+      },
+    })
+    setSelection([id])
+    setTool('select')
+  }
   return (
     <div
       // The dock excludes itself from `data-export-hide` because it's
@@ -144,8 +181,33 @@ export function FloatingDock() {
         )
       })}
 
-      {/* Place-image group — separator + the image button. */}
+      {/* Generator and media group. */}
       <span aria-hidden className="mx-1 h-[22px] w-px bg-border" />
+      <button
+        type="button"
+        title="Add Paper shader…"
+        aria-expanded={Boolean(shaderPickerAnchor)}
+        aria-haspopup="dialog"
+        onClick={(event) => {
+          const button = event.currentTarget
+          setShaderPickerAnchor((current) => (current ? null : button))
+        }}
+        className={[
+          'flex h-[34px] w-[34px] items-center justify-center rounded-lg transition-colors',
+          shaderPickerAnchor
+            ? 'bg-accent text-white shadow-sm'
+            : 'text-text-muted hover:bg-white/[0.07] hover:text-text',
+        ].join(' ')}
+      >
+        <Sparkles size={18} />
+      </button>
+      {shaderPickerAnchor ? (
+        <PaperShaderPicker
+          anchor={shaderPickerAnchor}
+          onSelect={insertPaperShader}
+          onClose={() => setShaderPickerAnchor(null)}
+        />
+      ) : null}
       <button
         type="button"
         title="Place image…"

--- a/src/ui/Inspector.tsx
+++ b/src/ui/Inspector.tsx
@@ -86,6 +86,7 @@ import {
   TextField,
 } from '@/ui/fields'
 import { PresetsPanel } from '@/ui/PresetsPanel'
+import { PaperShaderInspector } from '@/ui/PaperShaderInspector'
 import { AlignTools } from '@/ui/AlignTools'
 import { EasingPicker } from '@/ui/EasingPicker'
 import { currentAnimationAuthorTime } from '@/ui/animationPlayhead'
@@ -333,7 +334,6 @@ function SceneDetails({ api }: { api: SceneAPI }) {
       api.setNodeProperty(root.id, 'size', { width: safeW, height: safeH })
     }
   }
-
   return (
     <div className="space-y-6">
       <Section title="Scene">
@@ -786,6 +786,9 @@ function MultiNodeDetails({ nodes, api }: { nodes: Node[]; api: SceneAPI }) {
             mixedY={cSY.mixed}
             onCommitX={(v) => patchTransformAll({ scaleX: v })}
             onCommitY={(v) => patchTransformAll({ scaleY: v })}
+            onCommitPair={({ scaleX, scaleY }) =>
+              patchTransformAll({ scaleX, scaleY })
+            }
           />
         </FieldRow>
       </Section>
@@ -1450,6 +1453,22 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
     node.kind === 'camera'
       ? anim?.bloomThreshold ?? node.bloomThreshold ?? 0.75
       : 0.75
+  const liveVhsIntensity =
+    node.kind === 'camera'
+      ? anim?.vhsIntensity ?? node.vhsIntensity ?? 0.65
+      : 0.65
+  const liveVhsNoise =
+    node.kind === 'camera'
+      ? anim?.vhsNoise ?? node.vhsNoise ?? 0.35
+      : 0.35
+  const liveVhsScanlines =
+    node.kind === 'camera'
+      ? anim?.vhsScanlines ?? node.vhsScanlines ?? 0.5
+      : 0.5
+  const liveVhsColorBleed =
+    node.kind === 'camera'
+      ? anim?.vhsColorBleed ?? node.vhsColorBleed ?? 3
+      : 3
   const focusTargetOptions = useMemo(() => {
     // `version` makes this list react to layer additions, deletions and names.
     void version
@@ -1623,6 +1642,11 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
         | 'bloomStrength'
         | 'bloomRadius'
         | 'bloomThreshold'
+        | 'vhsEnabled'
+        | 'vhsIntensity'
+        | 'vhsNoise'
+        | 'vhsScanlines'
+        | 'vhsColorBleed'
         | 'showFocusPlane'
       >
     >,
@@ -1753,6 +1777,21 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
     if (patch.bloomThreshold !== undefined) {
       api.setNodeProperty(node.id, 'bloomThreshold', patch.bloomThreshold)
     }
+    if (patch.vhsEnabled !== undefined) {
+      api.setNodeProperty(node.id, 'vhsEnabled', patch.vhsEnabled)
+    }
+    if (patch.vhsIntensity !== undefined) {
+      api.setNodeProperty(node.id, 'vhsIntensity', patch.vhsIntensity)
+    }
+    if (patch.vhsNoise !== undefined) {
+      api.setNodeProperty(node.id, 'vhsNoise', patch.vhsNoise)
+    }
+    if (patch.vhsScanlines !== undefined) {
+      api.setNodeProperty(node.id, 'vhsScanlines', patch.vhsScanlines)
+    }
+    if (patch.vhsColorBleed !== undefined) {
+      api.setNodeProperty(node.id, 'vhsColorBleed', patch.vhsColorBleed)
+    }
     if (patch.showFocusPlane !== undefined) {
       api.setNodeProperty(node.id, 'showFocusPlane', patch.showFocusPlane)
     }
@@ -1803,7 +1842,6 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
       }
     }
   }
-
   return (
     <div className="space-y-6">
       <Section title="Node">
@@ -1815,7 +1853,9 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
           />
         </FieldRow>
         <FieldRow label="Kind">
-          <span className="pr-1.5 text-[12px] text-text">{node.kind}</span>
+          <span className="pr-1.5 text-[12px] text-text">
+            {node.kind}
+          </span>
         </FieldRow>
         <FieldRow label="Id">
           <span className="pr-1.5 font-mono text-[11px] text-text-muted">
@@ -1857,6 +1897,8 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
 
       {node.kind === 'camera' && (
         <>
+          <CameraViewportControlsHint />
+
           <Section
             title="Camera Position"
             action={
@@ -2157,6 +2199,9 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
             scaleY={liveSY}
             onCommitX={(v) => patchTransform({ scaleX: v })}
             onCommitY={(v) => patchTransform({ scaleY: v })}
+            onCommitPair={({ scaleX, scaleY }) =>
+              patchTransform({ scaleX, scaleY })
+            }
           />
         </FieldRow>
         <FieldRow label="Pivot">
@@ -2235,7 +2280,11 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
         <ImageSection node={node} api={api} />
       )}
 
-      {node.kind === 'video' && (
+      {node.kind === 'shader' && (
+        <PaperShaderInspector node={node} api={api} />
+      )}
+
+      {(node.kind === 'audio' || node.kind === 'video') && (
         <MediaSection node={node} api={api} />
       )}
 
@@ -2320,7 +2369,9 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
             <FieldRow label="Clip">
               <CheckboxField
                 value={node.clipsContent}
-                onCommit={(v) => api.setNodeProperty(node.id, 'clipsContent', v)}
+                onCommit={(v) =>
+                  api.setNodeProperty(node.id, 'clipsContent', v)
+                }
               />
             </FieldRow>
           ) : null}
@@ -2923,11 +2974,178 @@ function NodeDetails({ node, api }: { node: Node; api: SceneAPI }) {
                 </FieldRow>
               </>
             ) : null}
+
+            <div className="!my-3 border-t border-border" />
+
+            <FieldRow label="VHS tape">
+              <CheckboxField
+                value={node.vhsEnabled ?? false}
+                onCommit={(vhsEnabled) => patchCamera({ vhsEnabled })}
+              />
+            </FieldRow>
+            {node.vhsEnabled ? (
+              <>
+                <p className="pl-[22px] text-[10px] leading-4 text-text-dim">
+                  Adds frame-stable tape wobble, grain, scanlines and color
+                  bleed driven by the scene playhead.
+                </p>
+                <FieldRow
+                  label="Intensity"
+                  keyframe={
+                    <KeyframeButton
+                      nodeId={node.id}
+                      propertyId="camera.vhsIntensity"
+                      currentValue={liveVhsIntensity}
+                    />
+                  }
+                >
+                  <NumberField
+                    value={liveVhsIntensity * 100}
+                    onCommit={(v) =>
+                      patchCamera({
+                        vhsIntensity: Math.max(0, Math.min(1, v / 100)),
+                      })
+                    }
+                    min={0}
+                    max={100}
+                    step={1}
+                    suffix="%"
+                    ariaLabel="VHS intensity"
+                  />
+                </FieldRow>
+                <FieldRow
+                  label="Noise"
+                  keyframe={
+                    <KeyframeButton
+                      nodeId={node.id}
+                      propertyId="camera.vhsNoise"
+                      currentValue={liveVhsNoise}
+                    />
+                  }
+                >
+                  <NumberField
+                    value={liveVhsNoise * 100}
+                    onCommit={(v) =>
+                      patchCamera({
+                        vhsNoise: Math.max(0, Math.min(1, v / 100)),
+                      })
+                    }
+                    min={0}
+                    max={100}
+                    step={1}
+                    suffix="%"
+                    ariaLabel="VHS noise"
+                  />
+                </FieldRow>
+                <FieldRow
+                  label="Scanlines"
+                  keyframe={
+                    <KeyframeButton
+                      nodeId={node.id}
+                      propertyId="camera.vhsScanlines"
+                      currentValue={liveVhsScanlines}
+                    />
+                  }
+                >
+                  <NumberField
+                    value={liveVhsScanlines * 100}
+                    onCommit={(v) =>
+                      patchCamera({
+                        vhsScanlines: Math.max(0, Math.min(1, v / 100)),
+                      })
+                    }
+                    min={0}
+                    max={100}
+                    step={1}
+                    suffix="%"
+                    ariaLabel="VHS scanlines"
+                  />
+                </FieldRow>
+                <FieldRow
+                  label="Color bleed"
+                  keyframe={
+                    <KeyframeButton
+                      nodeId={node.id}
+                      propertyId="camera.vhsColorBleed"
+                      currentValue={liveVhsColorBleed}
+                    />
+                  }
+                >
+                  <NumberField
+                    value={liveVhsColorBleed}
+                    onCommit={(v) =>
+                      patchCamera({
+                        vhsColorBleed: Math.max(0, Math.min(32, v)),
+                      })
+                    }
+                    min={0}
+                    max={32}
+                    step={0.5}
+                    suffix="px"
+                    ariaLabel="VHS color bleed"
+                  />
+                </FieldRow>
+              </>
+            ) : null}
           </Section>
           <CameraAnimationActions node={node} api={api} />
         </>
       )}
     </div>
+  )
+}
+
+function CameraViewportControlsHint() {
+  const recording = useUI((state) => state.recording)
+  const controls = [
+    { shortcut: 'MMB / Option-drag', action: 'Orbit' },
+    { shortcut: 'Shift+MMB / Shift-scroll', action: 'Pan' },
+    { shortcut: 'Ctrl+MMB / Scroll', action: 'Dolly' },
+    { shortcut: 'Cmd/Ctrl-scroll', action: 'Canvas zoom' },
+  ] as const
+
+  return (
+    <aside
+      aria-label="Camera viewport controls"
+      className="rounded border border-border bg-panel-raised px-2.5 py-2"
+    >
+      <div className="mb-2 text-[10px] font-semibold tracking-[0.08em] text-text-muted uppercase">
+        Viewport controls
+      </div>
+      <dl className="space-y-1">
+        {controls.map(({ shortcut, action }) => (
+          <div
+            key={action}
+            className="flex min-w-0 items-center justify-between gap-2 text-[10px]"
+          >
+            <dt>
+              <kbd className="font-mono text-text-muted">{shortcut}</kbd>
+            </dt>
+            <dd className="shrink-0 text-text-dim">{action}</dd>
+          </div>
+        ))}
+      </dl>
+      <div
+        aria-live="polite"
+        className={[
+          'mt-2 flex items-start gap-1.5 border-t border-border pt-2 text-[10px] leading-4',
+          recording ? 'text-red-500' : 'text-text-dim',
+        ].join(' ')}
+      >
+        <span
+          aria-hidden
+          className={[
+            'mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full',
+            recording ? 'bg-red-500' : 'bg-text-dim',
+          ].join(' ')}
+        />
+        <span>
+          {recording
+            ? 'Auto Key is on — camera gestures record to the timeline.'
+            : 'Enable Auto Key in the timeline to record camera gestures.'}
+        </span>
+      </div>
+    </aside>
   )
 }
 

--- a/src/ui/LayersPanel.tsx
+++ b/src/ui/LayersPanel.tsx
@@ -1013,6 +1013,7 @@ const GLYPHS: Record<NodeKind, string> = {
   vector: '⌁',
   text: 'T',
   image: '▧',
+  shader: '✦',
   component: '◆',
   instance: '◇',
   camera: '◉',
@@ -1042,7 +1043,7 @@ function KindGlyph({ node }: { node: Node }) {
   const isComponentNode = node.kind === 'component' || node.kind === 'instance'
   return (
     <span
-      className="w-3 shrink-0 text-center font-mono text-[10px] text-text-dim"
+      className="flex w-3 shrink-0 items-center justify-center text-center font-mono text-[10px] text-text-dim"
       style={{
         color: isComponentNode ? 'oklch(0.7 0.24 300)' : undefined,
       }}

--- a/src/ui/PaperShaderInspector.tsx
+++ b/src/ui/PaperShaderInspector.tsx
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo, useRef } from 'react'
+import type { Node } from '@/scene'
+import type { NodeBaseMutable, SceneAPI } from '@/scene/doc'
+import {
+  getPaperShaderDefinition,
+  PAPER_SHADER_CATALOG,
+  type PaperShaderParamValue,
+  type PaperShaderType,
+} from '@/scene/paperShaders'
+import { isImageFile } from '@/ui/importImage'
+import {
+  CheckboxField,
+  ColorField,
+  FieldRow,
+  NumberField,
+  SelectField,
+  TextField,
+} from '@/ui/fields'
+
+type ShaderNode = Extract<Node, { kind: 'shader' }>
+
+const CATEGORY_LABELS = {
+  generated: 'Generated',
+  'image-filter': 'Image filters',
+  shape: 'Logo & shape',
+} as const
+
+const PARAM_OPTIONS: Partial<
+  Record<`${PaperShaderType}:${string}`, readonly string[]>
+> = {
+  'dithering:shape': ['simplex', 'warp', 'dots', 'wave', 'ripple', 'swirl', 'sphere'],
+  'dithering:type': ['random', '2x2', '4x4', '8x8'],
+  'grain-gradient:shape': ['wave', 'dots', 'truchet', 'corners', 'ripple', 'blob', 'sphere'],
+  'dot-grid:shape': ['circle', 'diamond', 'square', 'triangle'],
+  'warp:shape': ['checks', 'stripes', 'edge'],
+  'fluted-glass:shape': ['lines', 'linesIrregular', 'wave', 'zigzag', 'pattern'],
+  'fluted-glass:distortionShape': ['prism', 'lens', 'contour', 'cascade', 'flat'],
+  'image-dithering:type': ['random', '2x2', '4x4', '8x8'],
+  'halftone-dots:grid': ['square', 'hex'],
+  'halftone-dots:type': ['classic', 'gooey', 'holes', 'soft'],
+  'halftone-cmyk:type': ['dots', 'ink', 'sharp'],
+  'liquid-metal:shape': ['none', 'circle', 'daisy', 'diamond', 'metaballs'],
+  'gem-smoke:shape': ['none', 'circle', 'daisy', 'diamond', 'metaballs'],
+  'pulsing-border:aspectRatio': ['auto', 'square'],
+}
+
+const LABEL_OVERRIDES: Record<string, string> = {
+  colorBack: 'Background',
+  colorFront: 'Foreground',
+  colorMid: 'Mid color',
+  colorFill: 'Fill',
+  colorStroke: 'Stroke',
+  colorHighlight: 'Highlight',
+  colorShadow: 'Shadow',
+  colorBloom: 'Bloom color',
+  colorInner: 'Inner color',
+  colorTint: 'Tint',
+  grainMixer: 'Grain mix',
+  grainOverlay: 'Grain overlay',
+  gapX: 'Gap X',
+  gapY: 'Gap Y',
+  waveX: 'Wave X',
+  waveY: 'Wave Y',
+  waveXShift: 'Wave X shift',
+  waveYShift: 'Wave Y shift',
+  offsetX: 'Offset X',
+  offsetY: 'Offset Y',
+  marginLeft: 'Margin left',
+  marginRight: 'Margin right',
+  marginTop: 'Margin top',
+  marginBottom: 'Margin bottom',
+  shiftRed: 'Red shift',
+  shiftBlue: 'Blue shift',
+  sizeRange: 'Size range',
+  opacityRange: 'Opacity range',
+  stepsPerColor: 'Color steps',
+  focalDistance: 'Focal distance',
+  focalAngle: 'Focal angle',
+  distortionShape: 'Distortion shape',
+  colorSteps: 'Color steps',
+  originalColors: 'Original colors',
+  innerDistortion: 'Inner distortion',
+  outerDistortion: 'Outer distortion',
+  innerGlow: 'Inner glow',
+  outerGlow: 'Outer glow',
+  octaveCount: 'Octaves',
+  foldCount: 'Fold count',
+  spotSize: 'Spot size',
+  smokeSize: 'Smoke size',
+  noiseScale: 'Noise scale',
+  noiseIterations: 'Noise passes',
+  swirlIterations: 'Swirl passes',
+  bandCount: 'Band count',
+  strokeWidth: 'Stroke width',
+  strokeTaper: 'Stroke taper',
+  strokeCap: 'Stroke cap',
+  noiseFrequency: 'Noise frequency',
+  midSize: 'Mid size',
+  midIntensity: 'Mid intensity',
+  aspectRatio: 'Aspect',
+  gridNoise: 'Grid noise',
+}
+
+const INTEGER_PARAMS = new Set([
+  'positions',
+  'count',
+  'stepsPerColor',
+  'octaveCount',
+  'foldCount',
+  'spots',
+  'noiseIterations',
+  'swirlIterations',
+  'bandCount',
+])
+
+const ANGLE_PARAMS = new Set(['angle', 'angle1', 'angle2', 'focalAngle', 'rotation'])
+
+export function PaperShaderInspector({
+  node,
+  api,
+}: {
+  node: ShaderNode
+  api: SceneAPI
+}) {
+  const uploadRef = useRef<HTMLInputElement>(null)
+  const definition = getPaperShaderDefinition(node.shaderType)
+  const params = useMemo(
+    () => ({ ...definition.defaults.params, ...node.params }),
+    [definition.defaults.params, node.params],
+  )
+  const imageNodes = api
+    .getAllNodeIds()
+    .map((id) => api.getNode(id))
+    .filter((candidate): candidate is Extract<Node, { kind: 'image' }> =>
+      Boolean(candidate?.kind === 'image' && candidate.id !== node.id),
+    )
+  const sourceNode =
+    node.sourceNodeId != null ? api.getNode(node.sourceNodeId) : null
+  const sourcePreview =
+    node.sourceImage ??
+    (sourceNode?.kind === 'image' ? sourceNode.src : '')
+  const sourceValue = node.sourceImage
+    ? '__embedded__'
+    : sourceNode?.kind === 'image'
+      ? sourceNode.id
+      : ''
+
+  const setProperty = <K extends keyof NodeBaseMutable>(
+    key: K,
+    value: NodeBaseMutable[K],
+  ) => api.setNodeProperty(node.id, key, value)
+
+  const applyType = (type: PaperShaderType) => {
+    const next = getPaperShaderDefinition(type)
+    api.doc.transact(() => {
+      setProperty('shaderType', type)
+      setProperty('colors', [...next.defaults.colors])
+      setProperty('speed', next.defaults.speed)
+      setProperty('scale', next.defaults.scale)
+      setProperty('params', { ...next.defaults.params })
+      if (type === 'mesh-gradient') {
+        const distortion = numberParam(next.defaults.params.distortion, 0.8)
+        const swirl = numberParam(next.defaults.params.swirl, 0.1)
+        const grain = numberParam(next.defaults.params.grainOverlay, 0.08)
+        setProperty('distortion', distortion)
+        setProperty('swirl', swirl)
+        setProperty('grain', grain)
+      }
+    })
+  }
+
+  const setColor = (index: number, color: string | null) => {
+    if (!color) return
+    const colors = [...node.colors]
+    colors[index] = color
+    setProperty('colors', colors)
+  }
+
+  const setParam = (key: string, value: PaperShaderParamValue) => {
+    api.doc.transact(() => {
+      setProperty('params', { ...node.params, [key]: value })
+      // Keep the original Mesh Gradient fields synchronized so scenes made
+      // earlier on this branch and current renderers read the same values.
+      if (node.shaderType === 'mesh-gradient') {
+        if (key === 'distortion' && typeof value === 'number') {
+          setProperty('distortion', value)
+        } else if (key === 'swirl' && typeof value === 'number') {
+          setProperty('swirl', value)
+        } else if (key === 'grainOverlay' && typeof value === 'number') {
+          setProperty('grain', value)
+        }
+      }
+    })
+  }
+
+  const chooseSourceNode = (value: string) => {
+    api.doc.transact(() => {
+      setProperty('sourceImage', '')
+      setProperty('sourceNodeId', value)
+    })
+  }
+
+  const embedSource = (files: FileList | null) => {
+    const file = Array.from(files ?? []).find(isImageFile)
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      if (typeof reader.result !== 'string') return
+      api.doc.transact(() => {
+        setProperty('sourceNodeId', '')
+        setProperty('sourceImage', reader.result as string)
+      })
+    }
+    reader.readAsDataURL(file)
+  }
+
+  const groupedTypes = (
+    ['generated', 'image-filter', 'shape'] as const
+  ).map((category) => ({
+    label: CATEGORY_LABELS[category],
+    options: PAPER_SHADER_CATALOG.filter(
+      (candidate) => candidate.category === category,
+    ).map((candidate) => ({ value: candidate.type, label: candidate.label })),
+  }))
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-[13px] font-semibold text-text">Paper Shader</span>
+        <span className="rounded bg-accent-soft px-1.5 py-0.5 text-[9px] font-medium text-accent">
+          {CATEGORY_LABELS[definition.category]}
+        </span>
+      </div>
+      <div className="space-y-2">
+        <FieldRow label="Shader">
+          <SelectField<PaperShaderType>
+            value={node.shaderType}
+            groups={groupedTypes}
+            onCommit={applyType}
+            width="w-full"
+          />
+        </FieldRow>
+
+        {definition.acceptsImage ? (
+          <>
+            <FieldRow label="Source">
+              <SelectField<string>
+                value={sourceValue}
+                options={[
+                  { value: '', label: definition.requiresImage ? 'Choose an image…' : 'Generated texture' },
+                  ...(node.sourceImage
+                    ? [{ value: '__embedded__', label: 'Uploaded image' }]
+                    : []),
+                  ...imageNodes.map((image) => ({
+                    value: image.id,
+                    label: image.name || 'Image layer',
+                  })),
+                ]}
+                onCommit={(value) => {
+                  if (value === '__embedded__') return
+                  chooseSourceNode(value)
+                }}
+                width="w-full"
+              />
+            </FieldRow>
+            <div className="flex items-center gap-2 pl-[22px]">
+              <div className="grid h-10 w-14 shrink-0 place-items-center overflow-hidden rounded-md border border-border bg-app-bg">
+                {sourcePreview ? (
+                  <img
+                    src={sourcePreview}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    draggable={false}
+                  />
+                ) : (
+                  <span className="text-[9px] text-text-dim">No source</span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => uploadRef.current?.click()}
+                className="h-7 rounded-md border border-border px-2 text-[10px] font-medium text-text-muted transition-colors hover:border-border-strong hover:text-text"
+              >
+                Upload…
+              </button>
+              {sourcePreview ? (
+                <button
+                  type="button"
+                  onClick={() => chooseSourceNode('')}
+                  className="h-7 rounded-md px-1.5 text-[10px] text-text-dim transition-colors hover:bg-white/[0.05] hover:text-text"
+                >
+                  Clear
+                </button>
+              ) : null}
+              <input
+                ref={uploadRef}
+                type="file"
+                accept="image/*"
+                hidden
+                onChange={(event) => {
+                  embedSource(event.target.files)
+                  event.target.value = ''
+                }}
+              />
+            </div>
+            {definition.requiresImage && !sourcePreview ? (
+              <p className="ml-[22px] rounded-md border border-amber-400/30 bg-amber-400/10 px-2 py-1.5 text-[10px] leading-4 text-amber-200">
+                Choose an image layer or upload an image to render this filter.
+              </p>
+            ) : null}
+          </>
+        ) : null}
+
+        {node.colors.map((color, index) => (
+          <FieldRow key={`${node.shaderType}-color-${index}`} label={`Color ${index + 1}`}>
+            <ColorField value={color} onCommit={(next) => setColor(index, next)} />
+          </FieldRow>
+        ))}
+
+        <FieldRow label="Speed">
+          <NumberField
+            value={node.speed}
+            onCommit={(speed) => setProperty('speed', Math.max(0, Math.min(2, speed)))}
+            min={0}
+            max={2}
+            step={0.05}
+            suffix="×"
+            ariaLabel="Paper shader speed"
+          />
+        </FieldRow>
+        <FieldRow label="Scale">
+          <NumberField
+            value={node.scale * 100}
+            onCommit={(scale) =>
+              setProperty('scale', Math.max(0.1, Math.min(4, scale / 100)))
+            }
+            min={10}
+            max={400}
+            step={5}
+            suffix="%"
+            ariaLabel="Paper shader scale"
+          />
+        </FieldRow>
+
+        {Object.entries(params)
+          .filter(([key]) => !['colors', 'speed', 'scale', 'frame', 'image'].includes(key))
+          .map(([key, value]) => (
+            <ShaderParamField
+              key={`${node.shaderType}-${key}`}
+              shaderType={node.shaderType}
+              name={key}
+              value={value}
+              onCommit={(next) => setParam(key, next)}
+            />
+          ))}
+
+        <p className="pl-[22px] pt-1 text-[10px] leading-4 text-text-dim">
+          Timeline-synced and deterministic. Speed 0 freezes the current frame;
+          playback and export use the same shader time.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function ShaderParamField({
+  shaderType,
+  name,
+  value,
+  onCommit,
+}: {
+  shaderType: PaperShaderType
+  name: string
+  value: PaperShaderParamValue
+  onCommit: (value: PaperShaderParamValue) => void
+}) {
+  const label = parameterLabel(name)
+  if (Array.isArray(value)) return null
+  if (typeof value === 'boolean') {
+    return (
+      <FieldRow label={label}>
+        <CheckboxField value={value} onCommit={onCommit} />
+      </FieldRow>
+    )
+  }
+  if (typeof value === 'number') {
+    return (
+      <FieldRow label={label}>
+        <NumberField
+          value={value}
+          onCommit={onCommit}
+          step={INTEGER_PARAMS.has(name) || ANGLE_PARAMS.has(name) ? 1 : 0.05}
+          suffix={ANGLE_PARAMS.has(name) ? '°' : undefined}
+          ariaLabel={`${label} shader parameter`}
+        />
+      </FieldRow>
+    )
+  }
+  if (typeof value === 'string') {
+    if (name.startsWith('color')) {
+      return (
+        <FieldRow label={label}>
+          <ColorField value={value} onCommit={(next) => next && onCommit(next)} />
+        </FieldRow>
+      )
+    }
+    const options =
+      name === 'fit'
+        ? (['none', 'contain', 'cover'] as const)
+        : PARAM_OPTIONS[`${shaderType}:${name}`]
+    return (
+      <FieldRow label={label}>
+        {options ? (
+          <SelectField<string>
+            value={value}
+            options={options}
+            onCommit={onCommit}
+            width="w-full"
+          />
+        ) : (
+          <TextField value={value} onCommit={onCommit} />
+        )}
+      </FieldRow>
+    )
+  }
+  return null
+}
+
+function parameterLabel(name: string): string {
+  const override = LABEL_OVERRIDES[name]
+  if (override) return override
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/^./, (letter) => letter.toUpperCase())
+}
+
+function numberParam(value: PaperShaderParamValue | undefined, fallback: number) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}

--- a/src/ui/PaperShaderPicker.tsx
+++ b/src/ui/PaperShaderPicker.tsx
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { createPortal } from 'react-dom'
+import { ImageIcon, Search, Sparkles } from 'lucide-react'
+import {
+  PAPER_SHADER_CATALOG,
+  type PaperShaderCategory,
+  type PaperShaderType,
+} from '@/scene/paperShaders'
+
+type CategoryFilter = 'all' | PaperShaderCategory
+
+const CATEGORY_TABS: Array<{ id: CategoryFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'generated', label: 'Generated' },
+  { id: 'image-filter', label: 'Image' },
+  { id: 'shape', label: 'Shape' },
+]
+
+/**
+ * The catalog deliberately uses static swatches. Rendering 29 live Paper
+ * canvases in a menu would allocate 29 WebGL contexts just to browse, which
+ * crosses the context budget of several browsers before a shader is inserted.
+ */
+const SHADER_SWATCHES: Record<PaperShaderType, string> = {
+  'mesh-gradient':
+    'radial-gradient(circle at 24% 24%, #e0eaff 0 12%, transparent 36%), radial-gradient(circle at 76% 62%, #f75092 0 12%, transparent 42%), #241d9a',
+  'static-mesh-gradient':
+    'conic-gradient(from 220deg at 60% 45%, #ffad0a, #6200ff, #e2a3ff, #ff99fd, #ffad0a)',
+  'static-radial-gradient':
+    'radial-gradient(circle at 66% 32%, #fff 0 4%, #00ffe1 22%, #00bbff 42%, #000 76%)',
+  dithering:
+    'repeating-radial-gradient(circle at 25% 25%, #00b2ff 0 1px, #000 1.5px 4px)',
+  'grain-gradient':
+    'radial-gradient(ellipse at 30% 70%, #7300ff 0, transparent 52%), radial-gradient(ellipse at 70% 25%, #00bfff 0, #000 65%)',
+  'dot-orbit':
+    'radial-gradient(circle at 20% 30%, #ffc96b 0 8%, transparent 9%), radial-gradient(circle at 64% 30%, #ff6200 0 8%, transparent 9%), radial-gradient(circle at 42% 70%, #ff2f00 0 8%, #1a0000 9%)',
+  'dot-grid':
+    'radial-gradient(circle, #fff 0 10%, transparent 11%) 0 0 / 10px 10px, #000',
+  warp:
+    'repeating-linear-gradient(112deg, #121212 0 12%, #9470ff 14% 23%, #121212 25% 36%, #8838ff 38% 48%)',
+  spiral:
+    'repeating-radial-gradient(circle at 50% 50%, #79d1ff 0 4%, #001429 5% 12%)',
+  swirl:
+    'conic-gradient(from 35deg at 52% 52%, #ffd1d1, #660000 24%, #ff8a8a 50%, #330000 76%, #ffd1d1)',
+  waves:
+    'repeating-linear-gradient(165deg, #ffbb00 0 7%, #000 8% 17%)',
+  'neuro-noise':
+    'radial-gradient(ellipse at 35% 50%, #fff 0 3%, #47a6ff 18%, #000 55%), radial-gradient(ellipse at 75% 35%, #47a6ff, #000 64%)',
+  'perlin-noise':
+    'radial-gradient(ellipse at 22% 65%, #fccff7 0 18%, transparent 45%), radial-gradient(ellipse at 78% 35%, #fccff7 0 12%, #632ad5 55%)',
+  'simplex-noise':
+    'radial-gradient(circle at 25% 28%, #ffd1e0 0 13%, transparent 30%), radial-gradient(circle at 72% 62%, #ffd36b 0 14%, transparent 34%), #4449cf',
+  voronoi:
+    'radial-gradient(circle at 25% 30%, #ff8247 0 17%, #2e0000 19% 23%, transparent 25%), radial-gradient(circle at 72% 62%, #ffe53d 0 20%, #2e0000 22% 26%, transparent 28%), #2e0000',
+  'pulsing-border':
+    'radial-gradient(ellipse at center, #000 0 48%, transparent 51%), conic-gradient(#0dc1fd, #d915ef, #ff3f2e, #0dc1fd)',
+  metaballs:
+    'radial-gradient(circle at 28% 54%, #6e33cc 0 19%, transparent 21%), radial-gradient(circle at 62% 35%, #ff5500 0 21%, transparent 23%), radial-gradient(circle at 76% 72%, #ffc800 0 14%, #000 16%)',
+  'color-panels':
+    'linear-gradient(70deg, #000 0 20%, #ff9d0099 21% 38%, #809bffaa 39% 58%, #6d2effaa 59% 76%, #000 78%)',
+  'smoke-ring':
+    'radial-gradient(circle at center, transparent 0 24%, #fff 28% 36%, #8ba4c655 46%, #000 66%)',
+  'god-rays':
+    'conic-gradient(from 210deg at 50% 100%, #000 0 14%, #6200ff 15% 22%, #fff 23% 25%, #33fff5 27% 31%, #000 33% 100%)',
+  'paper-texture':
+    'repeating-linear-gradient(8deg, #ffffff 0 2px, #c5ccd4 3px 4px, #9fadbc 5px 6px)',
+  water:
+    'radial-gradient(ellipse at 35% 40%, #fff 0 3%, transparent 13%), radial-gradient(ellipse at 68% 58%, #d9f7ff 0 4%, transparent 18%), #477d93',
+  'fluted-glass':
+    'repeating-linear-gradient(90deg, #dce7f1 0 4px, #8499ad 5px 7px, #eef6fb 8px 11px)',
+  'image-dithering':
+    'repeating-radial-gradient(circle at 25% 25%, #94ffaf 0 1px, #000c38 1.5px 4px)',
+  'halftone-dots':
+    'radial-gradient(circle, #2b2b2b 0 24%, transparent 26%) 0 0 / 9px 9px, #f2f1e8',
+  'halftone-cmyk':
+    'radial-gradient(circle at 35% 40%, #00b4ffaa 0 17%, transparent 19%), radial-gradient(circle at 58% 50%, #fc519faa 0 18%, transparent 20%), radial-gradient(circle at 48% 68%, #ffd800aa 0 17%, #fbfaf5 19%)',
+  'liquid-metal':
+    'conic-gradient(from 105deg at 45% 48%, #323238, #fff 18%, #68686f 33%, #fafafa 49%, #3f4046 66%, #aaa 82%, #323238)',
+  'gem-smoke':
+    'radial-gradient(circle at 40% 38%, #fff 0 5%, #dcecff 18%, transparent 45%), radial-gradient(circle at 66% 66%, #333 0 11%, #e7e6df 38%, #f0efea 70%)',
+  heatmap:
+    'linear-gradient(135deg, #11206a, #2f63e7 28%, #6bd7ff 44%, #ffe679 60%, #ff991e 76%, #ff4c00)',
+}
+export function PaperShaderPicker({
+  anchor,
+  value,
+  onSelect,
+  onClose,
+}: {
+  anchor: HTMLElement
+  value?: PaperShaderType
+  onSelect: (type: PaperShaderType) => void
+  onClose: () => void
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [position, setPosition] = useState<{ left: number; top: number } | null>(
+    null,
+  )
+  const [category, setCategory] = useState<CategoryFilter>('all')
+  const [query, setQuery] = useState('')
+
+  const visible = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return PAPER_SHADER_CATALOG.filter(
+      (shader) =>
+        (category === 'all' || shader.category === category) &&
+        (!needle ||
+          shader.label.toLowerCase().includes(needle) ||
+          shader.type.includes(needle)),
+    )
+  }, [category, query])
+
+  useLayoutEffect(() => {
+    const popover = ref.current
+    if (!popover) return
+    const trigger = anchor.getBoundingClientRect()
+    const rect = popover.getBoundingClientRect()
+    const gap = 8
+    const edge = 8
+    let left = trigger.left + trigger.width / 2 - rect.width / 2
+    left = Math.min(window.innerWidth - rect.width - edge, Math.max(edge, left))
+    let top = trigger.top - rect.height - gap
+    if (top < edge) top = Math.min(window.innerHeight - rect.height - edge, trigger.bottom + gap)
+    setPosition({ left, top })
+  }, [anchor, category, query])
+
+  useEffect(() => {
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node
+      if (ref.current?.contains(target) || anchor.contains(target)) return
+      onClose()
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('pointerdown', onPointerDown, true)
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown, true)
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [anchor, onClose])
+
+  return createPortal(
+    <div
+      ref={ref}
+      data-export-hide="1"
+      role="dialog"
+      aria-label="Paper shader catalog"
+      style={{
+        position: 'fixed',
+        left: position?.left ?? -9999,
+        top: position?.top ?? -9999,
+        visibility: position ? 'visible' : 'hidden',
+        width: 380,
+        maxHeight: 'min(520px, calc(100vh - 16px))',
+      }}
+      className="z-[120] flex flex-col overflow-hidden rounded-xl border border-border-strong bg-panel-raised shadow-[var(--shadow-dock)]"
+    >
+      <div className="border-b border-border px-3 pb-2.5 pt-3">
+        <div className="mb-2.5 flex items-center gap-2">
+          <span className="grid h-7 w-7 place-items-center rounded-lg bg-accent-soft text-accent">
+            <Sparkles size={15} />
+          </span>
+          <div className="min-w-0">
+            <div className="text-[12px] font-semibold text-text">Paper shaders</div>
+            <div className="text-[10px] text-text-dim">29 timeline-ready effects</div>
+          </div>
+        </div>
+        <label className="flex h-8 items-center gap-2 rounded-lg bg-app-bg px-2.5 ring-1 ring-border focus-within:ring-accent/50">
+          <Search size={13} className="shrink-0 text-text-dim" />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Find a shader"
+            className="min-w-0 flex-1 bg-transparent text-[11px] text-text outline-none placeholder:text-text-dim"
+          />
+        </label>
+        <div className="mt-2 flex gap-1" role="tablist" aria-label="Shader category">
+          {CATEGORY_TABS.map((tab) => {
+            const active = tab.id === category
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => setCategory(tab.id)}
+                className={[
+                  'h-6 rounded-md px-2 text-[10px] font-medium transition-colors',
+                  active
+                    ? 'bg-accent text-white'
+                    : 'text-text-muted hover:bg-white/[0.06] hover:text-text',
+                ].join(' ')}
+              >
+                {tab.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div
+        role="listbox"
+        aria-label="Available Paper shaders"
+        className="grid min-h-0 grid-cols-2 gap-1.5 overflow-y-auto p-2"
+      >
+        {visible.map((shader) => {
+          const selected = shader.type === value
+          return (
+            <button
+              key={shader.type}
+              type="button"
+              role="option"
+              aria-selected={selected}
+              onClick={() => {
+                onSelect(shader.type)
+                onClose()
+              }}
+              className={[
+                'group flex min-w-0 items-center gap-2 rounded-lg border px-2 py-1.5 text-left transition-colors',
+                selected
+                  ? 'border-accent bg-accent-soft/55'
+                  : 'border-transparent hover:border-border hover:bg-white/[0.045]',
+              ].join(' ')}
+            >
+              <span
+                aria-hidden
+                style={{ background: SHADER_SWATCHES[shader.type] }}
+                className="h-9 w-9 shrink-0 rounded-md border border-white/10 shadow-inner"
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[11px] font-medium text-text">
+                  {shader.label}
+                </span>
+                <span className="mt-0.5 flex items-center gap-1 text-[9px] text-text-dim">
+                  {shader.acceptsImage ? <ImageIcon size={9} /> : <Sparkles size={9} />}
+                  {shader.requiresImage
+                    ? 'Image required'
+                    : shader.acceptsImage
+                      ? 'Image optional'
+                      : 'Generated'}
+                </span>
+              </span>
+            </button>
+          )
+        })}
+        {visible.length === 0 ? (
+          <div className="col-span-2 px-3 py-8 text-center text-[11px] text-text-dim">
+            No shaders match “{query.trim()}”.
+          </div>
+        ) : null}
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -289,6 +289,8 @@ export function Timeline() {
   const setPlayhead = useUI((s) => s.setPlayhead)
   const playing = useUI((s) => s.playing)
   const setPlaying = useUI((s) => s.setPlaying)
+  const recording = useUI((s) => s.recording)
+  const setRecording = useUI((s) => s.setRecording)
   const selection = useUI((s) => s.selection)
   const setSelection = useUI((s) => s.setSelection)
   const setInspectorMode = useUI((s) => s.setInspectorMode)
@@ -2660,6 +2662,33 @@ export function Timeline() {
             <TransportIcon kind="end" />
           </button>
         </div>
+
+        <button
+          type="button"
+          onClick={() => setRecording(!recording)}
+          aria-pressed={recording}
+          aria-label="Toggle Auto Key"
+          title={
+            recording
+              ? 'Auto Key is on — camera gestures and property edits create keyframes'
+              : 'Turn on Auto Key to record camera gestures and property edits as keyframes'
+          }
+          className={[
+            'flex h-7 shrink-0 items-center gap-1.5 rounded border px-2 text-[10px] font-semibold tracking-[0.06em] uppercase transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent',
+            recording
+              ? 'border-red-500/60 bg-red-500/15 text-red-500 hover:bg-red-500/20'
+              : 'border-border bg-panel text-text-muted hover:border-border-strong hover:text-text',
+          ].join(' ')}
+        >
+          <span
+            aria-hidden
+            className={[
+              'h-1.5 w-1.5 rounded-full',
+              recording ? 'bg-red-500' : 'bg-text-dim',
+            ].join(' ')}
+          />
+          Auto Key
+        </button>
 
         {/* Playhead readout sits adjacent to the transport — current
             time/frame is part of "where is playback right now," not a

--- a/src/ui/cameraNavigation.test.ts
+++ b/src/ui/cameraNavigation.test.ts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import {
+  cameraDollyFromWheel,
+  cameraOrbitFromPointer,
+  cameraOrbitFromWheel,
+  cameraPanFromPointer,
+  cameraPanFromWheel,
+  cameraZFromPointerDrag,
+  normalizedWheelDeltas,
+  resolveCameraPointerNavigation,
+  resolveCameraWheelNavigation,
+} from '@/ui/cameraNavigation'
+
+describe('camera navigation policy', () => {
+  it('uses Blender-style middle-mouse chords', () => {
+    expect(resolveCameraPointerNavigation({ button: 1 })).toBe('orbit')
+    expect(
+      resolveCameraPointerNavigation({ button: 1, shiftKey: true }),
+    ).toBe('pan')
+    expect(
+      resolveCameraPointerNavigation({ button: 1, ctrlKey: true }),
+    ).toBe('dolly')
+    expect(
+      resolveCameraPointerNavigation({
+        button: 1,
+        shiftKey: true,
+        ctrlKey: true,
+      }),
+    ).toBe('dolly')
+  })
+
+  it('emulates middle-mouse with Option/Alt plus primary drag', () => {
+    expect(
+      resolveCameraPointerNavigation({ button: 0, altKey: true }),
+    ).toBe('orbit')
+    expect(
+      resolveCameraPointerNavigation({
+        button: 0,
+        altKey: true,
+        shiftKey: true,
+      }),
+    ).toBe('pan')
+    expect(
+      resolveCameraPointerNavigation({
+        button: 0,
+        altKey: true,
+        ctrlKey: true,
+      }),
+    ).toBe('dolly')
+    expect(resolveCameraPointerNavigation({ button: 0 })).toBeNull()
+    expect(
+      resolveCameraPointerNavigation({ button: 2, altKey: true }),
+    ).toBeNull()
+  })
+
+  it('keeps editor zoom ahead of wheel camera navigation', () => {
+    expect(resolveCameraWheelNavigation({})).toBe('dolly')
+    expect(resolveCameraWheelNavigation({ shiftKey: true })).toBe('pan')
+    expect(resolveCameraWheelNavigation({ altKey: true })).toBe('orbit')
+    expect(
+      resolveCameraWheelNavigation({ shiftKey: true, altKey: true }),
+    ).toBe('pan')
+    expect(resolveCameraWheelNavigation({ ctrlKey: true })).toBeNull()
+    expect(resolveCameraWheelNavigation({ metaKey: true })).toBeNull()
+  })
+})
+
+describe('camera orbit navigation', () => {
+  it('maps horizontal motion to yaw and vertical motion to pitch', () => {
+    expect(
+      cameraOrbitFromPointer({
+        startRotationX: 10,
+        startRotationY: 20,
+        deltaX: 25,
+        deltaY: -50,
+      }),
+    ).toEqual({ rotationX: 18, rotationY: 24 })
+  })
+
+  it('clamps pitch without limiting continuous yaw', () => {
+    expect(
+      cameraOrbitFromPointer({
+        startRotationX: 80,
+        startRotationY: 0,
+        deltaX: 10_000,
+        deltaY: -100,
+      }),
+    ).toEqual({ rotationX: 89, rotationY: 1600 })
+  })
+
+  it('normalizes and caps both axes for wheel orbit', () => {
+    expect(
+      normalizedWheelDeltas({
+        deltaX: 4,
+        deltaY: -4,
+        deltaMode: 1,
+        pageWidth: 1200,
+        pageHeight: 800,
+      }),
+    ).toEqual({ x: 48, y: -48 })
+
+    expect(
+      cameraOrbitFromWheel({
+        currentRotationX: 0,
+        currentRotationY: 0,
+        deltaX: 100,
+        deltaY: -100,
+        deltaMode: 0,
+        pageWidth: 1200,
+        pageHeight: 800,
+      }),
+    ).toEqual({ rotationX: 3.84, rotationY: 3.84 })
+  })
+})
+
+describe('camera pan navigation', () => {
+  it('scales pointer pan by workspace zoom and visible camera scale', () => {
+    expect(
+      cameraPanFromPointer({
+        startX: 100,
+        startY: 200,
+        deltaX: 40,
+        deltaY: -20,
+        workspaceZoom: 2,
+        cameraApparentScale: 0.5,
+      }),
+    ).toEqual({ x: 60, y: 220 })
+  })
+
+  it('uses scroll direction and the same zoom-aware scale for wheel pan', () => {
+    expect(
+      cameraPanFromWheel({
+        currentX: 100,
+        currentY: 200,
+        deltaX: 24,
+        deltaY: -12,
+        deltaMode: 0,
+        pageWidth: 1200,
+        pageHeight: 800,
+        workspaceZoom: 2,
+        cameraApparentScale: 2,
+      }),
+    ).toEqual({ x: 106, y: 197 })
+  })
+
+  it('stays finite when a transient scale is invalid', () => {
+    expect(
+      cameraPanFromPointer({
+        startX: 0,
+        startY: 0,
+        deltaX: 10,
+        deltaY: 10,
+        workspaceZoom: Number.NaN,
+        cameraApparentScale: 0,
+      }),
+    ).toEqual({ x: -100, y: -100 })
+  })
+})
+
+describe('camera dolly navigation', () => {
+  it('uses proportional pointer dolly without capping the total drag', () => {
+    const z = cameraZFromPointerDrag({
+      startZ: 0,
+      focalLength: 1000,
+      deltaY: -100,
+    })
+
+    expect(z).toBeCloseTo(393.469, 3)
+  })
+
+  it('applies camera sensitivity and clamps at the lens safety limits', () => {
+    const halfSpeedZ = cameraZFromPointerDrag({
+      startZ: 0,
+      focalLength: 1000,
+      deltaY: -100,
+      scrollSensitivity: 0.5,
+    })
+    const nearLimitZ = cameraZFromPointerDrag({
+      startZ: 0,
+      focalLength: 1000,
+      deltaY: -1_000_000,
+    })
+
+    expect(halfSpeedZ).toBeCloseTo(221.199, 3)
+    expect(nearLimitZ).toBe(999)
+  })
+
+  it('returns a Z-only patch for wheel dolly', () => {
+    expect(
+      cameraDollyFromWheel({
+        currentZ: 0,
+        focalLength: 1000,
+        deltaY: -12,
+        deltaMode: 0,
+        pageHeight: 800,
+      }),
+    ).toEqual({ z: expect.closeTo(14.888, 3) })
+  })
+})

--- a/src/ui/cameraNavigation.ts
+++ b/src/ui/cameraNavigation.ts
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  normalizeCameraScrollSensitivity,
+  type Transform,
+} from '@/scene/types'
+import {
+  cameraZFromWheel,
+  normalizedWheelDeltaY,
+  type CameraWheelDollyInput,
+} from '@/ui/cameraWheel'
+
+export type CameraNavigationMode = 'orbit' | 'pan' | 'dolly'
+
+export type CameraOrbitPatch = Pick<Transform, 'rotationX' | 'rotationY'>
+export type CameraPanPatch = Pick<Transform, 'x' | 'y'>
+export type CameraDollyPatch = Pick<Transform, 'z'>
+
+export interface CameraPointerNavigationInput {
+  button: number
+  altKey?: boolean
+  shiftKey?: boolean
+  ctrlKey?: boolean
+}
+
+export interface CameraWheelNavigationInput {
+  altKey?: boolean
+  shiftKey?: boolean
+  ctrlKey?: boolean
+  metaKey?: boolean
+}
+
+/**
+ * Blender-style pointer navigation.
+ *
+ * Middle-mouse is the primary chord. Option/Alt + primary click mirrors it
+ * for trackpads and two-button mice. Ctrl deliberately wins over Shift when
+ * both are held, matching the more-specific dolly gesture.
+ */
+export function resolveCameraPointerNavigation(
+  input: CameraPointerNavigationInput,
+): CameraNavigationMode | null {
+  const isMiddleMouse = input.button === 1
+  const isEmulatedMiddleMouse = input.button === 0 && input.altKey === true
+  if (!isMiddleMouse && !isEmulatedMiddleMouse) return null
+  if (input.ctrlKey) return 'dolly'
+  if (input.shiftKey) return 'pan'
+  return 'orbit'
+}
+
+/**
+ * Resolve wheel/trackpad navigation after the editor has had first refusal
+ * for its Ctrl/Cmd zoom gesture.
+ */
+export function resolveCameraWheelNavigation(
+  input: CameraWheelNavigationInput,
+): CameraNavigationMode | null {
+  if (input.ctrlKey || input.metaKey) return null
+  if (input.shiftKey) return 'pan'
+  if (input.altKey) return 'orbit'
+  return 'dolly'
+}
+
+export interface NormalizedWheelDeltasInput {
+  deltaX: number
+  deltaY: number
+  deltaMode: number
+  pageWidth: number
+  pageHeight: number
+}
+
+/** Normalize both wheel axes with the same bounded packet policy as dolly. */
+export function normalizedWheelDeltas(
+  input: NormalizedWheelDeltasInput,
+): { x: number; y: number } {
+  return {
+    x: normalizedWheelDeltaY(
+      input.deltaX,
+      input.deltaMode,
+      input.pageWidth,
+    ),
+    y: normalizedWheelDeltaY(
+      input.deltaY,
+      input.deltaMode,
+      input.pageHeight,
+    ),
+  }
+}
+
+const POINTER_ORBIT_DEGREES_PER_PIXEL = 0.16
+const WHEEL_ORBIT_DEGREES_PER_PIXEL = 0.08
+const POINTER_DOLLY_SENSITIVITY = 0.005
+const MIN_CAMERA_DISTANCE = 1
+const MAX_CAMERA_DISTANCE_IN_FOCAL_LENGTHS = 1000
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+function finiteOr(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback
+}
+
+function cameraPanDivisor(
+  workspaceZoom: number,
+  cameraApparentScale: number,
+): number {
+  const zoom = Math.abs(finiteOr(workspaceZoom, 1))
+  const cameraScale = Math.abs(finiteOr(cameraApparentScale, 1))
+  return Math.max(0.1, zoom * cameraScale)
+}
+
+export interface CameraOrbitFromPointerInput {
+  startRotationX: number
+  startRotationY: number
+  deltaX: number
+  deltaY: number
+  degreesPerPixel?: number
+}
+
+export function cameraOrbitFromPointer(
+  input: CameraOrbitFromPointerInput,
+): CameraOrbitPatch {
+  const sensitivity = Math.max(
+    0,
+    finiteOr(input.degreesPerPixel ?? POINTER_ORBIT_DEGREES_PER_PIXEL, 0),
+  )
+  const deltaX = finiteOr(input.deltaX, 0)
+  const deltaY = finiteOr(input.deltaY, 0)
+  return {
+    rotationX: clamp(
+      finiteOr(input.startRotationX, 0) - deltaY * sensitivity,
+      -89,
+      89,
+    ),
+    rotationY: finiteOr(input.startRotationY, 0) + deltaX * sensitivity,
+  }
+}
+
+export interface CameraOrbitFromWheelInput {
+  currentRotationX: number
+  currentRotationY: number
+  deltaX: number
+  deltaY: number
+  deltaMode: number
+  pageWidth: number
+  pageHeight: number
+  degreesPerPixel?: number
+}
+
+export function cameraOrbitFromWheel(
+  input: CameraOrbitFromWheelInput,
+): CameraOrbitPatch {
+  const delta = normalizedWheelDeltas(input)
+  const sensitivity = Math.max(
+    0,
+    finiteOr(input.degreesPerPixel ?? WHEEL_ORBIT_DEGREES_PER_PIXEL, 0),
+  )
+  return {
+    rotationX: clamp(
+      finiteOr(input.currentRotationX, 0) - delta.y * sensitivity,
+      -89,
+      89,
+    ),
+    rotationY:
+      finiteOr(input.currentRotationY, 0) + delta.x * sensitivity,
+  }
+}
+
+export interface CameraPanFromPointerInput {
+  startX: number
+  startY: number
+  deltaX: number
+  deltaY: number
+  workspaceZoom: number
+  cameraApparentScale: number
+}
+
+export function cameraPanFromPointer(
+  input: CameraPanFromPointerInput,
+): CameraPanPatch {
+  const divisor = cameraPanDivisor(
+    input.workspaceZoom,
+    input.cameraApparentScale,
+  )
+  return {
+    x: finiteOr(input.startX, 0) - finiteOr(input.deltaX, 0) / divisor,
+    y: finiteOr(input.startY, 0) - finiteOr(input.deltaY, 0) / divisor,
+  }
+}
+
+export interface CameraPanFromWheelInput {
+  currentX: number
+  currentY: number
+  deltaX: number
+  deltaY: number
+  deltaMode: number
+  pageWidth: number
+  pageHeight: number
+  workspaceZoom: number
+  cameraApparentScale: number
+}
+
+export function cameraPanFromWheel(
+  input: CameraPanFromWheelInput,
+): CameraPanPatch {
+  const delta = normalizedWheelDeltas(input)
+  const divisor = cameraPanDivisor(
+    input.workspaceZoom,
+    input.cameraApparentScale,
+  )
+  // Wheel deltas describe the direction content should scroll. Since the
+  // renderer applies the inverse camera transform, advancing the camera in
+  // the same direction produces that familiar scroll response.
+  return {
+    x: finiteOr(input.currentX, 0) + delta.x / divisor,
+    y: finiteOr(input.currentY, 0) + delta.y / divisor,
+  }
+}
+
+export interface CameraZFromPointerDragInput {
+  startZ: number
+  focalLength: number
+  deltaY: number
+  scrollSensitivity?: number
+}
+
+/**
+ * Dolly from a pointer drag in lens-distance space.
+ *
+ * Unlike a wheel packet, a drag is measured from its start pose and must not
+ * be packet-capped. The exponential response stays proportional at every
+ * focal length while preserving the renderer's near/far safety envelope.
+ */
+export function cameraZFromPointerDrag(
+  input: CameraZFromPointerDragInput,
+): number {
+  const focalLength = Math.max(1, finiteOr(input.focalLength, 1000))
+  const authoredDistance = focalLength - finiteOr(input.startZ, 0)
+  const currentDistance = Math.max(
+    MIN_CAMERA_DISTANCE,
+    finiteOr(authoredDistance, focalLength),
+  )
+  const sensitivity =
+    POINTER_DOLLY_SENSITIVITY *
+    normalizeCameraScrollSensitivity(input.scrollSensitivity)
+  const exponent = clamp(finiteOr(input.deltaY, 0) * sensitivity, -20, 20)
+  const requestedDistance = currentDistance * Math.exp(exponent)
+  const nominalMaxDistance =
+    focalLength * MAX_CAMERA_DISTANCE_IN_FOCAL_LENGTHS
+  const gestureMinDistance = Math.min(MIN_CAMERA_DISTANCE, currentDistance)
+  const gestureMaxDistance = Math.max(nominalMaxDistance, currentDistance)
+  const nextDistance = clamp(
+    requestedDistance,
+    gestureMinDistance,
+    gestureMaxDistance,
+  )
+  return focalLength - nextDistance
+}
+
+/** Return the Z-only patch used by a wheel/trackpad dolly gesture. */
+export function cameraDollyFromWheel(
+  input: CameraWheelDollyInput,
+): CameraDollyPatch {
+  return { z: cameraZFromWheel(input) }
+}

--- a/src/ui/fields/ScalePairField.tsx
+++ b/src/ui/fields/ScalePairField.tsx
@@ -4,6 +4,11 @@ import { useEffect, useRef, useState } from 'react'
 import type { NodeId } from '@/scene'
 import { useUI } from '@/state/ui'
 import { KeyframeButton } from './KeyframeButton'
+import {
+  commitScaleAxisEdit,
+  type ScaleAxis,
+  type ScalePair,
+} from './scalePairEdit'
 
 /**
  * Scale editor — two percentage fields with leading "X" / "Y" labels,
@@ -27,13 +32,15 @@ import { KeyframeButton } from './KeyframeButton'
  *
  * Link state lives in UI state (`scaleLinked`) so it survives selection
  * changes. Default OFF — surprise mirroring on type was disorienting.
- * Click the chain icon on the right to opt into uniform scaling.
+ * Click the chain icon on the right to preserve the current X:Y proportion
+ * while either axis is edited.
  */
 export function ScalePairField({
   scaleX,
   scaleY,
   onCommitX,
   onCommitY,
+  onCommitPair,
   mixedX = false,
   mixedY = false,
   nodeId,
@@ -42,6 +49,11 @@ export function ScalePairField({
   scaleY: number
   onCommitX: (next: number) => void
   onCommitY: (next: number) => void
+  /**
+   * Optional atomic pair writer. Linked edits prefer this over the two
+   * per-axis callbacks so the owner can commit one transaction.
+   */
+  onCommitPair?: (next: ScalePair) => void
   mixedX?: boolean
   mixedY?: boolean
   /**
@@ -54,16 +66,46 @@ export function ScalePairField({
   const scaleLinked = useUI((s) => s.scaleLinked)
   const toggleScaleLinked = useUI((s) => s.toggleScaleLinked)
 
-  const commit = (axis: 'x' | 'y', percent: number) => {
-    // The link toggle no longer mirrors edits across axes — it
-    // surprised users who wanted to nudge one channel without losing
-    // the other. The toggle is kept around for a future
-    // ratio-preserving behavior (drag X, Y scales to match the
-    // original aspect) but for now both axes always edit
-    // independently regardless of `scaleLinked`.
-    const next = percent / 100
-    if (axis === 'x') onCommitX(next)
-    else onCommitY(next)
+  const currentPairRef = useRef<ScalePair>({ scaleX, scaleY })
+  const editRef = useRef<{
+    axis: ScaleAxis
+    baseline: ScalePair
+  } | null>(null)
+
+  // External changes (selection, timeline seeks, undo/redo) become the next
+  // edit's baseline. During an active edit the captured baseline stays fixed,
+  // which avoids ratio drift from rounded intermediate values.
+  useEffect(() => {
+    if (!editRef.current) currentPairRef.current = { scaleX, scaleY }
+  }, [scaleX, scaleY])
+
+  const beginEdit = (axis: ScaleAxis) => {
+    editRef.current = {
+      axis,
+      baseline: { ...currentPairRef.current },
+    }
+  }
+
+  const endEdit = (axis: ScaleAxis) => {
+    if (editRef.current?.axis === axis) editRef.current = null
+  }
+
+  const commit = (axis: ScaleAxis, percent: number) => {
+    const activeEdit = editRef.current
+    const baseline =
+      activeEdit?.axis === axis
+        ? activeEdit.baseline
+        : { ...currentPairRef.current }
+    currentPairRef.current = commitScaleAxisEdit({
+      baseline,
+      current: currentPairRef.current,
+      axis,
+      next: percent / 100,
+      linked: scaleLinked,
+      onCommitX,
+      onCommitY,
+      onCommitPair,
+    })
   }
 
   return (
@@ -73,6 +115,8 @@ export function ScalePairField({
         value={scaleX}
         mixed={mixedX}
         onCommit={(p) => commit('x', p)}
+        onEditStart={() => beginEdit('x')}
+        onEditEnd={() => endEdit('x')}
       />
       {nodeId ? (
         <KeyframeButton
@@ -86,6 +130,8 @@ export function ScalePairField({
         value={scaleY}
         mixed={mixedY}
         onCommit={(p) => commit('y', p)}
+        onEditStart={() => beginEdit('y')}
+        onEditEnd={() => endEdit('y')}
       />
       {nodeId ? (
         <KeyframeButton
@@ -113,11 +159,15 @@ function PercentField({
   value,
   mixed,
   onCommit,
+  onEditStart,
+  onEditEnd,
 }: {
   axis: 'X' | 'Y'
   value: number
   mixed: boolean
   onCommit: (percent: number) => void
+  onEditStart: () => void
+  onEditEnd: () => void
 }) {
   if (mixed) {
     return (
@@ -153,7 +203,12 @@ function PercentField({
       >
         {axis}
       </span>
-      <PercentInput value={value} onCommit={onCommit} />
+      <PercentInput
+        value={value}
+        onCommit={onCommit}
+        onEditStart={onEditStart}
+        onEditEnd={onEditEnd}
+      />
       <span
         className="pointer-events-none select-none pr-1.5 pl-0.5 text-[11px]"
         style={{ color: 'var(--color-text-dim)' }}
@@ -174,58 +229,75 @@ function PercentField({
 function PercentInput({
   value,
   onCommit,
+  onEditStart,
+  onEditEnd,
 }: {
   value: number
   onCommit: (percent: number) => void
+  onEditStart: () => void
+  onEditEnd: () => void
 }) {
   const [draft, setDraft] = useState(() => formatPercent(value))
   const [focused, setFocused] = useState(false)
-  const ref = useRef<HTMLInputElement>(null)
+  const livePercentRef = useRef(toPercent(value))
+  const cancelBlurCommitRef = useRef(false)
 
-  // Keep the draft in sync with the prop while the user isn't typing.
-  useEffect(() => {
-    if (!focused) setDraft(formatPercent(value))
-  }, [value, focused])
+  const emit = (percent: number) => {
+    if (!Number.isFinite(percent)) return false
+    if (percent !== livePercentRef.current) {
+      livePercentRef.current = percent
+      onCommit(percent)
+    }
+    return true
+  }
 
-  const commit = () => {
-    const parsed = parseFloat(draft)
-    if (!Number.isFinite(parsed)) {
+  const commitDraft = () => {
+    const parsed = Number.parseFloat(draft)
+    if (!emit(parsed)) {
       setDraft(formatPercent(value))
       return
     }
-    if (parsed !== toPercent(value)) onCommit(parsed)
     setDraft(formatPercentNumber(parsed))
   }
 
   return (
     <input
-      ref={ref}
       type="text"
       inputMode="decimal"
-      value={draft}
+      value={focused ? draft : formatPercent(value)}
       onChange={(e) => setDraft(e.target.value)}
       onFocus={(e) => {
+        setDraft(formatPercent(value))
         setFocused(true)
+        livePercentRef.current = toPercent(value)
+        cancelBlurCommitRef.current = false
+        onEditStart()
         e.currentTarget.select()
       }}
       onBlur={() => {
         setFocused(false)
-        commit()
+        if (cancelBlurCommitRef.current) {
+          cancelBlurCommitRef.current = false
+        } else {
+          commitDraft()
+        }
+        onEditEnd()
       }}
       onKeyDown={(e) => {
         if (e.key === 'Enter') {
           e.preventDefault()
-          commit()
-          ref.current?.blur()
+          e.currentTarget.blur()
         } else if (e.key === 'Escape') {
+          e.preventDefault()
+          cancelBlurCommitRef.current = true
           setDraft(formatPercent(value))
-          ref.current?.blur()
+          e.currentTarget.blur()
         } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
           e.preventDefault()
           const delta = (e.key === 'ArrowUp' ? 1 : -1) * (e.shiftKey ? 10 : 1)
-          const next = (parseFloat(draft) || 0) + delta
+          const next = (Number.parseFloat(draft) || 0) + delta
           setDraft(formatPercentNumber(next))
-          onCommit(next)
+          emit(next)
         }
       }}
       className="min-w-0 flex-1 bg-transparent py-0.5 text-right font-mono text-[12px] tabular-nums text-text outline-none"

--- a/src/ui/fields/scalePairEdit.test.ts
+++ b/src/ui/fields/scalePairEdit.test.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+  commitScaleAxisEdit,
+  resolveScaleAxisEdit,
+  type ScalePair,
+} from './scalePairEdit'
+
+describe('linked Scale axis edits', () => {
+  it('preserves the edit-start X:Y ratio when X changes', () => {
+    const baseline = { scaleX: 2, scaleY: 0.5 }
+
+    expect(resolveScaleAxisEdit(baseline, 'x', 3, true)).toEqual({
+      scaleX: 3,
+      scaleY: 0.75,
+    })
+
+    // A later update in the same edit still resolves from the original pair,
+    // not from a rounded intermediate result.
+    expect(resolveScaleAxisEdit(baseline, 'x', 4, true)).toEqual({
+      scaleX: 4,
+      scaleY: 1,
+    })
+  })
+
+  it('preserves the edit-start X:Y ratio when Y changes', () => {
+    const baseline = { scaleX: 1.5, scaleY: 0.5 }
+
+    expect(resolveScaleAxisEdit(baseline, 'y', 1, true)).toEqual({
+      scaleX: 3,
+      scaleY: 1,
+    })
+  })
+
+  it('keeps unlinked edits independent', () => {
+    const baseline = { scaleX: 1.5, scaleY: 0.5 }
+
+    expect(resolveScaleAxisEdit(baseline, 'x', 2, false)).toEqual({
+      scaleX: 2,
+      scaleY: 0.5,
+    })
+    expect(resolveScaleAxisEdit(baseline, 'y', 0.25, false)).toEqual({
+      scaleX: 1.5,
+      scaleY: 0.25,
+    })
+  })
+
+  it('uses a finite 1:1 fallback when the edited axis starts at zero', () => {
+    const fromPositiveFollower = resolveScaleAxisEdit(
+      { scaleX: 0, scaleY: 2 },
+      'x',
+      0.5,
+      true,
+    )
+    const fromNegativeFollower = resolveScaleAxisEdit(
+      { scaleX: -2, scaleY: 0 },
+      'y',
+      0.5,
+      true,
+    )
+
+    expect(fromPositiveFollower).toEqual({ scaleX: 0.5, scaleY: 0.5 })
+    expect(fromNegativeFollower).toEqual({ scaleX: -0.5, scaleY: 0.5 })
+    expect(Object.values(fromPositiveFollower).every(Number.isFinite)).toBe(
+      true,
+    )
+    expect(Object.values(fromNegativeFollower).every(Number.isFinite)).toBe(
+      true,
+    )
+  })
+
+  it('uses one pair callback for a linked commit when provided', () => {
+    const onCommitX = vi.fn()
+    const onCommitY = vi.fn()
+    const onCommitPair = vi.fn()
+
+    const result = commitScaleAxisEdit({
+      baseline: { scaleX: 2, scaleY: 1 },
+      current: { scaleX: 2, scaleY: 1 },
+      axis: 'x',
+      next: 4,
+      linked: true,
+      onCommitX,
+      onCommitY,
+      onCommitPair,
+    })
+
+    expect(result).toEqual({ scaleX: 4, scaleY: 2 })
+    expect(onCommitPair).toHaveBeenCalledOnce()
+    expect(onCommitPair).toHaveBeenCalledWith({ scaleX: 4, scaleY: 2 })
+    expect(onCommitX).not.toHaveBeenCalled()
+    expect(onCommitY).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the individual callbacks for existing call sites', () => {
+    const onCommitX = vi.fn()
+    const onCommitY = vi.fn()
+    const baseline: ScalePair = { scaleX: 1, scaleY: 2 }
+
+    commitScaleAxisEdit({
+      baseline,
+      current: baseline,
+      axis: 'y',
+      next: 4,
+      linked: true,
+      onCommitX,
+      onCommitY,
+    })
+
+    expect(onCommitX).toHaveBeenCalledOnce()
+    expect(onCommitX).toHaveBeenCalledWith(2)
+    expect(onCommitY).toHaveBeenCalledOnce()
+    expect(onCommitY).toHaveBeenCalledWith(4)
+  })
+})

--- a/src/ui/fields/scalePairEdit.ts
+++ b/src/ui/fields/scalePairEdit.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type ScaleAxis = 'x' | 'y'
+
+export interface ScalePair {
+  scaleX: number
+  scaleY: number
+}
+
+export interface ScalePairCommitters {
+  onCommitX: (next: number) => void
+  onCommitY: (next: number) => void
+  /**
+   * Prefer this callback when the owner can write both axes in one
+   * transaction. The individual callbacks remain the backwards-compatible
+   * fallback for existing call sites.
+   */
+  onCommitPair?: (next: ScalePair) => void
+}
+
+const ZERO_EPSILON = 1e-8
+
+/**
+ * Resolve one Scale field edit against the values captured when that edit
+ * began. Linked edits use the original X:Y ratio for their entire lifetime,
+ * rather than recomputing from rounded intermediate values on every keypress.
+ *
+ * A zero driving axis has no defined ratio. In that case we use a finite 1:1
+ * fallback (preserving the follower's sign) so moving away from zero never
+ * produces Infinity or NaN.
+ */
+export function resolveScaleAxisEdit(
+  baseline: ScalePair,
+  axis: ScaleAxis,
+  next: number,
+  linked: boolean,
+): ScalePair {
+  if (!linked) {
+    return axis === 'x'
+      ? { ...baseline, scaleX: next }
+      : { ...baseline, scaleY: next }
+  }
+
+  const driver = axis === 'x' ? baseline.scaleX : baseline.scaleY
+  const follower = axis === 'x' ? baseline.scaleY : baseline.scaleX
+  const ratio =
+    Math.abs(driver) > ZERO_EPSILON
+      ? follower / driver
+      : follower < 0
+        ? -1
+        : 1
+  const proportionalFollower = next * ratio
+  const safeFollower = Number.isFinite(proportionalFollower)
+    ? proportionalFollower
+    : follower
+
+  return axis === 'x'
+    ? { scaleX: next, scaleY: safeFollower }
+    : { scaleX: safeFollower, scaleY: next }
+}
+
+/**
+ * Resolve and dispatch a Scale edit. When a pair callback is available a
+ * linked change is emitted exactly once, allowing the caller to create one
+ * undoable transaction and one paired keyframe update.
+ */
+export function commitScaleAxisEdit({
+  baseline,
+  current,
+  axis,
+  next,
+  linked,
+  onCommitX,
+  onCommitY,
+  onCommitPair,
+}: {
+  baseline: ScalePair
+  current: ScalePair
+  axis: ScaleAxis
+  next: number
+  linked: boolean
+} & ScalePairCommitters): ScalePair {
+  const nextPair = resolveScaleAxisEdit(baseline, axis, next, linked)
+  const changedX = nextPair.scaleX !== current.scaleX
+  const changedY = nextPair.scaleY !== current.scaleY
+
+  if (!changedX && !changedY) return nextPair
+
+  if (linked && onCommitPair) {
+    onCommitPair(nextPair)
+    return nextPair
+  }
+
+  if (changedX) onCommitX(nextPair.scaleX)
+  if (changedY) onCommitY(nextPair.scaleY)
+  return nextPair
+}

--- a/src/ui/hooks/useAnimatedValues.ts
+++ b/src/ui/hooks/useAnimatedValues.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useMemo, useSyncExternalStore } from 'react'
-import type { NodeId, SceneAPI } from '@/scene'
+import type { BlendMode, NodeId, SceneAPI } from '@/scene'
 import { getAnimEngine } from '@/anim'
 import type { TextAnimationConfig } from '@/anim'
 
@@ -35,6 +35,7 @@ export interface AnimatedValue {
   opacity?: number
   cornerRadius?: number
   fill?: string
+  blendMode?: BlendMode
   textProgress?: number
   textAnimation?: TextAnimationConfig
   focusDistance?: number

--- a/src/ui/hooks/useAnimatedValues.ts
+++ b/src/ui/hooks/useAnimatedValues.ts
@@ -64,6 +64,10 @@ export interface AnimatedValue {
   bloomStrength?: number
   bloomRadius?: number
   bloomThreshold?: number
+  vhsIntensity?: number
+  vhsNoise?: number
+  vhsScanlines?: number
+  vhsColorBleed?: number
 }
 
 const EMPTY_ANIMATED_VALUES = Object.freeze({}) as Record<


### PR DESCRIPTION
## Summary

- Add all 29 Paper Shaders as first-class scene layers with a searchable picker, shader-specific Inspector controls, colors, image sources, speed, and scale.
- Drive shader playback and export from the scene playhead so previews, seeks, and frame capture remain deterministic.
- Add Blender-style camera orbit, pan, and dolly gestures with atomic undo and Auto Key recording.
- Add a deterministic camera-wide VHS effect with animatable intensity, noise, scanlines, and color bleed across WebGL, fallback rendering, and export.
- Fix shader/layer blend modes with destination-aware WebGL compositing and animated blend-mode snapshots.
- Fix linked X/Y scaling so edits preserve the original proportion and commit both axes atomically.
- Retire standalone `primitive3d` objects and sanitize legacy scenes, tracks, selections, and references on load.
- Extend scene persistence, CLI/MCP authoring, tests, documentation, packaging, and Apache attribution for the shader model.

## Why

This adds expressive GPU effects and practical 2.5D camera manipulation while keeping timeline playback, saved scenes, and exports reproducible. It also removes the premature standalone 3D-object surface without removing camera-based depth workflows.

## User impact

- Add shaders directly from the floating dock and edit them like ordinary layers.
- Use middle-drag to orbit, Shift + middle-drag to pan, and Ctrl + middle-drag to dolly; Alt/Option + primary drag emulates middle mouse.
- Use wheel/trackpad to dolly, Shift + wheel to pan, Alt/Option + wheel to orbit, and Ctrl/Cmd + wheel for workspace zoom.
- Camera gestures create keyframes when Auto Key is enabled.
- Existing scenes containing retired standalone 3D objects are cleaned automatically on load, including descendants and animation references.
- Paper Shaders is pinned at `0.0.77` and includes its required NOTICE attribution.

## Validation

- Canvas suite: **428/428 passed**
- CLI suite: **471/471 passed**
- `pnpm exec vite build`: **passed**
- `pnpm typecheck`: the feature-specific animated blend-mode mismatch was fixed; the command still reports existing baseline errors elsewhere in the repository.
- `git diff --check`: **passed**

Vite continues to report the existing main-bundle chunk-size warning (about 2.17 MB minified / 625 kB gzip).
