### PR TITLE
Fix stagger test type import

### DIFF
--- a/src/anim/staggerSets.test.ts
+++ b/src/anim/staggerSets.test.ts
@@ -2,11 +2,14 @@
 
 import { describe, expect, it } from 'vitest'
 import * as Y from 'yjs'
-import type { PropertyId, TextAnimationConfig, Track } from '@/scene'
+import type { PropertyId, Track } from '@/scene'
 import { createSceneAPI } from '@/scene/doc'
 import { UNDOABLE_GESTURE_ORIGIN } from '@/scene/undo'
 import { addKeyframe, findTrack } from './tracks'
-import { DEFAULT_TEXT_ANIMATION } from './textAnimations'
+import {
+  DEFAULT_TEXT_ANIMATION,
+  type TextAnimationConfig,
+} from './textAnimations'
 import {
   createStaggerSetReturn,
   deleteStaggerSetKeyframes,


### PR DESCRIPTION
## What changed

- Import TextAnimationConfig from its canonical textAnimations module instead of the scene barrel.

## Why

The scene barrel does not export this type, so the test file produced a TypeScript error even though the runtime tests passed.

## Impact

Test-only type-safety maintenance; no production behavior changes.

## Validation

- pnpm exec vitest run src/anim/staggerSets.test.ts — 27 tests passed
- pnpm exec eslint src/anim/staggerSets.test.ts — passed
- Repository typecheck no longer reports staggerSets.test.ts; unrelated pre-existing type errors remain elsewhere.