### PR TITLE
Add local gifenc type declarations

### DIFF
--- a/src/types/gifenc.d.ts
+++ b/src/types/gifenc.d.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+declare module 'gifenc' {
+  type PixelData = Uint8Array | Uint8ClampedArray
+  type PixelFormat = 'rgb565' | 'rgb444' | 'rgba4444'
+  type PaletteColor = [number, number, number] | [number, number, number, number]
+  type Palette = PaletteColor[]
+
+  interface QuantizeOptions {
+    format?: PixelFormat
+    oneBitAlpha?: boolean | number
+    clearAlpha?: boolean
+    clearAlphaThreshold?: number
+    clearAlphaColor?: number
+  }
+
+  interface Encoder {
+    writeFrame(
+      index: Uint8Array,
+      width: number,
+      height: number,
+      options?: {
+        palette?: Palette
+        delay?: number
+      },
+    ): void
+    finish(): void
+    bytes(): Uint8Array<ArrayBuffer>
+  }
+
+  export function GIFEncoder(options?: {
+    auto?: boolean
+    initialCapacity?: number
+  }): Encoder
+
+  export function quantize(
+    rgba: PixelData,
+    maxColors: number,
+    options?: QuantizeOptions,
+  ): Palette
+
+  export function applyPalette(
+    rgba: PixelData,
+    palette: Palette,
+    format?: PixelFormat,
+  ): Uint8Array<ArrayBuffer>
+}


### PR DESCRIPTION
## Summary

- add a local declaration for the untyped `gifenc` package
- type the encoder, palette, and quantization API used by the GIF export call site
- keep runtime behavior unchanged

## Why

`gifenc` 1.0.3 does not ship TypeScript declarations, so the GIF encoder import produced TS7016 and was implicitly typed as `any`. The local declaration restores type checking without changing dependencies or runtime code.

## Validation

- `pnpm exec tsc --ignoreConfig --noEmit --strict --target es2023 --module esnext --moduleResolution bundler --lib ES2023,DOM src/types/gifenc.d.ts src/export/encodeGif.ts`
- `pnpm exec eslint src/types/gifenc.d.ts src/export/encodeGif.ts`
- `pnpm test` (474 passed)

The repository-wide typecheck and lint still contain unrelated pre-existing failures; this PR does not expand scope to address them.
