### PR TITLE
Remove unused projected 3D flag

### DIFF
--- a/src/ui/Canvas.tsx
+++ b/src/ui/Canvas.tsx
@@ -4688,11 +4688,6 @@ function NodeView({
   const anchorY = isRoot ? 0.5 : anim?.anchorY ?? node.transform.anchorY ?? 0.5
   const anchorZ = isRoot ? 0 : anim?.anchorZ ?? node.transform.anchorZ ?? 0
   const transformOrigin = `${Number((anchorX * 100).toFixed(3))}% ${Number((anchorY * 100).toFixed(3))}% ${Number(anchorZ.toFixed(3))}px`
-  const hasProjected3D =
-    Math.abs(rotationX) > 0.001 ||
-    Math.abs(rotationY) > 0.001 ||
-    Math.abs(rotation) > 0.001 ||
-    Math.abs(tz) > 0.001
 
   const clips = node.kind === 'frame' && node.clipsContent
 


### PR DESCRIPTION
## What changed

Removed the unused `hasProjected3D` local from `NodeView` in `Canvas.tsx`.

## Why

The value was computed but never read, producing an unused-local TypeScript diagnostic without affecting rendering behavior.

## Impact

No runtime behavior changes. This is a five-line dead-code cleanup in the canvas UI.

## Verification

- `pnpm test:canvas` — 54 files, 438 tests passed
- `pnpm typecheck` — the `hasProjected3D` diagnostic is resolved; the command still reports unrelated pre-existing diagnostics elsewhere
- `pnpm exec eslint src/ui/Canvas.tsx` — the removed local no longer appears; the command still reports unrelated pre-existing file diagnostics
