### PR TITLE
Remove stale font lint suppression

### DIFF
--- a/src/fonts/registration.ts
+++ b/src/fonts/registration.ts
@@ -64,7 +64,6 @@ export async function registerFont(font: CustomFont): Promise<boolean> {
     registered.set(keyFor(font), face)
     return true
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.warn(
       `[fonts] failed to register "${font.family}" (${font.weight} ${font.style}): ${
         err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## What changed

Removed an obsolete `eslint-disable-next-line no-console` comment from the font registration error path.

## Why

The current ESLint configuration permits this `console.warn`, so the suppression is unused and produces a lint warning. Removing it keeps the source aligned with the active lint rules without changing runtime behavior.

## Impact

No user-facing or runtime behavior changes.

## Validation

- `pnpm exec eslint src/fonts/registration.ts`
- `pnpm exec vitest run src/ui/fonts/googleFonts.test.ts` (3 tests passed)

Repository-wide lint and typecheck remain red on unrelated pre-existing baseline errors.
