### PR TITLE
Remove stale recording lint suppression

### DIFF
--- a/src/export/recordTab.ts
+++ b/src/export/recordTab.ts
@@ -203,7 +203,6 @@ export async function recordTabCapture(
         const cropTarget = await win.CropTarget.fromElement(artboardEl)
         await trackWithCrop.cropTo(cropTarget)
       } catch (cropErr) {
-        // eslint-disable-next-line no-console
         console.warn(
           '[export] Region Capture not applied; recording the full tab. ' +
             'If you picked a different tab in the share picker, this is expected. ' +


### PR DESCRIPTION
## Summary

- remove an obsolete `eslint-disable-next-line no-console` comment from tab recording fallback logging
- keep runtime behavior unchanged

## Why

The repository ESLint configuration does not enable `no-console`, so this suppression is stale and adds noise around an intentional warning.

## Validation

- `pnpm exec eslint src/export/recordTab.ts`
- `git diff --check`
- `pnpm test` (474/474 passing, run from the fresh-main source checkout using its existing installed workspace tooling)

The isolated worktree's first `pnpm test` invocation could not start because its temporary dependency link did not include CLI workspace package links; no tests ran in that attempt. No dependencies or lockfiles were changed.
