### PR TITLE
Remove stale headless export lint suppression

### DIFF
--- a/src/headlessExport.ts
+++ b/src/headlessExport.ts
@@ -141,7 +141,6 @@ async function runHeadlessRender(req: HeadlessRequest): Promise<void> {
   }
   inFlight = true
 
-  // eslint-disable-next-line no-console
   console.log('[headless] export requested:', req)
 
   try {


### PR DESCRIPTION
## Summary
- remove one obsolete no-console suppression before the headless export request log
- preserve runtime behavior

## Verification
- pnpm exec eslint src/headlessExport.ts (passes; three unrelated stale-suppression warnings remain)
- git diff --check (passes)

## Baseline note
- pnpm typecheck remains red on pre-existing errors outside this one-line comment-only change