### PR TITLE
Remove stale NumberField lint suppression

### DIFF
--- a/src/ui/fields/NumberField.tsx
+++ b/src/ui/fields/NumberField.tsx
@@ -351,7 +351,6 @@ function evaluateExpression(text: string): number | null {
     // already proven the body contains nothing identifier-like. Wrap
     // in `"use strict"` and parens so the parser treats the body as
     // an expression statement.
-    // eslint-disable-next-line no-new-func
     const fn = new Function(`"use strict"; return (${trimmed})`) as () => unknown
     const result = fn()
     return typeof result === 'number' && Number.isFinite(result) ? result : null


### PR DESCRIPTION
## Summary

Remove an unused `eslint-disable-next-line no-new-func` directive from `NumberField.tsx`. The repository does not enable that rule, so ESLint reports the suppression as unused; runtime code and its safety explanation are unchanged.

## How to test

- `pnpm exec eslint src/ui/fields/NumberField.tsx --report-unused-disable-directives --rule 'react-hooks/refs: off' --rule 'react-hooks/set-state-in-effect: off'`
- `pnpm exec vitest run src/ui/fields/scalePairEdit.test.ts` — 6 tests passed
- `git diff --check`

Repository-wide typechecking was attempted and remains blocked by existing unrelated errors on `main`.

## Checklist

- [ ] `pnpm build` is clean (repository-wide typecheck has existing unrelated failures)
- [x] Targeted lint introduces no new warnings
- [x] I read `CONTRIBUTING.md` and the repository guidance; this change is comment-only
- [x] Release notes are not required because this is not user-facing
