### PR TITLE
Clarify error sentinel retry behavior

### DIFF
--- a/cli/src/electron/driver.ts
+++ b/cli/src/electron/driver.ts
@@ -143,8 +143,8 @@ export async function driveHeadlessRender(req: HeadlessRenderRequest): Promise<v
       return
     }
     if (fs.existsSync(errorPath)) {
-      // Renderer reported an error. Surface it and bail — no point
-      // continuing to poll, the render isn't going to finish.
+      // Surface complete error sentinels immediately. Partial or malformed
+      // writes are retried until they become readable or the exit grace ends.
       const message = readRenderErrorMessage(errorPath)
       if (message) {
         cleanFile(errorPath)


### PR DESCRIPTION
## What changed

Updated the render-driver polling comment to accurately describe how complete, partial, and malformed error sentinels are handled.

## Why

The previous comment said every error sentinel caused an immediate failure, but the implementation intentionally retries incomplete writes until they become readable or the post-exit grace period ends. This documentation-only change keeps the explanation aligned with the tested behavior.

## Impact

No runtime behavior changes.

## Validation

- `pnpm exec eslint cli/src/electron/driver.ts --report-unused-disable-directives`
- `pnpm --dir cli build && node --test --test-concurrency=1 cli/dist/electron/driver.test.js` (22 passed)
