### PR TITLE
Clarify render window architecture comment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,7 +156,7 @@ function Shell() {
   //
   // The new render-window pipeline (electron/main.ts → render-window
   // BrowserWindow → src/render/RenderWindowApp.tsx) runs the export
-  // in a separate, hidden process at the exact output dimensions.
+  // in a separate, hidden BrowserWindow at the exact output dimensions.
   // No editor chrome is ever present in the captured frames because
   // the render window only mounts the canvas. The editor stays
   // fully interactive throughout — pan, zoom, edit anything you


### PR DESCRIPTION
## Summary
- correct the export pipeline comment to identify the isolated renderer as a hidden BrowserWindow
- keep the documentation aligned with the Electron implementation

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test (501 passed)