### PR TITLE
Improve rendering and export workflows

### DIFF
--- a/electron/captureBitmap.test.ts
+++ b/electron/captureBitmap.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import {
+  detectNativeBitmapMetadata,
+  detectNativeBitmapPixelFormat,
+  expectedBitmapByteLength,
+  pickBitmapMetadata,
+} from './captureBitmap'
+
+describe('detectNativeBitmapPixelFormat', () => {
+  it('detects RGBA from an opaque red pixel', () => {
+    expect(
+      detectNativeBitmapPixelFormat(Uint8Array.from([255, 0, 0, 255])),
+    ).toBe('rgba')
+  })
+
+  it('detects BGRA from an opaque red pixel', () => {
+    expect(
+      detectNativeBitmapPixelFormat(Uint8Array.from([0, 0, 255, 255])),
+    ).toBe('bgra')
+  })
+
+  it('rejects malformed or ambiguous probe pixels', () => {
+    expect(() =>
+      detectNativeBitmapPixelFormat(Uint8Array.from([255, 0, 0])),
+    ).toThrow(/expected 4/i)
+    expect(() =>
+      detectNativeBitmapPixelFormat(Uint8Array.from([64, 0, 64, 255])),
+    ).toThrow(/could not classify/i)
+  })
+})
+
+describe('detectNativeBitmapMetadata', () => {
+  it('detects Display-P3 RGBA and BGRA red pixels with rounding tolerance', () => {
+    expect(
+      detectNativeBitmapMetadata(Uint8Array.from([233, 50, 35, 255])),
+    ).toEqual({ pixelFormat: 'rgba', colorSpace: 'display-p3' })
+    expect(
+      detectNativeBitmapMetadata(Uint8Array.from([35, 50, 233, 255])),
+    ).toEqual({ pixelFormat: 'bgra', colorSpace: 'display-p3' })
+  })
+})
+
+describe('pickBitmapMetadata', () => {
+  it('keeps the first calibrated profile for a capture session', () => {
+    const displayP3 = { pixelFormat: 'bgra', colorSpace: 'display-p3' } as const
+    const srgb = { pixelFormat: 'rgba', colorSpace: 'srgb' } as const
+    expect(pickBitmapMetadata(undefined, displayP3)).toBe(displayP3)
+    expect(pickBitmapMetadata(displayP3, srgb)).toBe(displayP3)
+  })
+})
+
+describe('expectedBitmapByteLength', () => {
+  it('returns four bytes per pixel', () => {
+    expect(expectedBitmapByteLength(1920, 1080)).toBe(8_294_400)
+  })
+
+  it('rejects invalid dimensions', () => {
+    expect(() => expectedBitmapByteLength(0, 1080)).toThrow(/invalid/i)
+    expect(() => expectedBitmapByteLength(1.5, 1080)).toThrow(/invalid/i)
+  })
+})

--- a/electron/captureBitmap.ts
+++ b/electron/captureBitmap.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type NativeBitmapPixelFormat = 'rgba' | 'bgra'
+export type NativeBitmapColorSpace = 'srgb' | 'display-p3'
+
+export interface NativeBitmapMetadata {
+  pixelFormat: NativeBitmapPixelFormat
+  colorSpace: NativeBitmapColorSpace
+}
+
+export function pickBitmapMetadata(
+  cached: NativeBitmapMetadata | undefined,
+  calibrated: NativeBitmapMetadata,
+): NativeBitmapMetadata {
+  return cached ?? calibrated
+}
+
+const RED_PIXEL_CANDIDATES: readonly {
+  bytes: readonly [number, number, number, number]
+  metadata: NativeBitmapMetadata
+}[] = [
+  {
+    bytes: [255, 0, 0, 255],
+    metadata: { pixelFormat: 'rgba', colorSpace: 'srgb' },
+  },
+  {
+    bytes: [0, 0, 255, 255],
+    metadata: { pixelFormat: 'bgra', colorSpace: 'srgb' },
+  },
+  {
+    // HTML's sRGB-red → Display-P3 conversion is approximately 234, 51, 35.
+    bytes: [234, 51, 35, 255],
+    metadata: { pixelFormat: 'rgba', colorSpace: 'display-p3' },
+  },
+  {
+    bytes: [35, 51, 234, 255],
+    metadata: { pixelFormat: 'bgra', colorSpace: 'display-p3' },
+  },
+]
+
+/** Classify a CSS-red pixel captured from the actual render WebContents. */
+export function detectNativeBitmapMetadata(
+  knownRedPixel: Uint8Array,
+): NativeBitmapMetadata {
+  if (knownRedPixel.byteLength !== 4) {
+    throw new Error(
+      `Native bitmap probe returned ${knownRedPixel.byteLength} bytes; expected 4.`,
+    )
+  }
+
+  let best:
+    | { score: number; metadata: NativeBitmapMetadata }
+    | undefined
+  for (const candidate of RED_PIXEL_CANDIDATES) {
+    const score = candidate.bytes.reduce(
+      (total, expected, index) =>
+        total + Math.abs(expected - knownRedPixel[index]!),
+      0,
+    )
+    if (!best || score < best.score) {
+      best = { score, metadata: candidate.metadata }
+    }
+  }
+
+  // The capture is uncompressed and the probe is opaque. Allow a few values
+  // of rounding variance, but reject antialiasing or an unexpected profile.
+  if (!best || best.score > 12) {
+    throw new Error(
+      `Native bitmap probe could not classify red pixel (${[...knownRedPixel].join(', ')}).`,
+    )
+  }
+  return best.metadata
+}
+
+/**
+ * Detect Electron's platform-native four-channel bitmap order from a known
+ * opaque red pixel. Electron documents `NativeImage.toBitmap()` as
+ * platform-dependent, so callers must not assume BGRA (macOS/Windows) or RGBA.
+ */
+export function detectNativeBitmapPixelFormat(
+  knownRedPixel: Uint8Array,
+): NativeBitmapPixelFormat {
+  return detectNativeBitmapMetadata(knownRedPixel).pixelFormat
+}
+
+export function expectedBitmapByteLength(width: number, height: number): number {
+  if (
+    !Number.isSafeInteger(width) ||
+    !Number.isSafeInteger(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    throw new Error(`Invalid native bitmap dimensions ${width}×${height}.`)
+  }
+
+  const byteLength = width * height * 4
+  if (!Number.isSafeInteger(byteLength)) {
+    throw new Error(`Native bitmap dimensions ${width}×${height} are too large.`)
+  }
+  return byteLength
+}

--- a/electron/exportDestination.test.ts
+++ b/electron/exportDestination.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { resolveExportDestinationPath } from './exportDestination'
+
+describe('native export destination', () => {
+  it('joins a safe video filename to the selected folder', () => {
+    expect(
+      resolveExportDestinationPath('/Users/example/My Movies', 'Demo.webm'),
+    ).toBe(path.resolve('/Users/example/My Movies/Demo.webm'))
+  })
+
+  it('rejects traversal and unsupported extensions', () => {
+    expect(() =>
+      resolveExportDestinationPath('/Users/example/Movies', '../Demo.mp4'),
+    ).toThrow('valid filename')
+    expect(() =>
+      resolveExportDestinationPath('/Users/example/Movies', 'Demo.mov'),
+    ).toThrow('MP4, WebM, or GIF')
+  })
+})

--- a/electron/exportDestination.ts
+++ b/electron/exportDestination.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import path from 'node:path'
+
+const ALLOWED_EXPORT_EXTENSIONS = new Set(['.mp4', '.webm', '.gif'])
+
+/** Resolve one renderer-supplied filename inside an approved directory. */
+export function resolveExportDestinationPath(
+  directory: string,
+  fileName: string,
+): string {
+  const root = path.resolve(directory)
+  if (!directory.trim()) throw new Error('Choose an export folder.')
+  if (!fileName || path.basename(fileName) !== fileName) {
+    throw new Error('The export title is not a valid filename.')
+  }
+  if (!ALLOWED_EXPORT_EXTENSIONS.has(path.extname(fileName).toLowerCase())) {
+    throw new Error('The export format must be MP4, WebM, or GIF.')
+  }
+
+  const destination = path.resolve(root, fileName)
+  if (path.dirname(destination) !== root) {
+    throw new Error('The export path must stay inside the selected folder.')
+  }
+  return destination
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -25,6 +25,8 @@ import {
   Notification,
   shell,
   webContents,
+  type NativeImage,
+  type Rectangle,
   type MenuItemConstructorOptions,
 } from 'electron'
 import path from 'node:path'
@@ -36,6 +38,14 @@ import {
   type FigmaPluginStatus,
 } from './figmaPlugin'
 import { isRenderWindowLeaseStale } from './renderWindowLease'
+import {
+  detectNativeBitmapMetadata,
+  expectedBitmapByteLength,
+  pickBitmapMetadata,
+  type NativeBitmapColorSpace,
+  type NativeBitmapMetadata,
+  type NativeBitmapPixelFormat,
+} from './captureBitmap'
 
 // Hyper Motion is a desktop editor: pressing Play in our own timeline should
 // always be allowed to start timeline audio, even if React applies the state
@@ -1152,28 +1162,230 @@ ipcMain.handle('preview:open-window', async () => {
   return { ok: true }
 })
 
+type ExportCaptureTransport = 'bitmap' | 'png'
+
+interface ExportCaptureRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+interface ExportCaptureRequest {
+  rect: ExportCaptureRect
+  transport: ExportCaptureTransport
+  outputSize?: { width: number; height: number }
+}
+
+interface ExportBitmapCaptureResult {
+  transport: 'bitmap'
+  data: Uint8Array
+  width: number
+  height: number
+  pixelFormat: NativeBitmapPixelFormat
+  colorSpace: NativeBitmapColorSpace
+}
+
+interface ExportPngCaptureResult {
+  transport: 'png'
+  data: Uint8Array
+}
+
+type ExportCaptureResult = ExportBitmapCaptureResult | ExportPngCaptureResult
+
+const nativeBitmapMetadataByWebContents = new Map<
+  number,
+  NativeBitmapMetadata
+>()
+
+async function calibrateNativeBitmapMetadata(
+  wc: Electron.WebContents,
+  rect: Rectangle,
+): Promise<NativeBitmapMetadata> {
+  const image = await wc.capturePage(rect)
+  if (image.isEmpty()) {
+    throw new Error('Native bitmap calibration returned an empty image')
+  }
+  const size = image.getSize(1)
+  const pixel = image
+    .crop({
+      x: Math.floor(size.width / 2),
+      y: Math.floor(size.height / 2),
+      width: 1,
+      height: 1,
+    })
+    .toBitmap({ scaleFactor: 1 })
+  const metadata = detectNativeBitmapMetadata(pixel)
+  const resolved = pickBitmapMetadata(
+    nativeBitmapMetadataByWebContents.get(wc.id),
+    metadata,
+  )
+  if (!nativeBitmapMetadataByWebContents.has(wc.id)) {
+    nativeBitmapMetadataByWebContents.set(wc.id, resolved)
+    wc.once('destroyed', () => nativeBitmapMetadataByWebContents.delete(wc.id))
+  }
+  return resolved
+}
+
+function isStructuredCaptureRequest(
+  request: ExportCaptureRect | ExportCaptureRequest,
+): request is ExportCaptureRequest {
+  return 'rect' in request
+}
+
+function normalizeCaptureRect(rect: ExportCaptureRect): Rectangle {
+  return {
+    x: Math.max(0, Math.round(rect.x)),
+    y: Math.max(0, Math.round(rect.y)),
+    width: Math.max(1, Math.round(rect.width)),
+    height: Math.max(1, Math.round(rect.height)),
+  }
+}
+
+function normalizeOutputSize(
+  outputSize: ExportCaptureRequest['outputSize'],
+): { width: number; height: number } | null {
+  if (!outputSize) return null
+  if (
+    !Number.isFinite(outputSize.width) ||
+    !Number.isFinite(outputSize.height) ||
+    outputSize.width <= 0 ||
+    outputSize.height <= 0
+  ) {
+    throw new Error(
+      `export:capture-rect — invalid output size ${outputSize.width}×${outputSize.height}`,
+    )
+  }
+  return {
+    width: Math.max(1, Math.round(outputSize.width)),
+    height: Math.max(1, Math.round(outputSize.height)),
+  }
+}
+
+async function capturePng(
+  wc: Electron.WebContents,
+  rect: Rectangle,
+): Promise<Uint8Array> {
+  // PRIMARY: Chrome DevTools Protocol `Page.captureScreenshot` with a
+  // `clip` parameter. CDP captures regions of the rendered DOCUMENT,
+  // NOT just the visible viewport — which is the whole point. An
+  // artboard sized 3840×2880 on a 1920×1080 screen normally has the
+  // off-viewport portion unrasterized by Chromium's compositor, so
+  // `webContents.capturePage` only returns the visible center. CDP
+  // rasterizes the requested clip rect even when it extends beyond
+  // the visible area, giving us the full artboard at native pixels.
+  //
+  // We attach the debugger once per process and reuse it; reattaching
+  // every frame would burn IPC time. If anything goes wrong we fall
+  // through to the legacy capturePage path below, which still works
+  // for artboards that fit in the viewport.
+  try {
+    if (!wc.debugger.isAttached()) {
+      wc.debugger.attach('1.3')
+    }
+    const result = (await wc.debugger.sendCommand('Page.captureScreenshot', {
+      format: 'png',
+      clip: {
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+        // `scale: 1` means "capture at the page's current device pixel
+        // ratio." Use the WebContents zoom factor to influence
+        // resolution; here we want native CSS pixels per unit.
+        scale: 1,
+      },
+      // Force the capture beyond the viewport. Without this, CDP
+      // still respects viewport bounds and we're back to square one.
+      captureBeyondViewport: true,
+      fromSurface: true,
+    })) as { data: string }
+    // CDP returns base64; decode to a buffer for IPC.
+    return Buffer.from(result.data, 'base64')
+  } catch (err) {
+    console.warn(
+      '[export] CDP captureScreenshot failed, falling back to capturePage:',
+      err,
+    )
+    const image = await wc.capturePage(rect)
+    return image.toPNG()
+  }
+}
+
+async function captureBitmap(
+  wc: Electron.WebContents,
+  rect: Rectangle,
+  outputSize: ExportCaptureRequest['outputSize'],
+): Promise<ExportBitmapCaptureResult> {
+  let image: NativeImage = await wc.capturePage(rect)
+  if (image.isEmpty()) {
+    throw new Error('capturePage returned an empty NativeImage')
+  }
+
+  const metadata = nativeBitmapMetadataByWebContents.get(wc.id)
+  if (!metadata) {
+    throw new Error(
+      'Native bitmap capture was not calibrated for this render surface',
+    )
+  }
+
+  const target = normalizeOutputSize(outputSize)
+  if (target) {
+    const current = image.getSize(1)
+    if (current.width !== target.width || current.height !== target.height) {
+      image = image.resize({ ...target, quality: 'best' })
+    }
+  }
+
+  // Use the same explicit representation for size and bytes. Mixing the
+  // default representation with `scaleFactor: 1` can report CSS dimensions
+  // for one and Retina dimensions for the other.
+  const scaleFactor = 1
+  const size = image.getSize(scaleFactor)
+  const data = image.toBitmap({ scaleFactor })
+  const expectedLength = expectedBitmapByteLength(size.width, size.height)
+  if (data.byteLength !== expectedLength) {
+    throw new Error(
+      `Native bitmap returned ${data.byteLength} bytes for ${size.width}×${size.height}; expected ${expectedLength}.`,
+    )
+  }
+
+  return {
+    transport: 'bitmap',
+    data,
+    width: size.width,
+    height: size.height,
+    pixelFormat: metadata.pixelFormat,
+    colorSpace: metadata.colorSpace,
+  }
+}
+
+ipcMain.handle(
+  'export:probe-bitmap-metadata',
+  async (e, requestedRect: ExportCaptureRect): Promise<NativeBitmapMetadata> => {
+    const wc = e.sender ?? mainWindow?.webContents
+    if (!wc) {
+      throw new Error('export:probe-bitmap-metadata — no active webContents')
+    }
+    return calibrateNativeBitmapMetadata(wc, normalizeCaptureRect(requestedRect))
+  },
+)
+
 /**
  * Export capture bridge.
  *
- * `webContents.capturePage(rect)` returns the rendered page region as a
- * NativeImage — bypasses getDisplayMedia entirely (no permission prompt,
- * no OS-level "REC" overlay, no chrome bleed) and captures only the
- * rectangle we care about (the artboard). The renderer drives the
- * timeline frame-by-frame and asks for one capture per frame; the
- * resulting PNG bytes are decoded back into a canvas in the renderer
- * and handed to the WebCodecs MP4 / GIF encoder.
- *
- * For HQ exports (2K / 4K from a 1080p artboard), the renderer calls
- * `export:set-zoom-factor` first. Page zoom re-rasterizes the scene
- * (text stays sharp) and `capturePage` then returns image data scaled
- * up by the same factor — real pixels, not upscale mush.
+ * Legacy rectangle-only calls preserve the original PNG-byte return value.
+ * Structured callers may request a native four-channel bitmap to avoid the
+ * PNG encode/base64/decode loop. Bitmap capture permanently falls back to the
+ * tagged PNG path, and `HYPERMOTION_CAPTURE_TRANSPORT=png` can force that path
+ * for A/B benchmarks without rebuilding the app.
  */
 ipcMain.handle(
   'export:capture-rect',
   async (
     e,
-    rect: { x: number; y: number; width: number; height: number },
-  ): Promise<Uint8Array> => {
+    request: ExportCaptureRect | ExportCaptureRequest,
+  ): Promise<Uint8Array | ExportCaptureResult> => {
     // Use the SENDER's webContents — not mainWindow's. The render-window
     // architecture (added below) spawns a separate BrowserWindow that
     // calls this IPC to capture itself, not the editor. Reading
@@ -1181,58 +1393,34 @@ ipcMain.handle(
     // legacy in-editor capture path AND the new render-window flow.
     const wc = e.sender ?? mainWindow?.webContents
     if (!wc) throw new Error('export:capture-rect — no active webContents')
-    // Whole numbers + ≥1 dims; Electron / CDP both reject odd inputs.
-    const r = {
-      x: Math.max(0, Math.round(rect.x)),
-      y: Math.max(0, Math.round(rect.y)),
-      width: Math.max(1, Math.round(rect.width)),
-      height: Math.max(1, Math.round(rect.height)),
+    const structured = isStructuredCaptureRequest(request)
+    const rect = normalizeCaptureRect(structured ? request.rect : request)
+
+    if (!structured) {
+      return capturePng(wc, rect)
     }
 
-    // PRIMARY: Chrome DevTools Protocol `Page.captureScreenshot` with a
-    // `clip` parameter. CDP captures regions of the rendered DOCUMENT,
-    // NOT just the visible viewport — which is the whole point. An
-    // artboard sized 3840×2880 on a 1920×1080 screen normally has the
-    // off-viewport portion unrasterized by Chromium's compositor, so
-    // `webContents.capturePage` only returns the visible center. CDP
-    // rasterizes the requested clip rect even when it extends beyond
-    // the visible area, giving us the full artboard at native pixels.
-    //
-    // We attach the debugger once per process and reuse it; reattaching
-    // every frame would burn IPC time. If anything goes wrong we fall
-    // through to the legacy capturePage path below, which still works
-    // for artboards that fit in the viewport.
-    try {
-      if (!wc.debugger.isAttached()) {
-        wc.debugger.attach('1.3')
-      }
-      const result = (await wc.debugger.sendCommand('Page.captureScreenshot', {
-        format: 'png',
-        clip: {
-          x: r.x,
-          y: r.y,
-          width: r.width,
-          height: r.height,
-          // `scale: 1` means "capture at the page's current device pixel
-          // ratio." Use the WebContents zoom factor to influence
-          // resolution; here we want native CSS pixels per unit.
-          scale: 1,
-        },
-        // Force the capture beyond the viewport. Without this, CDP
-        // still respects viewport bounds and we're back to square one.
-        captureBeyondViewport: true,
-        fromSurface: true,
-      })) as { data: string }
-      // CDP returns base64; decode to a buffer for IPC.
-      return Buffer.from(result.data, 'base64')
-    } catch (err) {
-      console.warn(
-        '[export] CDP captureScreenshot failed, falling back to capturePage:',
-        err,
+    if (request.transport !== 'bitmap' && request.transport !== 'png') {
+      throw new Error(
+        `export:capture-rect — unsupported transport ${String(request.transport)}`,
       )
-      const image = await wc.capturePage(r)
-      return image.toPNG()
     }
+
+    const forcePng =
+      process.env.HYPERMOTION_CAPTURE_TRANSPORT?.trim().toLowerCase() ===
+      'png'
+    if (request.transport === 'bitmap' && !forcePng) {
+      try {
+        return await captureBitmap(wc, rect, request.outputSize)
+      } catch (err) {
+        console.warn(
+          '[export] Native bitmap capture failed, falling back to PNG:',
+          err,
+        )
+      }
+    }
+
+    return { transport: 'png', data: await capturePng(wc, rect) }
   },
 )
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -38,6 +38,7 @@ import {
   type FigmaPluginStatus,
 } from './figmaPlugin'
 import { isRenderWindowLeaseStale } from './renderWindowLease'
+import { resolveExportDestinationPath } from './exportDestination'
 import {
   detectNativeBitmapMetadata,
   expectedBitmapByteLength,
@@ -1759,6 +1760,14 @@ ipcMain.handle(
         'The export worker became unresponsive and was closed.',
       )
     })
+    // Keep one concise transport summary visible to headless/CLI callers.
+    // This makes it possible to verify that a job used direct GPU frames or
+    // the fidelity fallback without forwarding the hidden renderer's full log.
+    win.webContents.on('console-message', (_event, _level, message) => {
+      if (message.startsWith('[render-window] frame transport ')) {
+        console.info(message)
+      }
+    })
     win.webContents.on('render-process-gone', (_event, details) => {
       failRenderWindow(
         requestId,
@@ -1900,6 +1909,70 @@ ipcMain.handle(
 ipcMain.handle('export:cancel-render-window', (_e, requestId: string) => {
   closeRenderWindow(requestId)
 })
+
+ipcMain.handle('export:get-default-directory', () => app.getPath('downloads'))
+
+ipcMain.handle(
+  'export:choose-directory',
+  async (
+    _e,
+    opts?: { defaultPath?: string; suggestedName?: string },
+  ): Promise<{ directory: string; fileName: string } | null> => {
+    if (!mainWindow) return null
+    const directory = opts?.defaultPath || app.getPath('downloads')
+    const suggestedName =
+      opts?.suggestedName && path.basename(opts.suggestedName) === opts.suggestedName
+        ? opts.suggestedName
+        : 'export.mp4'
+    const extension = path.extname(suggestedName).slice(1).toLowerCase()
+    const result = await dialog.showSaveDialog(mainWindow, {
+      title: 'Choose export destination',
+      defaultPath: path.join(directory, suggestedName),
+      buttonLabel: 'Save',
+      filters: [
+        {
+          name: extension ? extension.toUpperCase() : 'Video',
+          extensions: [extension || 'mp4'],
+        },
+      ],
+    })
+    return result.canceled || !result.filePath
+      ? null
+      : {
+          directory: path.dirname(result.filePath),
+          fileName: path.basename(result.filePath),
+        }
+  },
+)
+
+ipcMain.handle(
+  'export:write-file',
+  (
+    _e,
+    payload: {
+      directory: string
+      fileName: string
+      bytes: Uint8Array
+    },
+  ): { ok: boolean; path?: string; error?: string } => {
+    try {
+      const directoryStats = fs.statSync(payload.directory)
+      if (!directoryStats.isDirectory()) {
+        throw new Error('The selected export folder is unavailable.')
+      }
+      const destination = resolveExportDestinationPath(
+        payload.directory,
+        payload.fileName,
+      )
+      fs.writeFileSync(destination, Buffer.from(payload.bytes))
+      return { ok: true, path: destination }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.error(`[export] write failed: ${message}`)
+      return { ok: false, error: message }
+    }
+  },
+)
 
 /**
  * `.hype` file I/O bridge.

--- a/src/anim/index.ts
+++ b/src/anim/index.ts
@@ -84,6 +84,8 @@ export {
   type TextAnimationId,
   type TextAnimationMode,
   type TextAnimationMotionVector,
+  type NumberFlowDigitMode,
+  type NumberFlowDigitOrder,
   type NumberFlowTrend,
   type TextAnimationOrder,
   type TextAnimationPreset,

--- a/src/anim/numberFlow.test.ts
+++ b/src/anim/numberFlow.test.ts
@@ -341,3 +341,240 @@ describe('numberFlowVisualFrameAtProgress', () => {
     expect(endpoint.outgoingText).toBe('100')
   })
 })
+
+describe('per-digit Number Flow frames', () => {
+  it('keeps semantic token columns stable when grouping changes', () => {
+    const start = numberFlowVisualFrameAtProgress(
+      '$1,000.50 USD',
+      999.5,
+      'in',
+      0,
+      { continuous: false, digitMode: 'staggered' },
+    )
+    const middle = numberFlowVisualFrameAtProgress(
+      '$1,000.50 USD',
+      999.5,
+      'in',
+      0.5,
+      { continuous: false, digitMode: 'staggered' },
+    )
+    const end = numberFlowVisualFrameAtProgress(
+      '$1,000.50 USD',
+      999.5,
+      'in',
+      1,
+      { continuous: false, digitMode: 'staggered' },
+    )
+
+    const keys = middle.tokens.map((token) => token.key)
+    expect(start.tokens.map((token) => token.key)).toEqual(keys)
+    expect(end.tokens.map((token) => token.key)).toEqual(keys)
+    expect(keys).toEqual([
+      'prefix:0',
+      'digit:integer:3',
+      'separator:group:2',
+      'digit:integer:2',
+      'digit:integer:1',
+      'digit:integer:0',
+      'separator:decimal',
+      'digit:fraction:0',
+      'digit:fraction:1',
+      'suffix:0',
+      'suffix:1',
+      'suffix:2',
+      'suffix:3',
+    ])
+
+    const leadingDigit = middle.tokens.find(
+      (token) => token.key === 'digit:integer:3',
+    )!
+    const group = middle.tokens.find(
+      (token) => token.key === 'separator:group:2',
+    )!
+    expect(leadingDigit).toMatchObject({
+      kind: 'digit',
+      outgoingChar: '',
+      incomingChar: '1',
+    })
+    expect(group).toMatchObject({
+      kind: 'separator',
+      outgoingChar: '',
+      incomingChar: ',',
+    })
+    expect(
+      middle.tokens
+        .filter((token) => token.kind === 'prefix' || token.kind === 'suffix')
+        .every((token) => !token.active && token.phase === 0),
+    ).toBe(true)
+  })
+
+  it('stagger-rolls digits from left to right in forward order', () => {
+    const frame = numberFlowVisualFrameAtProgress('123', 0, 'in', 0.3, {
+      continuous: false,
+      digitMode: 'staggered',
+      digitOrder: 'forward',
+      digitStagger: 0.6,
+      spinTimingRatio: 1,
+    })
+    const digits = frame.tokens.filter((token) => token.kind === 'digit')
+    expect(digits.map((token) => token.key)).toEqual([
+      'digit:integer:2',
+      'digit:integer:1',
+      'digit:integer:0',
+    ])
+    expect(digits[0]!.phase).toBeCloseTo(0.75)
+    expect(digits[1]!.phase).toBe(0)
+    expect(digits[2]!.phase).toBe(0)
+  })
+
+  it('reverses only the timing order without changing display order', () => {
+    const frame = numberFlowVisualFrameAtProgress('123', 0, 'in', 0.3, {
+      continuous: false,
+      digitMode: 'staggered',
+      digitOrder: 'backward',
+      digitStagger: 0.6,
+      spinTimingRatio: 1,
+    })
+    const digits = frame.tokens.filter((token) => token.kind === 'digit')
+    expect(digits.map((token) => token.key)).toEqual([
+      'digit:integer:2',
+      'digit:integer:1',
+      'digit:integer:0',
+    ])
+    expect(digits[0]!.phase).toBe(0)
+    expect(digits[1]!.phase).toBe(0)
+    expect(digits[2]!.phase).toBeCloseTo(0.75)
+  })
+
+  it('keeps all digit phases together when stagger is disabled', () => {
+    const frame = numberFlowVisualFrameAtProgress('123', 0, 'in', 0.3, {
+      continuous: false,
+      digitMode: 'together',
+      digitStagger: 0.9,
+      spinTimingRatio: 1,
+    })
+    const activeDigits = frame.tokens.filter(
+      (token) => token.kind === 'digit' && token.active,
+    )
+    expect(activeDigits.map((token) => token.phase)).toEqual([0.3, 0.3, 0.3])
+  })
+
+  it('resolves shortest-roll direction independently for each digit', () => {
+    const frame = numberFlowVisualFrameAtProgress('28', 11, 'in', 0.5, {
+      continuous: false,
+      digitMode: 'together',
+      trend: 'individual',
+      spinDistance: 1,
+    })
+    const tens = frame.tokens.find(
+      (token) => token.key === 'digit:integer:1',
+    )!
+    const ones = frame.tokens.find(
+      (token) => token.key === 'digit:integer:0',
+    )!
+    expect(tens.outgoingOffsetEm).toBeLessThan(0)
+    expect(tens.incomingOffsetEm).toBeGreaterThan(0)
+    expect(ones.outgoingOffsetEm).toBeGreaterThan(0)
+    expect(ones.incomingOffsetEm).toBeLessThan(0)
+  })
+
+  it('retains count-by stepping while exposing changed digit columns', () => {
+    const frame = numberFlowVisualFrameAtProgress('25', 0, 'in', 0.9, {
+      continuous: true,
+      increment: 10,
+      digitMode: 'together',
+      spinTimingRatio: 1,
+    })
+    expect(frame).toMatchObject({
+      outgoingText: '20',
+      incomingText: '25',
+    })
+    expect(frame.phase).toBeCloseTo(0.7)
+    const tens = frame.tokens.find(
+      (token) => token.key === 'digit:integer:1',
+    )!
+    const ones = frame.tokens.find(
+      (token) => token.key === 'digit:integer:0',
+    )!
+    expect(tens).toMatchObject({
+      outgoingChar: '2',
+      incomingChar: '2',
+      active: false,
+    })
+    expect(ones).toMatchObject({
+      outgoingChar: '0',
+      incomingChar: '5',
+      active: true,
+    })
+    expect(ones.phase).toBeCloseTo(0.7)
+  })
+
+  it('uses raw timeline endpoints to settle every digit deterministically', () => {
+    const atStart = numberFlowVisualFrameAtProgress(
+      '321',
+      0,
+      'in',
+      0.8,
+      { digitMode: 'staggered', digitStagger: 0.8 },
+      0,
+    )
+    const atEnd = numberFlowVisualFrameAtProgress(
+      '321',
+      0,
+      'in',
+      0.2,
+      { digitMode: 'staggered', digitStagger: 0.8 },
+      1,
+    )
+    expect(atStart.settledText).toBe('0')
+    expect(atEnd.settledText).toBe('321')
+    expect(atStart.tokens.every((token) => !token.active)).toBe(true)
+    expect(atEnd.tokens.every((token) => !token.active)).toBe(true)
+    expect(
+      atEnd.tokens
+        .filter((token) => token.kind === 'digit')
+        .map((token) => token.outgoingChar)
+        .join(''),
+    ).toBe('321')
+  })
+
+  it('returns byte-for-byte identical token frames for the same seek', () => {
+    const resolve = () =>
+      numberFlowVisualFrameAtProgress('Revenue $12,345.67', 0, 'in', 0.437, {
+        continuous: true,
+        increment: 100,
+        digitMode: 'staggered',
+        digitOrder: 'backward',
+        digitStagger: 0.45,
+        trend: 'individual',
+      })
+    expect(resolve()).toEqual(resolve())
+  })
+
+  it('keeps endpoint token topology when easing overshoots a digit boundary', () => {
+    const inRange = numberFlowVisualFrameAtProgress(
+      '99',
+      0,
+      'in',
+      0.5,
+      { digitMode: 'staggered', continuous: true },
+      0.5,
+    )
+    const overshoot = numberFlowVisualFrameAtProgress(
+      '99',
+      0,
+      'in',
+      1.2,
+      { digitMode: 'staggered', continuous: true },
+      0.5,
+    )
+
+    expect(overshoot.settledText).toBe('119')
+    expect(overshoot.tokens.map((token) => token.key)).toEqual(
+      inRange.tokens.map((token) => token.key),
+    )
+    expect(
+      overshoot.tokens.filter((token) => token.kind === 'digit'),
+    ).toHaveLength(2)
+  })
+})

--- a/src/anim/numberFlow.ts
+++ b/src/anim/numberFlow.ts
@@ -9,6 +9,35 @@ export interface ParsedNumberFlowText {
 }
 
 export type NumberFlowTrend = 'auto' | 'up' | 'down' | 'individual'
+export type NumberFlowDigitMode = 'together' | 'staggered'
+export type NumberFlowDigitOrder = 'forward' | 'backward'
+
+export type NumberFlowVisualTokenKind =
+  | 'prefix'
+  | 'digit'
+  | 'separator'
+  | 'suffix'
+
+/**
+ * One stable visual column in a Number Flow frame.
+ *
+ * `key` and array order are deterministic across preview seeks and exports.
+ * Missing characters are represented by an empty string so renderers can
+ * retain the column while measuring the currently settled text separately.
+ */
+export interface NumberFlowVisualToken {
+  key: string
+  kind: NumberFlowVisualTokenKind
+  outgoingChar: string
+  incomingChar: string
+  outgoingOffsetEm: number
+  incomingOffsetEm: number
+  outgoingOpacity: number
+  incomingOpacity: number
+  blurRadius: number
+  phase: number
+  active: boolean
+}
 
 export interface NumberFlowVisualOptions {
   trend: NumberFlowTrend
@@ -23,6 +52,10 @@ export interface NumberFlowVisualOptions {
   spinTimingRatio: number
   opacityTimingRatio: number
   blurRadius: number
+  digitMode: NumberFlowDigitMode
+  digitOrder: NumberFlowDigitOrder
+  /** Portion of the authored segment reserved for delays between digits. */
+  digitStagger: number
 }
 
 export interface NumberFlowVisualFrame {
@@ -37,6 +70,8 @@ export interface NumberFlowVisualFrame {
   maskWidthEm: number
   phase: number
   settledText: string
+  /** Stable display-order columns for independent digit rendering. */
+  tokens: NumberFlowVisualToken[]
 }
 
 export const DEFAULT_NUMBER_FLOW_VISUAL_OPTIONS: NumberFlowVisualOptions = {
@@ -51,6 +86,9 @@ export const DEFAULT_NUMBER_FLOW_VISUAL_OPTIONS: NumberFlowVisualOptions = {
   spinTimingRatio: 1,
   opacityTimingRatio: 0.5,
   blurRadius: 8,
+  digitMode: 'together',
+  digitOrder: 'forward',
+  digitStagger: 0.25,
 }
 
 export function numberFlowVisualOptionsFromConfig(config: {
@@ -65,6 +103,9 @@ export function numberFlowVisualOptionsFromConfig(config: {
   numberFlowSpinTimingRatio: number
   numberFlowOpacityTimingRatio: number
   blurRadius: number
+  numberFlowDigitMode?: NumberFlowDigitMode
+  numberFlowDigitOrder?: NumberFlowDigitOrder
+  numberFlowDigitStagger?: number
 }): NumberFlowVisualOptions {
   return {
     trend: config.numberFlowTrend,
@@ -78,6 +119,9 @@ export function numberFlowVisualOptionsFromConfig(config: {
     spinTimingRatio: config.numberFlowSpinTimingRatio,
     opacityTimingRatio: config.numberFlowOpacityTimingRatio,
     blurRadius: config.blurRadius,
+    digitMode: config.numberFlowDigitMode ?? 'together',
+    digitOrder: config.numberFlowDigitOrder ?? 'forward',
+    digitStagger: config.numberFlowDigitStagger ?? 0.25,
   }
 }
 
@@ -225,6 +269,8 @@ export function numberFlowVisualFrameAtProgress(
       startText,
       normalized.maskHeight,
       normalized.maskWidth,
+      format,
+      [startText, endText],
     )
   }
   if (timelineT >= 1) {
@@ -232,6 +278,8 @@ export function numberFlowVisualFrameAtProgress(
       endText,
       normalized.maskHeight,
       normalized.maskWidth,
+      format,
+      [startText, endText],
     )
   }
 
@@ -239,61 +287,20 @@ export function numberFlowVisualFrameAtProgress(
     easedProgress,
     normalized.transformTimingRatio,
   )
-  let outgoingText = startText
-  let incomingText = endText
-  let rawPhase = transformProgress
+  const transition = numberTransitionAtProgress(
+    format,
+    startValue,
+    endValue,
+    transformProgress,
+    normalized,
+    startText,
+    endText,
+  )
 
-  if (normalized.continuous) {
-    const decimalScale = 10 ** Math.max(0, Math.trunc(format.decimals))
-    const startTicks = Math.round(startValue * decimalScale)
-    const endTicks = Math.round(endValue * decimalScale)
-    const distanceTicks = Math.abs(endTicks - startTicks)
-    const numericalDirection = endValue >= startValue ? 1 : -1
-    const incrementTicks =
-      normalized.increment === null
-        ? 1
-        : Math.max(
-            1,
-            Math.min(
-              Number.MAX_SAFE_INTEGER,
-              Math.round(normalized.increment * decimalScale),
-            ),
-          )
-    const stepCount = Math.max(1, Math.ceil(distanceTicks / incrementTicks))
-    const stepPosition = transformProgress * stepCount
-    const outgoingIndex = Math.floor(stepPosition)
-    const incomingIndex = outgoingIndex + 1
-    const ticksAtStep = (index: number): number => {
-      if (distanceTicks === 0) return startTicks
-      if (index <= 0) {
-        return startTicks + numericalDirection * index * incrementTicks
-      }
-      if (index < stepCount) {
-        return (
-          startTicks +
-          numericalDirection * Math.min(distanceTicks, index * incrementTicks)
-        )
-      }
-      if (index === stepCount) return endTicks
-      return (
-        endTicks +
-        numericalDirection * (index - stepCount) * incrementTicks
-      )
-    }
-    const outgoingScaled = ticksAtStep(outgoingIndex)
-    const incomingScaled = ticksAtStep(incomingIndex)
-    rawPhase = stepPosition - outgoingIndex
-    outgoingText = formatNumberFlowValue(
-      outgoingScaled / decimalScale,
-      format,
-    )
-    incomingText = formatNumberFlowValue(
-      incomingScaled / decimalScale,
-      format,
-    )
-  }
-
-  const phase = channelProgress(rawPhase, normalized.spinTimingRatio)
+  const phase = channelProgress(
+    transition.rawPhase,
+    normalized.spinTimingRatio,
+  )
   const direction = resolvedTrendDirection(
     normalized.trend,
     startValue,
@@ -311,8 +318,8 @@ export function numberFlowVisualFrameAtProgress(
   const blurEnvelope = Math.sin(Math.PI * phase)
 
   return {
-    outgoingText,
-    incomingText,
+    outgoingText: transition.outgoingText,
+    incomingText: transition.incomingText,
     outgoingOffsetEm: -direction * phase * normalized.spinDistance,
     incomingOffsetEm:
       direction * (1 - phase) * normalized.spinDistance,
@@ -322,15 +329,416 @@ export function numberFlowVisualFrameAtProgress(
     maskHeightEm: normalized.maskHeight,
     maskWidthEm: normalized.maskWidth,
     phase,
-    settledText: normalized.continuous
-      ? formatNumberFlowValue(
-          startValue + (endValue - startValue) * transformProgress,
-          format,
-        )
-      : transformProgress < 0.5
-        ? startText
-        : endText,
+    settledText: transition.settledText,
+    tokens: numberFlowVisualTokens(
+      format,
+      startValue,
+      endValue,
+      startText,
+      endText,
+      transformProgress,
+      transition,
+      normalized,
+    ),
   }
+}
+
+interface NumberFlowTransition {
+  outgoingText: string
+  incomingText: string
+  rawPhase: number
+  settledText: string
+}
+
+function numberTransitionAtProgress(
+  format: ParsedNumberFlowText,
+  startValue: number,
+  endValue: number,
+  transformProgress: number,
+  options: NumberFlowVisualOptions,
+  authoredStartText = formatNumberFlowValue(startValue, format),
+  authoredEndText = formatNumberFlowValue(endValue, format),
+): NumberFlowTransition {
+  if (!options.continuous) {
+    return {
+      outgoingText: authoredStartText,
+      incomingText: authoredEndText,
+      rawPhase: transformProgress,
+      settledText:
+        transformProgress < 0.5 ? authoredStartText : authoredEndText,
+    }
+  }
+
+  const decimalScale = 10 ** Math.max(0, Math.trunc(format.decimals))
+  const startTicks = Math.round(startValue * decimalScale)
+  const endTicks = Math.round(endValue * decimalScale)
+  const distanceTicks = Math.abs(endTicks - startTicks)
+  const numericalDirection = endValue >= startValue ? 1 : -1
+  const incrementTicks =
+    options.increment === null
+      ? 1
+      : Math.max(
+          1,
+          Math.min(
+            Number.MAX_SAFE_INTEGER,
+            Math.round(options.increment * decimalScale),
+          ),
+        )
+  const stepCount = Math.max(1, Math.ceil(distanceTicks / incrementTicks))
+  const stepPosition = transformProgress * stepCount
+  const outgoingIndex = Math.floor(stepPosition)
+  const incomingIndex = outgoingIndex + 1
+  const ticksAtStep = (index: number): number => {
+    if (distanceTicks === 0) return startTicks
+    if (index <= 0) {
+      return startTicks + numericalDirection * index * incrementTicks
+    }
+    if (index < stepCount) {
+      return (
+        startTicks +
+        numericalDirection * Math.min(distanceTicks, index * incrementTicks)
+      )
+    }
+    if (index === stepCount) return endTicks
+    return (
+      endTicks + numericalDirection * (index - stepCount) * incrementTicks
+    )
+  }
+  const outgoingScaled = ticksAtStep(outgoingIndex)
+  const incomingScaled = ticksAtStep(incomingIndex)
+
+  return {
+    outgoingText: formatNumberFlowValue(outgoingScaled / decimalScale, format),
+    incomingText: formatNumberFlowValue(incomingScaled / decimalScale, format),
+    rawPhase: stepPosition - outgoingIndex,
+    settledText: formatNumberFlowValue(
+      startValue + (endValue - startValue) * transformProgress,
+      format,
+    ),
+  }
+}
+
+interface NumberFlowDisplayParts {
+  negative: boolean
+  integerDigits: string
+  fractionDigits: string
+}
+
+type NumberFlowTokenSlot =
+  | {
+      key: string
+      kind: 'prefix' | 'suffix'
+      staticChar: string
+    }
+  | {
+      key: string
+      kind: 'digit'
+      section: 'integer' | 'fraction'
+      position: number
+    }
+  | {
+      key: string
+      kind: 'separator'
+      separator: 'sign' | 'group' | 'decimal'
+      place?: number
+    }
+
+function numberFlowVisualTokens(
+  format: ParsedNumberFlowText,
+  startValue: number,
+  endValue: number,
+  startText: string,
+  endText: string,
+  transformProgress: number,
+  transition: NumberFlowTransition,
+  options: NumberFlowVisualOptions,
+): NumberFlowVisualToken[] {
+  const slots = numberFlowTokenSlots(format, [
+    startText,
+    endText,
+  ])
+  const digitSlots = slots.filter(
+    (slot): slot is Extract<NumberFlowTokenSlot, { kind: 'digit' }> =>
+      slot.kind === 'digit',
+  )
+  const digitOrder = new Map(
+    digitSlots.map((slot, index) => [slot.key, index]),
+  )
+  const transitionCache = new Map<number, NumberFlowTransition>()
+  const transitionForSlot = (
+    slotIndex: number,
+    slot: NumberFlowTokenSlot,
+  ): NumberFlowTransition => {
+    if (options.digitMode !== 'staggered' || digitSlots.length <= 1) {
+      return transition
+    }
+    const relatedDigitKey = relatedDigitSlotKey(slots, slotIndex, slot)
+    const displayIndex =
+      relatedDigitKey === null ? 0 : (digitOrder.get(relatedDigitKey) ?? 0)
+    const orderIndex =
+      options.digitOrder === 'backward'
+        ? digitSlots.length - 1 - displayIndex
+        : displayIndex
+    const delay =
+      digitSlots.length <= 1
+        ? 0
+        : options.digitStagger * (orderIndex / (digitSlots.length - 1))
+    const cached = transitionCache.get(delay)
+    if (cached) return cached
+
+    const localProgress = staggeredChannelProgress(
+      transformProgress,
+      delay,
+      options.digitStagger,
+    )
+    const localTransition = numberTransitionAtProgress(
+      format,
+      startValue,
+      endValue,
+      localProgress,
+      options,
+      startText,
+      endText,
+    )
+    transitionCache.set(delay, localTransition)
+    return localTransition
+  }
+
+  return slots.map((slot, slotIndex) => {
+    if (slot.kind === 'prefix' || slot.kind === 'suffix') {
+      return staticNumberFlowToken(slot, slot.staticChar)
+    }
+
+    const localTransition = transitionForSlot(slotIndex, slot)
+    const outgoingChar = numberFlowCharAtSlot(
+      slot,
+      localTransition.outgoingText,
+      format,
+    )
+    const incomingChar = numberFlowCharAtSlot(
+      slot,
+      localTransition.incomingText,
+      format,
+    )
+    if (outgoingChar === incomingChar) {
+      return staticNumberFlowToken(slot, outgoingChar)
+    }
+
+    const phase = channelProgress(
+      localTransition.rawPhase,
+      options.spinTimingRatio,
+    )
+    const outgoingFade = channelProgress(phase, options.opacityTimingRatio)
+    const incomingFade = channelProgress(
+      1 - phase,
+      options.opacityTimingRatio,
+    )
+    const blurEnvelope = Math.sin(Math.PI * phase)
+    const rolls = slot.kind === 'digit'
+    const direction = rolls
+      ? resolvedTokenDirection(
+          options.trend,
+          outgoingChar,
+          incomingChar,
+          startValue,
+          endValue,
+          format.decimals,
+        )
+      : 0
+
+    return {
+      key: slot.key,
+      kind: slot.kind,
+      outgoingChar,
+      incomingChar,
+      outgoingOffsetEm: -direction * phase * options.spinDistance,
+      incomingOffsetEm: direction * (1 - phase) * options.spinDistance,
+      outgoingOpacity: clamp01(1 - options.fadeAmount * outgoingFade),
+      incomingOpacity: clamp01(1 - options.fadeAmount * incomingFade),
+      blurRadius: options.blurRadius * Math.max(0, blurEnvelope),
+      phase,
+      active: true,
+    }
+  })
+}
+
+function numberFlowTokenSlots(
+  format: ParsedNumberFlowText,
+  texts: readonly string[],
+): NumberFlowTokenSlot[] {
+  const displays = texts.map((text) => numberFlowDisplayParts(text, format))
+  const maxIntegerDigits = Math.max(
+    1,
+    ...displays.map((display) => display.integerDigits.length),
+  )
+  const slots: NumberFlowTokenSlot[] = Array.from(format.prefix).map(
+    (char, index) => ({
+      key: `prefix:${index}`,
+      kind: 'prefix' as const,
+      staticChar: char,
+    }),
+  )
+
+  if (displays.some((display) => display.negative)) {
+    slots.push({ key: 'separator:sign', kind: 'separator', separator: 'sign' })
+  }
+  for (let place = maxIntegerDigits - 1; place >= 0; place -= 1) {
+    if (
+      format.useGrouping &&
+      place < maxIntegerDigits - 1 &&
+      (place + 1) % 3 === 0
+    ) {
+      slots.push({
+        key: `separator:group:${place}`,
+        kind: 'separator',
+        separator: 'group',
+        place,
+      })
+    }
+    slots.push({
+      key: `digit:integer:${place}`,
+      kind: 'digit',
+      section: 'integer',
+      position: place,
+    })
+  }
+  if (format.decimals > 0) {
+    slots.push({
+      key: 'separator:decimal',
+      kind: 'separator',
+      separator: 'decimal',
+    })
+    for (let position = 0; position < format.decimals; position += 1) {
+      slots.push({
+        key: `digit:fraction:${position}`,
+        kind: 'digit',
+        section: 'fraction',
+        position,
+      })
+    }
+  }
+  slots.push(
+    ...Array.from(format.suffix).map((char, index) => ({
+      key: `suffix:${index}`,
+      kind: 'suffix' as const,
+      staticChar: char,
+    })),
+  )
+  return slots
+}
+
+function numberFlowDisplayParts(
+  text: string,
+  format: ParsedNumberFlowText,
+): NumberFlowDisplayParts {
+  const suffixStart = Math.max(format.prefix.length, text.length - format.suffix.length)
+  const numericText = text.slice(format.prefix.length, suffixStart)
+  const match = /^(-?)([\d,]+)(?:\.(\d+))?$/.exec(numericText)
+  if (!match) {
+    return { negative: false, integerDigits: '', fractionDigits: '' }
+  }
+  return {
+    negative: match[1] === '-',
+    integerDigits: match[2]!.replaceAll(',', ''),
+    fractionDigits: match[3] ?? '',
+  }
+}
+
+function numberFlowCharAtSlot(
+  slot: NumberFlowTokenSlot,
+  text: string,
+  format: ParsedNumberFlowText,
+): string {
+  if ('staticChar' in slot) {
+    return slot.staticChar
+  }
+  const display = numberFlowDisplayParts(text, format)
+  if (slot.kind === 'digit') {
+    if (slot.section === 'fraction') {
+      return display.fractionDigits[slot.position] ?? ''
+    }
+    return (
+      display.integerDigits[
+        display.integerDigits.length - 1 - slot.position
+      ] ?? ''
+    )
+  }
+  if (slot.separator === 'sign') return display.negative ? '-' : ''
+  if (slot.separator === 'decimal') return format.decimals > 0 ? '.' : ''
+  const place = slot.place ?? 0
+  return display.integerDigits.length > place + 1 ? ',' : ''
+}
+
+function relatedDigitSlotKey(
+  slots: readonly NumberFlowTokenSlot[],
+  slotIndex: number,
+  slot: NumberFlowTokenSlot,
+): string | null {
+  if (slot.kind === 'digit') return slot.key
+  if (slot.kind !== 'separator') return null
+
+  for (let index = slotIndex + 1; index < slots.length; index += 1) {
+    if (slots[index]!.kind === 'digit') return slots[index]!.key
+  }
+  for (let index = slotIndex - 1; index >= 0; index -= 1) {
+    if (slots[index]!.kind === 'digit') return slots[index]!.key
+  }
+  return null
+}
+
+function staticNumberFlowToken(
+  slot: NumberFlowTokenSlot,
+  char: string,
+): NumberFlowVisualToken {
+  return {
+    key: slot.key,
+    kind: slot.kind,
+    outgoingChar: char,
+    incomingChar: char,
+    outgoingOffsetEm: 0,
+    incomingOffsetEm: 0,
+    outgoingOpacity: 1,
+    incomingOpacity: 0,
+    blurRadius: 0,
+    phase: 0,
+    active: false,
+  }
+}
+
+function staggeredChannelProgress(
+  progress: number,
+  delay: number,
+  maximumDelay: number,
+): number {
+  const safeProgress = finite(progress, 0)
+  const clampedProgress = clampProgress(safeProgress)
+  const activeSpan = Math.max(0.1, 1 - maximumDelay)
+  return (
+    clampProgress((clampedProgress - delay) / activeSpan) +
+    safeProgress -
+    clampedProgress
+  )
+}
+
+function resolvedTokenDirection(
+  trend: NumberFlowTrend,
+  outgoingChar: string,
+  incomingChar: string,
+  start: number,
+  end: number,
+  decimals: number,
+): 1 | -1 {
+  if (trend !== 'individual') {
+    return resolvedTrendDirection(trend, start, end, decimals)
+  }
+  if (/^\d$/.test(outgoingChar) && /^\d$/.test(incomingChar)) {
+    const outgoingDigit = Number(outgoingChar)
+    const incomingDigit = Number(incomingChar)
+    const upward = positiveModulo(incomingDigit - outgoingDigit, 10)
+    const downward = positiveModulo(outgoingDigit - incomingDigit, 10)
+    return upward <= downward ? 1 : -1
+  }
+  return end >= start ? 1 : -1
 }
 
 function normalizeVisualOptions(
@@ -361,6 +769,11 @@ function normalizeVisualOptions(
       1,
     ),
     blurRadius: clamp(finite(options.blurRadius, 8), 0, 32),
+    digitMode:
+      options.digitMode === 'staggered' ? 'staggered' : 'together',
+    digitOrder:
+      options.digitOrder === 'backward' ? 'backward' : 'forward',
+    digitStagger: clamp(finite(options.digitStagger, 0.25), 0, 0.9),
   }
 }
 
@@ -375,6 +788,8 @@ function settledNumberFlowFrame(
   text: string,
   maskHeightEm: number,
   maskWidthEm: number,
+  format = parseNumberFlowText(text),
+  layoutTexts: readonly string[] = [text],
 ): NumberFlowVisualFrame {
   return {
     outgoingText: text,
@@ -388,7 +803,26 @@ function settledNumberFlowFrame(
     maskWidthEm,
     phase: 0,
     settledText: text,
+    tokens: settledNumberFlowTokens(text, format, layoutTexts),
   }
+}
+
+function settledNumberFlowTokens(
+  text: string,
+  format: ParsedNumberFlowText | null,
+  layoutTexts: readonly string[],
+): NumberFlowVisualToken[] {
+  if (!format) {
+    return Array.from(text).map((char, index) =>
+      staticNumberFlowToken(
+        { key: `prefix:${index}`, kind: 'prefix', staticChar: char },
+        char,
+      ),
+    )
+  }
+  return numberFlowTokenSlots(format, layoutTexts).map((slot) =>
+    staticNumberFlowToken(slot, numberFlowCharAtSlot(slot, text, format)),
+  )
 }
 
 /** Ratios describe how much of the authored segment a channel consumes. */

--- a/src/anim/textAnimations.test.ts
+++ b/src/anim/textAnimations.test.ts
@@ -96,6 +96,9 @@ describe('text animation track reconciliation', () => {
       blurRadius: 8,
       numberFlowTrend: 'auto',
       numberFlowContinuous: true,
+      numberFlowDigitMode: 'together',
+      numberFlowDigitOrder: 'forward',
+      numberFlowDigitStagger: 0.25,
       numberFlowIncrement: null,
       numberFlowSpinDistance: 1,
       numberFlowFadeAmount: 1,
@@ -121,6 +124,9 @@ describe('text animation track reconciliation', () => {
         blurRadius: 16,
         numberFlowTrend: 'down',
         numberFlowContinuous: false,
+        numberFlowDigitMode: 'staggered',
+        numberFlowDigitOrder: 'backward',
+        numberFlowDigitStagger: 4,
         numberFlowIncrement: 1_000_000_000_000_001,
         numberFlowSpinDistance: 5,
         numberFlowFadeAmount: -1,
@@ -141,6 +147,9 @@ describe('text animation track reconciliation', () => {
       blurRadius: 16,
       numberFlowTrend: 'down',
       numberFlowContinuous: false,
+      numberFlowDigitMode: 'staggered',
+      numberFlowDigitOrder: 'backward',
+      numberFlowDigitStagger: 0.9,
       numberFlowIncrement: 1_000_000_000_000_000,
       numberFlowSpinDistance: 2,
       numberFlowFadeAmount: 0,
@@ -162,6 +171,18 @@ describe('text animation track reconciliation', () => {
         numberFlowIncrement: 0,
       })?.numberFlowIncrement,
     ).toBeNull()
+    expect(
+      normalizeTextAnimation({
+        id: 'number-flow',
+        numberFlowDigitMode: 'unsupported',
+        numberFlowDigitOrder: 'outside-in',
+        numberFlowDigitStagger: Number.NaN,
+      }),
+    ).toMatchObject({
+      numberFlowDigitMode: 'together',
+      numberFlowDigitOrder: 'forward',
+      numberFlowDigitStagger: 0.25,
+    })
   })
 
   it('installs Curve Drop motion and preserves a customized path across presets', () => {
@@ -245,6 +266,9 @@ describe('text animation track reconciliation', () => {
         applyTo: 'letters',
         delay: 0.2,
         numberFrom: 25,
+        numberFlowDigitMode: 'staggered',
+        numberFlowDigitOrder: 'backward',
+        numberFlowDigitStagger: 0.4,
         numberFlowIncrement: 10,
         motionVector: { x: 1, y: 2, z: 3 },
       },
@@ -256,6 +280,9 @@ describe('text animation track reconciliation', () => {
       applyTo: 'layer',
       delay: 0,
       numberFrom: 25,
+      numberFlowDigitMode: 'staggered',
+      numberFlowDigitOrder: 'backward',
+      numberFlowDigitStagger: 0.4,
       numberFlowIncrement: 10,
       travelDistance: 0,
       motionVector: null,
@@ -269,6 +296,20 @@ describe('text animation track reconciliation', () => {
       1,
       1.8,
     ])
+    expect(api.getNode(nodeId)).toMatchObject({
+      textAnimation: {
+        numberFlowDigitMode: 'staggered',
+        numberFlowDigitOrder: 'backward',
+        numberFlowDigitStagger: 0.4,
+      },
+    })
+    expect(api.getTrack(track.id)).toMatchObject({
+      textAnimation: {
+        numberFlowDigitMode: 'staggered',
+        numberFlowDigitOrder: 'backward',
+        numberFlowDigitStagger: 0.4,
+      },
+    })
   })
 
   it('leaves existing animation data untouched when Number Flow text is invalid', () => {

--- a/src/anim/textAnimations.ts
+++ b/src/anim/textAnimations.ts
@@ -56,6 +56,8 @@ export type TextAnimationAcceleration =
   | 'spring'
 export type TextAnimationSmoothing = 'none' | 'soft' | 'smooth'
 export type NumberFlowTrend = 'auto' | 'up' | 'down' | 'individual'
+export type NumberFlowDigitMode = 'together' | 'staggered'
+export type NumberFlowDigitOrder = 'forward' | 'backward'
 
 /**
  * Per-segment motion offset in line-height multiples: +X moves right, +Y moves
@@ -76,6 +78,12 @@ export interface TextAnimationConfig {
   numberFrom: number
   numberFlowTrend: NumberFlowTrend
   numberFlowContinuous: boolean
+  /** Whether digit columns move together or occupy staggered segment windows. */
+  numberFlowDigitMode: NumberFlowDigitMode
+  /** Visual digit traversal order used when digit staggering is enabled. */
+  numberFlowDigitOrder: NumberFlowDigitOrder
+  /** Portion of the segment reserved for delays between digit columns. */
+  numberFlowDigitStagger: number
   /** Numeric increment between visible rolls; null follows display precision. */
   numberFlowIncrement: number | null
   /** Whole-digit travel measured in the current text line height. */
@@ -130,6 +138,9 @@ export const DEFAULT_TEXT_ANIMATION: TextAnimationConfig = {
   numberFrom: 0,
   numberFlowTrend: 'auto',
   numberFlowContinuous: true,
+  numberFlowDigitMode: 'together',
+  numberFlowDigitOrder: 'forward',
+  numberFlowDigitStagger: 0.25,
   numberFlowIncrement: null,
   numberFlowSpinDistance: 1,
   numberFlowFadeAmount: 1,
@@ -294,6 +305,9 @@ export function applyTextAnimation(
           numberFrom: previous.numberFrom,
           numberFlowTrend: previous.numberFlowTrend,
           numberFlowContinuous: previous.numberFlowContinuous,
+          numberFlowDigitMode: previous.numberFlowDigitMode,
+          numberFlowDigitOrder: previous.numberFlowDigitOrder,
+          numberFlowDigitStagger: previous.numberFlowDigitStagger,
           numberFlowIncrement: previous.numberFlowIncrement,
           numberFlowSpinDistance: previous.numberFlowSpinDistance,
           numberFlowFadeAmount: previous.numberFlowFadeAmount,
@@ -575,6 +589,17 @@ export function normalizeTextAnimation(raw: unknown): TextAnimationConfig | null
       typeof value.numberFlowContinuous === 'boolean'
         ? value.numberFlowContinuous
         : base.numberFlowContinuous,
+    numberFlowDigitMode: isNumberFlowDigitMode(value.numberFlowDigitMode)
+      ? value.numberFlowDigitMode
+      : base.numberFlowDigitMode,
+    numberFlowDigitOrder: isNumberFlowDigitOrder(value.numberFlowDigitOrder)
+      ? value.numberFlowDigitOrder
+      : base.numberFlowDigitOrder,
+    numberFlowDigitStagger: clamp(
+      finiteNumber(value.numberFlowDigitStagger, base.numberFlowDigitStagger),
+      0,
+      0.9,
+    ),
     numberFlowIncrement: normalizeNumberFlowIncrement(
       value.numberFlowIncrement,
       base.numberFlowIncrement,
@@ -657,6 +682,14 @@ function isNumberFlowTrend(value: unknown): value is NumberFlowTrend {
     value === 'down' ||
     value === 'individual'
   )
+}
+
+function isNumberFlowDigitMode(value: unknown): value is NumberFlowDigitMode {
+  return value === 'together' || value === 'staggered'
+}
+
+function isNumberFlowDigitOrder(value: unknown): value is NumberFlowDigitOrder {
+  return value === 'forward' || value === 'backward'
 }
 
 function clampTimingRatio(value: unknown, fallback: number): number {

--- a/src/export/captureBitmap.test.ts
+++ b/src/export/captureBitmap.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { captureBitmapToRgba } from './captureBitmap'
+
+describe('captureBitmapToRgba', () => {
+  it('keeps RGBA channels unchanged', () => {
+    const data = new Uint8Array([255, 16, 8, 128, 4, 3, 2, 1])
+    expect(
+      [
+        ...captureBitmapToRgba({
+          data,
+          width: 2,
+          height: 1,
+          pixelFormat: 'rgba',
+          colorSpace: 'srgb',
+        }),
+      ],
+    ).toEqual([255, 16, 8, 128, 4, 3, 2, 1])
+  })
+
+  it('swaps BGRA red and blue channels in place', () => {
+    const data = new Uint8Array([8, 16, 255, 128, 2, 3, 4, 1])
+    const rgba = captureBitmapToRgba({
+      data,
+      width: 2,
+      height: 1,
+      pixelFormat: 'bgra',
+      colorSpace: 'srgb',
+    })
+    expect([...rgba]).toEqual([255, 16, 8, 128, 4, 3, 2, 1])
+    expect([...data]).toEqual([255, 16, 8, 128, 4, 3, 2, 1])
+  })
+
+  it('rejects dimensions that do not match the byte buffer', () => {
+    expect(() =>
+      captureBitmapToRgba({
+        data: new Uint8Array(4),
+        width: 2,
+        height: 1,
+        pixelFormat: 'rgba',
+        colorSpace: 'srgb',
+      }),
+    ).toThrow('expected 8, received 4')
+  })
+
+  it('rejects invalid dimensions', () => {
+    expect(() =>
+      captureBitmapToRgba({
+        data: new Uint8Array(0),
+        width: 0,
+        height: 1,
+        pixelFormat: 'rgba',
+        colorSpace: 'srgb',
+      }),
+    ).toThrow('Invalid capture bitmap width')
+  })
+})

--- a/src/export/captureBitmap.ts
+++ b/src/export/captureBitmap.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type CapturePixelFormat = 'rgba' | 'bgra'
+export type CaptureColorSpace = 'srgb' | 'display-p3'
+
+export interface CaptureBitmapPayload {
+  data: Uint8Array
+  width: number
+  height: number
+  pixelFormat: CapturePixelFormat
+  colorSpace: CaptureColorSpace
+}
+
+/** Convert Electron's platform-native bitmap bytes to browser RGBA bytes. */
+export function captureBitmapToRgba(
+  payload: CaptureBitmapPayload,
+): Uint8ClampedArray<ArrayBuffer> {
+  const width = normalizedDimension(payload.width, 'width')
+  const height = normalizedDimension(payload.height, 'height')
+  const expected = width * height * 4
+  if (payload.data.byteLength !== expected) {
+    throw new Error(
+      `Invalid capture bitmap length: expected ${expected}, received ${payload.data.byteLength}.`,
+    )
+  }
+
+  // IPC gives this capture an owned byte buffer. Reuse it so BGRA conversion
+  // does not allocate another full-size frame on the hot export path.
+  const bytes: Uint8ClampedArray<ArrayBuffer> =
+    payload.data.buffer instanceof ArrayBuffer
+      ? new Uint8ClampedArray(
+          payload.data.buffer,
+          payload.data.byteOffset,
+          payload.data.byteLength,
+        )
+      : Uint8ClampedArray.from(payload.data)
+
+  if (payload.pixelFormat === 'bgra') {
+    for (let offset = 0; offset < bytes.length; offset += 4) {
+      const blue = bytes[offset]!
+      bytes[offset] = bytes[offset + 2]!
+      bytes[offset + 2] = blue
+    }
+  } else if (payload.pixelFormat !== 'rgba') {
+    throw new Error(
+      `Unsupported capture pixel format: ${String(payload.pixelFormat)}.`,
+    )
+  }
+
+  return bytes
+}
+
+function normalizedDimension(value: number, label: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Invalid capture bitmap ${label}: ${String(value)}.`)
+  }
+  return value
+}

--- a/src/export/captureRect.ts
+++ b/src/export/captureRect.ts
@@ -264,6 +264,11 @@ export async function createElectronCapture(
     } finally {
       probe.remove()
       probe = null
+      // The bitmap probe deliberately paints a red calibration pixel. Wait
+      // until its removal reaches Chromium's compositor before the first real
+      // capture; this matters now that fallback capture is initialized lazily
+      // on the exact frame that will be encoded.
+      await waitForFrames(2)
     }
   }
 

--- a/src/export/captureRect.ts
+++ b/src/export/captureRect.ts
@@ -5,9 +5,9 @@
  *
  * This is the new export-time source of truth. The renderer drives the
  * timeline (engine.seek), then asks main to capture the artboard's
- * on-screen rectangle. Pixel data comes back as PNG bytes, gets decoded
- * into an HTMLCanvasElement, and that canvas is what the encoder
- * ingests — same shape the WebCodecs MP4 / GIF encoders already accept.
+ * on-screen rectangle. Pixel data comes back as either an owned native
+ * bitmap or PNG fallback and is copied into an HTMLCanvasElement for the
+ * existing WebCodecs MP4 / GIF encoders.
  *
  * Why this replaces both prior paths:
  *
@@ -38,6 +38,12 @@
  *     subsequent capturePage rects come back with that many more
  *     pixels per CSS unit. We restore the original zoom in destroy().
  */
+
+import {
+  captureBitmapToRgba,
+  type CaptureColorSpace,
+  type CapturePixelFormat,
+} from './captureBitmap'
 
 /**
  * Stable selector for the artboard frame in the editor DOM.
@@ -99,6 +105,11 @@ export function isElectronCaptureSupported(): boolean {
 
 export interface ElectronCaptureOptions {
   /**
+   * Bitmap avoids a PNG encode/decode round-trip in the isolated render
+   * worker. PNG remains the legacy default and permanent fallback.
+   */
+  transport?: 'png' | 'bitmap'
+  /**
    * Page-zoom factor to apply BEFORE the frame loop. Use 2 for 2K
    * exports from a 1080p artboard, 4 for 4K. Pass 1 for native size.
    */
@@ -136,7 +147,7 @@ export interface ElectronCapture {
    * the timeline + waited at least one rAF so the DOM reflects the
    * new playhead before this is called.
    */
-  capture(): Promise<HTMLCanvasElement>
+  capture(opts?: { surface?: number }): Promise<HTMLCanvasElement>
   /**
    * Restore zoom factor. Always call in a `finally` block — leaving
    * the page zoomed in after a failed export is the worst possible
@@ -206,11 +217,16 @@ export async function createElectronCapture(
     )
   }
 
-  // Cache one canvas, resize it on first capture and reuse — saves a
-  // GC churn cycle per frame on long exports.
-  const outCanvas = document.createElement('canvas')
-  const outCtx = outCanvas.getContext('2d', { alpha: false })
-  if (!outCtx) {
+  // Cache capture surfaces by slot. Ordinary frames use slot zero;
+  // crossfades use slots zero and one so both scene captures remain valid
+  // until compositing without allocating full-resolution canvases per frame.
+  const captureSurfaces = [document.createElement('canvas')]
+  if (
+    !captureSurfaces[0]!.getContext('2d', {
+      alpha: false,
+      colorSpace: 'srgb',
+    })
+  ) {
     if (Math.abs(targetZoom - originalZoom) > 0.001) {
       await invoke('export:set-zoom-factor', originalZoom)
     }
@@ -218,50 +234,100 @@ export async function createElectronCapture(
   }
 
   let destroyed = false
+  let bitmapTransportActive = opts.transport === 'bitmap'
+  let probe: HTMLElement | null = null
+
+  if (bitmapTransportActive) {
+    probe = document.createElement('div')
+    probe.setAttribute('aria-hidden', 'true')
+    Object.assign(probe.style, {
+      position: 'fixed',
+      left: `${Math.round(initialRect.x)}px`,
+      top: `${Math.round(initialRect.y)}px`,
+      width: '1px',
+      height: '1px',
+      background: '#ff0000',
+      pointerEvents: 'none',
+      zIndex: '2147483647',
+    })
+    document.body.appendChild(probe)
+    await waitForFrames(2)
+    try {
+      await invoke('export:probe-bitmap-metadata', {
+        x: initialRect.x,
+        y: initialRect.y,
+        width: 1,
+        height: 1,
+      })
+    } catch {
+      bitmapTransportActive = false
+    } finally {
+      probe.remove()
+      probe = null
+    }
+  }
 
   return {
-    async capture(): Promise<HTMLCanvasElement> {
+    async capture(captureOpts = {}): Promise<HTMLCanvasElement> {
       if (destroyed) throw new Error('capture() called after destroy()')
       // Re-read the rect each frame — cheap (one getBoundingClientRect
       // on a div with no children intersecting it) — so a window
       // resize mid-export doesn't strand us with a stale rect.
       const rect = readArtboardRect() ?? initialRect
-      const png = (await invoke('export:capture-rect', rect)) as Uint8Array
-      // Cast through BlobPart — Uint8Array<ArrayBufferLike> doesn't
-      // satisfy the strict ArrayBuffer-only constraint TS infers under
-      // SharedArrayBuffer-aware lib settings, even though the runtime
-      // is happy. Same workaround used in transcodeMp4.ts.
-      const blob = new Blob([png as BlobPart], { type: 'image/png' })
-      const bitmap = await createImageBitmap(blob)
-      try {
-        // Two paths:
-        //   - outputSize set → draw the bitmap into a fixed-size canvas,
-        //     letting drawImage's bilinear filter downsample any DPR
-        //     inflation. Encoder gets exact target pixel dims.
-        //   - outputSize unset → keep the captured bitmap at native
-        //     dims (legacy behavior).
-        const targetW = opts.outputSize?.width ?? bitmap.width
-        const targetH = opts.outputSize?.height ?? bitmap.height
-        if (
-          outCanvas.width !== targetW ||
-          outCanvas.height !== targetH
-        ) {
-          outCanvas.width = targetW
-          outCanvas.height = targetH
-        }
-        // drawImage with explicit destination rect performs the
-        // resample. High-quality on modern Chromium without us
-        // having to manage smoothing settings.
-        outCtx.drawImage(bitmap, 0, 0, targetW, targetH)
-      } finally {
-        bitmap.close()
+      const surface = captureOpts.surface ?? 0
+      if (!Number.isSafeInteger(surface) || surface < 0) {
+        throw new Error(`Invalid capture surface: ${String(surface)}.`)
       }
-      return outCanvas
+      const canvas =
+        captureSurfaces[surface] ??
+        (captureSurfaces[surface] = document.createElement('canvas'))
+
+      if (opts.transport === 'bitmap') {
+        const result = (await invoke('export:capture-rect', {
+          rect,
+          transport: bitmapTransportActive ? 'bitmap' : 'png',
+          outputSize: opts.outputSize,
+        })) as StructuredCaptureResult
+        if (result.transport === 'bitmap') {
+          try {
+            drawNativeBitmap(canvas, result)
+            return canvas
+          } catch {
+            // A malformed/unsupported native representation should cost one
+            // retry, not fail every remaining frame. Permanently use the
+            // tagged PNG transport for this capture session after the first
+            // bitmap-side failure.
+            bitmapTransportActive = false
+            const pngFallback = (await invoke('export:capture-rect', {
+              rect,
+              transport: 'png',
+            })) as StructuredCaptureResult
+            if (pngFallback.transport !== 'png') {
+              throw new Error('PNG capture fallback returned bitmap data.')
+            }
+            await drawPng(canvas, pngFallback.data, opts.outputSize)
+            return canvas
+          }
+        } else {
+          // Main uses this tagged result when native capture is unavailable
+          // or explicitly disabled. Latch it so later frames do not retry the
+          // native path (and potentially perform two captures every frame).
+          bitmapTransportActive = false
+          await drawPng(canvas, result.data, opts.outputSize)
+        }
+        return canvas
+      }
+
+      const png = (await invoke('export:capture-rect', rect)) as Uint8Array
+      await drawPng(canvas, png, opts.outputSize)
+      return canvas
     },
 
     async destroy(): Promise<void> {
       if (destroyed) return
       destroyed = true
+      probe?.remove()
+      probe = null
       if (Math.abs(targetZoom - originalZoom) > 0.001) {
         try {
           await invoke('export:set-zoom-factor', originalZoom)
@@ -279,6 +345,73 @@ export async function createElectronCapture(
       }
     },
   }
+}
+
+type StructuredCaptureResult =
+  | {
+      transport: 'bitmap'
+      data: Uint8Array
+      width: number
+      height: number
+      pixelFormat: CapturePixelFormat
+      colorSpace: CaptureColorSpace
+    }
+  | { transport: 'png'; data: Uint8Array }
+
+function drawNativeBitmap(
+  canvas: HTMLCanvasElement,
+  payload: Extract<StructuredCaptureResult, { transport: 'bitmap' }>,
+): void {
+  const context = prepareCanvas(canvas, payload.width, payload.height)
+  const rgba = captureBitmapToRgba(payload)
+  const imageData = new ImageData(rgba, payload.width, payload.height, {
+    colorSpace: payload.colorSpace,
+  })
+  if (imageData.colorSpace !== payload.colorSpace) {
+    throw new Error(
+      `Native bitmap color space ${payload.colorSpace} is not supported.`,
+    )
+  }
+  context.putImageData(imageData, 0, 0)
+}
+
+async function drawPng(
+  canvas: HTMLCanvasElement,
+  png: Uint8Array,
+  outputSize?: { width: number; height: number },
+): Promise<void> {
+  // Uint8Array<ArrayBufferLike> does not satisfy the strict ArrayBuffer-only
+  // BlobPart constraint under SharedArrayBuffer-aware lib settings, even
+  // though Chromium accepts it at runtime.
+  const blob = new Blob([png as BlobPart], { type: 'image/png' })
+  const bitmap = await createImageBitmap(blob)
+  try {
+    const targetW = outputSize?.width ?? bitmap.width
+    const targetH = outputSize?.height ?? bitmap.height
+    const context = prepareCanvas(canvas, targetW, targetH)
+    context.drawImage(bitmap, 0, 0, targetW, targetH)
+  } finally {
+    bitmap.close()
+  }
+}
+
+function prepareCanvas(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+): CanvasRenderingContext2D {
+  if (canvas.width !== width || canvas.height !== height) {
+    canvas.width = width
+    canvas.height = height
+  }
+  const context = canvas.getContext('2d', {
+    alpha: false,
+    colorSpace: 'srgb',
+  })
+  if (!context) {
+    throw new Error('Failed to create output canvas — no 2D context.')
+  }
+  return context
 }
 
 function waitForFrames(n: number): Promise<void> {

--- a/src/export/destination.test.ts
+++ b/src/export/destination.test.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+  chooseExportDirectory,
+  resolveExportFileName,
+  sanitizeExportTitle,
+  writeExportBlob,
+} from './destination'
+
+describe('export destination', () => {
+  it('keeps Format responsible for the file extension', () => {
+    expect(resolveExportFileName('Launch film.mp4', 'webm')).toBe(
+      'Launch film.webm',
+    )
+    expect(resolveExportFileName('Launch film', 'gif')).toBe('Launch film.gif')
+  })
+
+  it('sanitizes an editable title and retains a usable fallback', () => {
+    expect(sanitizeExportTitle('  Report: Q3 / Final  ')).toBe(
+      'Report Q3 Final',
+    )
+    expect(sanitizeExportTitle('  ...  ')).toBe('export')
+  })
+
+  it('keeps the current folder when the Finder picker is cancelled', async () => {
+    const bridge = { invoke: vi.fn().mockResolvedValue(null) }
+    await expect(
+      chooseExportDirectory(
+        bridge,
+        '/Users/example/Movies',
+        'Demo',
+        'mp4',
+      ),
+    ).resolves.toBeNull()
+    expect(bridge.invoke).toHaveBeenCalledWith('export:choose-directory', {
+      defaultPath: '/Users/example/Movies',
+      suggestedName: 'Demo.mp4',
+    })
+  })
+
+  it('returns the folder and any title updated in the Finder sheet', async () => {
+    const bridge = {
+      invoke: vi.fn().mockResolvedValue({
+        directory: '/Users/example/Desktop',
+        fileName: 'Final cut.mp4',
+      }),
+    }
+    await expect(
+      chooseExportDirectory(
+        bridge,
+        '/Users/example/Movies',
+        'Demo',
+        'mp4',
+      ),
+    ).resolves.toEqual({
+      directory: '/Users/example/Desktop',
+      title: 'Final cut',
+    })
+  })
+
+  it('writes the finished bytes to the selected folder', async () => {
+    const bridge = {
+      invoke: vi.fn().mockResolvedValue({
+        ok: true,
+        path: '/Users/example/Movies/Demo.mp4',
+      }),
+    }
+    const blob = new Blob([new Uint8Array([3, 1, 4])], {
+      type: 'video/mp4',
+    })
+
+    await expect(
+      writeExportBlob(
+        bridge,
+        '/Users/example/Movies',
+        'Demo.mp4',
+        blob,
+      ),
+    ).resolves.toBe('/Users/example/Movies/Demo.mp4')
+
+    const [, payload] = bridge.invoke.mock.calls[0]
+    expect(payload).toMatchObject({
+      directory: '/Users/example/Movies',
+      fileName: 'Demo.mp4',
+    })
+    expect(Array.from((payload as { bytes: Uint8Array }).bytes)).toEqual([
+      3, 1, 4,
+    ])
+  })
+})

--- a/src/export/destination.ts
+++ b/src/export/destination.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ExportFormatId } from './formats'
+
+export interface ExportDestinationBridge {
+  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>
+}
+
+export interface ExportWriteResult {
+  ok: boolean
+  path?: string
+  error?: string
+}
+
+export interface ExportDestinationSelection {
+  directory: string
+  title: string
+}
+
+const KNOWN_EXPORT_EXTENSION = /\.(?:mp4|webm|gif)$/i
+const INVALID_FILENAME_PUNCTUATION = /[<>:"/\\|?*]/g
+
+function replaceFilenameControlCharacters(value: string): string {
+  let result = ''
+  for (const character of value) {
+    result += character.charCodeAt(0) < 32 ? ' ' : character
+  }
+  return result
+}
+
+function cleanExportTitle(value: string): string {
+  return replaceFilenameControlCharacters(value.trim())
+    .replace(KNOWN_EXPORT_EXTENSION, '')
+    .replace(INVALID_FILENAME_PUNCTUATION, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/[. ]+$/g, '')
+    .trim()
+}
+
+/**
+ * Keep the Title field extension-free so Format remains the single source of
+ * truth. Invalid filesystem punctuation is removed before the title reaches
+ * the render pipeline or the native writer.
+ */
+export function sanitizeExportTitle(
+  value: string,
+  fallback = 'export',
+): string {
+  const cleaned = cleanExportTitle(value)
+  if (cleaned) return cleaned
+
+  const safeFallback = cleanExportTitle(fallback)
+  return safeFallback || 'export'
+}
+
+export function resolveExportFileName(
+  title: string,
+  format: ExportFormatId,
+): string {
+  return `${sanitizeExportTitle(title)}.${format}`
+}
+
+export async function getDefaultExportDirectory(
+  bridge: ExportDestinationBridge,
+): Promise<string> {
+  const result = await bridge.invoke('export:get-default-directory')
+  return typeof result === 'string' ? result : ''
+}
+
+export async function chooseExportDirectory(
+  bridge: ExportDestinationBridge,
+  currentDirectory: string,
+  title: string,
+  format: ExportFormatId,
+): Promise<ExportDestinationSelection | null> {
+  const result = await bridge.invoke('export:choose-directory', {
+    defaultPath: currentDirectory || undefined,
+    suggestedName: resolveExportFileName(title, format),
+  })
+  if (
+    !result ||
+    typeof result !== 'object' ||
+    typeof (result as { directory?: unknown }).directory !== 'string' ||
+    typeof (result as { fileName?: unknown }).fileName !== 'string'
+  ) {
+    return null
+  }
+  const selection = result as { directory: string; fileName: string }
+  return {
+    directory: selection.directory,
+    title: sanitizeExportTitle(selection.fileName, title),
+  }
+}
+
+export async function writeExportBlob(
+  bridge: ExportDestinationBridge,
+  directory: string,
+  fileName: string,
+  blob: Blob,
+): Promise<string> {
+  const bytes = new Uint8Array(await blob.arrayBuffer())
+  const result = (await bridge.invoke('export:write-file', {
+    directory,
+    fileName,
+    bytes,
+  })) as ExportWriteResult
+
+  if (!result?.ok || !result.path) {
+    throw new Error(result?.error || 'The exported file could not be saved.')
+  }
+  return result.path
+}

--- a/src/export/renderWindowClient.ts
+++ b/src/export/renderWindowClient.ts
@@ -152,7 +152,10 @@ export async function runRenderWindowExport(
   // Provisional filename — main's filename is informational; we re-derive
   // in the render window so the chapterTag etc. is consistent. Provide
   // here for the progress UI before any frames render.
-  const sceneName = targetComposition?.name ?? ctx.sceneName
+  // `ctx.sceneName` is the user-editable export title. Composition identity
+  // is carried independently by `compositionSceneId`, so replacing the title
+  // here with the authored scene name would silently ignore the dialog field.
+  const sceneName = ctx.sceneName
   const provisionalFileName = `${sceneName.replace(/[^a-zA-Z0-9-_ ]/g, '').trim() || 'export'}.${ctx.format.extension}`
 
   progress.start(ctx.format, totalFrames, provisionalFileName)

--- a/src/render/RenderWindowApp.tsx
+++ b/src/render/RenderWindowApp.tsx
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import {
   SceneProvider,
   fillToCss,
@@ -67,6 +74,12 @@ import {
   type DofRenderQuality,
 } from './apertureBokeh'
 import { shouldUseRadialExportFocusMask } from './focusFallback'
+import { resolveDirectGpuExportEligibility } from './directGpuExportEligibility'
+import {
+  FrameReadyBarrier,
+  type FrameReadyIdentity,
+} from './frameReady'
+import { renderCameraBackendKey } from './renderCameraBackend'
 
 /**
  * RenderWindowApp — the chrome-less render shell loaded in the hidden
@@ -83,9 +96,10 @@ import { shouldUseRadialExportFocusMask } from './focusFallback'
  *      render-window mode.
  *   3. Mount <RenderCanvas> — paints the scene at the exact output
  *      dimensions, no editor chrome, no overlays, no pan/zoom transform.
- *   4. Wait for first paint + a few rAFs so the canvas is on-screen.
- *   5. Walk the requested frame range, seek the anim engine, capture
- *      each frame via Electron CDP, push into the WebCodecs encoder.
+ *   4. Wait for the initial scene assets to become renderable.
+ *   5. Walk the requested frame range, seek the animation engine, then
+ *      wait for an exact renderer acknowledgement. Eligible WebGL surfaces
+ *      feed WebCodecs directly; all other frames use Electron capture.
  *   6. Stream progress to the editor via `export:render-window-progress`.
  *   7. On completion, ship the encoded bytes back via
  *      `export:render-window-done`. Main closes this window.
@@ -99,6 +113,81 @@ interface HyperMotionBridge {
 }
 
 const EMPTY_NODE_IDS: NodeId[] = []
+
+interface PreparedRenderFrame {
+  identity: FrameReadyIdentity
+  sceneId: string | null
+  localTime: number
+  backend: 'dom' | 'webgl'
+  surface: HTMLCanvasElement | null
+  sceneFillCss: string | null
+}
+
+interface RenderFrameRequest extends FrameReadyIdentity {
+  sceneId: string | null
+  localTime: number
+}
+
+interface RenderFrameCoordinator {
+  prepareFrame: (input: {
+    sceneId: string | null
+    localTime: number
+  }) => Promise<PreparedRenderFrame>
+  acknowledge: (
+    request: RenderFrameRequest,
+    backend: PreparedRenderFrame['backend'],
+    surface?: HTMLCanvasElement | null,
+    sceneFillCss?: string | null,
+  ) => void
+  dispose: (reason?: unknown) => void
+}
+
+function createRenderFrameCoordinator(
+  publish: (request: RenderFrameRequest) => void,
+): RenderFrameCoordinator {
+  const barrier = new FrameReadyBarrier({ timeoutMs: 15_000 })
+  const receipts = new Map<number, PreparedRenderFrame>()
+
+  return {
+    async prepareFrame(input) {
+      const pending = barrier.begin()
+      const request: RenderFrameRequest = {
+        ...pending.identity,
+        sceneId: input.sceneId,
+        localTime: input.localTime,
+      }
+      publish(request)
+      await pending.promise
+      const receipt = receipts.get(request.token)
+      receipts.delete(request.token)
+      if (!receipt) {
+        throw new Error(
+          `Renderer acknowledged frame ${request.token} without a surface receipt.`,
+        )
+      }
+      return receipt
+    },
+    acknowledge(request, backend, surface = null, sceneFillCss = null) {
+      const receipt: PreparedRenderFrame = {
+        identity: { token: request.token, pass: request.pass },
+        sceneId: request.sceneId,
+        localTime: request.localTime,
+        backend,
+        surface,
+        sceneFillCss,
+      }
+      // Promise continuations run in a microtask, so recording immediately
+      // after a successful acknowledgement still precedes prepareFrame's
+      // receipt lookup. A duplicate DOM/WebGL acknowledgement must not erase
+      // the valid receipt for the request that won the race.
+      if (barrier.acknowledge(request)) receipts.set(request.token, receipt)
+    },
+    dispose(reason) {
+      receipts.clear()
+      barrier.dispose(reason)
+    },
+  }
+}
 
 function getBridge(): HyperMotionBridge | null {
   if (typeof window === 'undefined') return null
@@ -172,7 +261,13 @@ function RenderRunnerContent({ requestId }: { requestId: string }) {
 
   const [job, setJob] = useState<RenderJob | null>(null)
   const [fontsReady, setFontsReady] = useState(false)
+  const [renderRequest, setRenderRequest] =
+    useState<RenderFrameRequest | null>(null)
   const exportStartedRef = useRef(false)
+  const frameCoordinator = useMemo(
+    () => createRenderFrameCoordinator(setRenderRequest),
+    [],
+  )
 
   // Step 1: fetch our render job from main and seed the document before
   // publishing the job to React. Treating that pair as one async operation
@@ -264,8 +359,8 @@ function RenderRunnerContent({ requestId }: { requestId: string }) {
   useEffect(() => {
     if (!fontsReady || !job || exportStartedRef.current) return
     exportStartedRef.current = true
-    void runExportLoop(api, job, requestId)
-  }, [fontsReady, job, api, requestId])
+    void runExportLoop(api, job, requestId, frameCoordinator)
+  }, [fontsReady, job, api, requestId, frameCoordinator])
 
   if (!job || !fontsReady) {
     // Black surface while we boot. Hidden window so the user never sees
@@ -281,7 +376,13 @@ function RenderRunnerContent({ requestId }: { requestId: string }) {
       />
     )
   }
-  return <RenderCanvas job={job} />
+  return (
+    <RenderCanvas
+      job={job}
+      renderRequest={renderRequest}
+      acknowledgeFrame={frameCoordinator.acknowledge}
+    />
+  )
 }
 
 /**
@@ -303,7 +404,15 @@ function RenderRunnerContent({ requestId }: { requestId: string }) {
  * imported from Canvas.tsx so editor and render-window paint identical
  * pixels for the same scene state.
  */
-function RenderCanvas({ job }: { job: RenderJob }) {
+function RenderCanvas({
+  job,
+  renderRequest,
+  acknowledgeFrame,
+}: {
+  job: RenderJob
+  renderRequest: RenderFrameRequest | null
+  acknowledgeFrame: RenderFrameCoordinator['acknowledge']
+}) {
   const api = useSceneAPI()
   const version = useSceneVersion()
   const project = useProjectAPI()
@@ -348,10 +457,7 @@ function RenderCanvas({ job }: { job: RenderJob }) {
         fallbackCameraId: api.getActiveCameraId(),
       }).cameraId
     : api.getActiveCameraId()
-  const cameraAnimationIds = useMemo(
-    () => (cameraId ? [cameraId] : []),
-    [cameraId],
-  )
+  const cameraAnimationIds = cameraId ? [cameraId] : EMPTY_NODE_IDS
   const animated = useAnimatedValues(renderOrder)
   const sceneFill =
     rootId && animated[rootId]?.fill !== undefined
@@ -387,51 +493,86 @@ function RenderCanvas({ job }: { job: RenderJob }) {
     ? fillBackgroundStyle(cameraBackgroundFill)
     : null
 
-  const cameraDomProjection = useMemo(
-    () =>
-      resolveCameraDomProjection(
-        camera && camera.kind === 'camera' ? camera : null,
-        cameraAnim,
-        { width: canvasWidth, height: canvasHeight },
-      ),
-    [camera, cameraAnim, canvasWidth, canvasHeight],
+  const cameraDomProjection = resolveCameraDomProjection(
+    camera && camera.kind === 'camera' ? camera : null,
+    cameraAnim,
+    { width: canvasWidth, height: canvasHeight },
   )
   const cameraFocalLength = cameraDomProjection.focalLength
   const cameraScaleFromZ = cameraDomProjection.scale
   const cameraTransform = cameraDomProjection.transform
 
-  const cameraDepthOfField = useMemo(
-    () => {
-      const focusTargetWorld = resolveCameraFocusTargetPoint(
-        api,
-        camera && camera.kind === 'camera' ? camera : null,
-        solved ?? {},
-        animated,
-        inherited,
-        { width: canvasWidth, height: canvasHeight },
-      )
-      return computeCameraDepthOfField(
-        camera && camera.kind === 'camera' ? camera : null,
-        cameraAnim,
-        cameraScaleFromZ,
-        canvasWidth,
-        canvasHeight,
-        focusTargetWorld,
-      )
-    },
-    [
-      api,
-      camera,
-      cameraAnim,
-      cameraScaleFromZ,
-      canvasWidth,
-      canvasHeight,
-      solved,
-      animated,
-      inherited,
-    ],
+  const focusTargetWorld = resolveCameraFocusTargetPoint(
+    api,
+    camera && camera.kind === 'camera' ? camera : null,
+    solved ?? {},
+    animated,
+    inherited,
+    { width: canvasWidth, height: canvasHeight },
   )
-  const [threeCameraAvailable, setThreeCameraAvailable] = useState(false)
+  const cameraDepthOfField = computeCameraDepthOfField(
+    camera && camera.kind === 'camera' ? camera : null,
+    cameraAnim,
+    cameraScaleFromZ,
+    canvasWidth,
+    canvasHeight,
+    focusTargetWorld,
+  )
+  const cameraBackendKey = renderCameraBackendKey(
+    activeComposition?.id,
+    cameraId,
+  )
+  const [threeCapability, setThreeCapability] = useState<{
+    key: string
+    available: boolean
+  } | null>(null)
+  const threeCameraAvailable =
+    threeCapability?.key === cameraBackendKey
+      ? threeCapability.available
+      : null
+  const handleThreeAvailability = useCallback(
+    (available: boolean) => {
+      setThreeCapability({ key: cameraBackendKey, available })
+    },
+    [cameraBackendKey],
+  )
+  const acknowledgedDomTokenRef = useRef(0)
+  const acknowledgeWebglFrame = useCallback(
+    (
+      request: FrameReadyIdentity,
+      surface: HTMLCanvasElement,
+    ) => {
+      if (
+        !renderRequest ||
+        request.token !== renderRequest.token ||
+        request.pass !== renderRequest.pass
+      ) {
+        return
+      }
+      acknowledgeFrame(renderRequest, 'webgl', surface, sceneFill)
+    },
+    [acknowledgeFrame, renderRequest, sceneFill],
+  )
+
+  useLayoutEffect(() => {
+    if (!renderRequest || !solved) return
+    const expectsWebgl = camera?.kind === 'camera'
+    // A camera viewport first reports availability from its WebGL mount. Do
+    // not acknowledge the temporary DOM fallback while that capability is
+    // still unknown, otherwise export can capture the pre-GPU frame.
+    if (expectsWebgl && threeCameraAvailable === null) return
+    if (expectsWebgl && threeCameraAvailable) return
+    if (acknowledgedDomTokenRef.current === renderRequest.token) return
+    acknowledgedDomTokenRef.current = renderRequest.token
+    acknowledgeFrame(renderRequest, 'dom', null, sceneFill)
+  }, [
+    acknowledgeFrame,
+    camera,
+    renderRequest,
+    sceneFill,
+    solved,
+    threeCameraAvailable,
+  ])
 
   // Output scale — the render window's content area is sized to the
   // output dimensions in main. The artboard is rendered at its own
@@ -576,7 +717,10 @@ function RenderCanvas({ job }: { job: RenderJob }) {
               playing={playing}
               playhead={playhead}
               sceneVersion={version}
-              onAvailabilityChange={setThreeCameraAvailable}
+              key={cameraBackendKey}
+              onAvailabilityChange={handleThreeAvailability}
+              renderRequest={renderRequest}
+              onFrameRendered={acknowledgeWebglFrame}
             />
           </div>
         ) : (
@@ -631,6 +775,7 @@ async function runExportLoop(
   api: ReturnType<typeof useSceneAPI>,
   job: RenderJob,
   requestId: string,
+  frameCoordinator: RenderFrameCoordinator,
 ): Promise<void> {
   const bridge = getBridge()
   if (!bridge) {
@@ -753,31 +898,34 @@ async function runExportLoop(
   const originalSceneId = project.getActiveSceneId()
   ui.setPlaying(false)
 
-  let capture: Awaited<ReturnType<typeof createElectronCapture>>
-  try {
-    capture = await createElectronCapture({
+  // The capture bridge is initialized lazily. A fully eligible GPU job never
+  // calls capturePage or transfers a frame-sized bitmap through Electron.
+  const captureSession: {
+    current: Awaited<ReturnType<typeof createElectronCapture>> | null
+  } = { current: null }
+  const getCapture = async () => {
+    if (captureSession.current) return captureSession.current
+    captureSession.current = await createElectronCapture({
       // No zoomFactor — the render window's WebContents is already at
       // 1.0 by default and there's no editor zoom to fight.
       // No fitViewportTo — main sized the window to exactly outputW × H
       // when it spawned us. Resizing again would be redundant + might
       // race against the visible-window dimensions.
       outputSize: targetDims,
-      // Avoid PNG encoding and decoding on every worker frame. The main
+      // Avoid PNG encoding and decoding on every fallback frame. The main
       // process retains a tagged PNG fallback if native bitmap capture fails.
       transport: 'bitmap',
     })
-  } catch (e) {
-    reportError(
-      requestId,
-      `Failed to set up capture: ${e instanceof Error ? e.message : String(e)}`,
-    )
-    return
+    return captureSession.current
   }
 
   let encoder: FrameEncoder | null = null
   let smoothedFrameMs = 0
   let outputIndex = 0
-  let isFirstFrameOverall = true
+  const directGpuFallbackReasons = new Set<string>()
+  let directGpuFrames = 0
+  let captureFrames = 0
+  let previousPreparedSceneId: string | null = null
   // Crossfades need a third retained surface while the two scene captures
   // are blended. Reuse it for the complete job to avoid allocating a full
   // output-sized canvas on every transition frame.
@@ -817,36 +965,125 @@ async function runExportLoop(
 
         for (const [layerIndex, layer] of captureLayers.entries()) {
           const targetSceneId = layer.item?.scene.id ?? null
+          const requestedSceneId =
+            targetSceneId ?? project.getActiveSceneId()
           const changedScene =
             targetSceneId !== null &&
             project.getActiveSceneId() !== targetSceneId
+          const firstPreparedFrame = previousPreparedSceneId === null
           if (targetSceneId && changedScene) {
             project.activateScene(targetSceneId)
           }
+          const activeRootId = api.getRoot() || null
+          const asyncNodes = inspectActiveRenderSubtree(api, activeRootId)
           engine.seek(layer.localTime)
           useUI.getState().setPlayhead(layer.localTime)
-          // Multiple rAFs let React commit the new composition + local
-          // playhead before CDP captures. A transition captures both scenes at
-          // their own local times, then composites the two canvases below.
-          await waitForFrames(isFirstFrameOverall || changedScene ? 5 : 3)
-          if (changedScene) await waitForPaperShadersReady()
-          await waitForRender3dVideosReady()
+          // React/Yoga and the GPU renderer acknowledge this exact token only
+          // after the requested local time reaches their committed surface.
+          // This replaces the old fixed 3-5 display-frame delay.
+          let prepared = await frameCoordinator.prepareFrame({
+            sceneId: requestedSceneId,
+            localTime: layer.localTime,
+          })
+          const shadersReady =
+            asyncNodes.hasShader || changedScene || firstPreparedFrame
+            ? await waitForPaperShadersReady()
+            : true
+          if (!shadersReady) {
+            throw new Error(
+              'A Paper shader image could not be prepared for export. Check its source image and CORS access, then try again.',
+            )
+          }
+          // Paper applies uniforms in a passive effect and publishes its source
+          // to Three on the following paint. Shader scenes remain on the
+          // fidelity fallback, so retain a bounded settle window here instead
+          // of letting their asynchronous source lag a frame behind.
+          if (asyncNodes.hasShader) await waitForFrames(3)
+          if (asyncNodes.hasVideo) await waitForRender3dVideosReady()
           await waitForCachedRender3dImages()
-          isFirstFrameOverall = false
+
+          // Scene switches and asynchronous asset readiness can invalidate a
+          // texture after the first GPU commit. Request one exact second pass
+          // so the decoded source reaches the final surface before encoding.
+          if (
+            changedScene ||
+            firstPreparedFrame ||
+            asyncNodes.hasShader ||
+            asyncNodes.hasVideo
+          ) {
+            prepared = await frameCoordinator.prepareFrame({
+              sceneId: requestedSceneId,
+              localTime: layer.localTime,
+            })
+          }
+          if (asyncNodes.hasVideo) {
+            // Pass two can be the first pass with metadata available, in which
+            // case it initiates the target seek. Wait for that exact decoded
+            // presentation frame, then submit one final GPU pass.
+            await waitForRender3dVideosReady()
+            prepared = await frameCoordinator.prepareFrame({
+              sceneId: requestedSceneId,
+              localTime: layer.localTime,
+            })
+          }
+          previousPreparedSceneId = requestedSceneId
+
+          const rootId = api.getRoot()
+          const rootNode = rootId ? api.getNode(rootId) : null
+          const rootHasVisualAnimation = rootId
+            ? api.getTracksForNode(rootId).some((track) =>
+                ROOT_COMPOSITING_PROPERTY_IDS.has(track.propertyId),
+              )
+            : false
+          const activeCameraId = resolveRenderProgramCameraId(
+            api,
+            project,
+            layer.localTime,
+          )
+          const activeCamera = activeCameraId
+            ? api.getNode(activeCameraId)
+            : null
+          const eligibility = resolveDirectGpuExportEligibility({
+            format: job.format,
+            sequenceLayerCount: captureLayers.length,
+            receipt: {
+              backend: prepared.backend,
+              surface: prepared.surface,
+            },
+            target: targetDims,
+            activeCamera:
+              activeCamera?.kind === 'camera' ? activeCamera : null,
+            activeRoot: rootNode,
+            rootHasVisualAnimation,
+            getNode: (id) => api.getNode(id),
+            animatedSceneFillCss: prepared.sceneFillCss,
+          })
 
           let layerCanvas: HTMLCanvasElement
-          try {
-            layerCanvas = await capture.capture({
-              // A transition retains both captures until compositing, so each
-              // needs its own pooled slot. Ordinary frames use slot zero.
-              surface: layerIndex,
-            })
-          } catch (e) {
-            throw new Error(
-              `Failed to capture frame ${outputIndex + 1}/${totalFrames}: ${
-                e instanceof Error ? e.message : String(e)
-              }`,
-            )
+          if (eligibility.eligible && prepared.surface) {
+            layerCanvas = prepared.surface
+            directGpuFrames += 1
+          } else {
+            directGpuFallbackReasons.add(eligibility.reason)
+            // capturePage observes Chromium's composited page rather than the
+            // renderer's drawing buffer. One post-paint turn is sufficient
+            // after the exact React/GPU acknowledgement above.
+            await waitForFrames(2)
+            try {
+              const fallbackCapture = await getCapture()
+              layerCanvas = await fallbackCapture.capture({
+                // A transition retains both captures until compositing, so each
+                // needs its own pooled slot. Ordinary frames use slot zero.
+                surface: layerIndex,
+              })
+              captureFrames += 1
+            } catch (e) {
+              throw new Error(
+                `Failed to capture frame ${outputIndex + 1}/${totalFrames}: ${
+                  e instanceof Error ? e.message : String(e)
+                }`,
+              )
+            }
           }
           // ThreeSceneViewport already resolves depth-of-field in its final
           // render pass. Applying the canvas aperture pass on that capture
@@ -954,6 +1191,14 @@ async function runExportLoop(
     if (!encoder) throw new Error('No frames captured — export aborted.')
     const blob = await encoder.finish()
 
+    console.info(
+      `[render-window] frame transport ${JSON.stringify({
+        directGpuFrames,
+        captureFrames,
+        fallbackReasons: [...directGpuFallbackReasons],
+      })}`,
+    )
+
     const buf = await blob.arrayBuffer()
     const bytes = new Uint8Array(buf)
 
@@ -968,7 +1213,7 @@ async function runExportLoop(
     reportError(requestId, e instanceof Error ? e.message : String(e))
   } finally {
     try {
-      await capture.destroy()
+      await captureSession.current?.destroy()
     } catch {
       /* best effort */
     }
@@ -980,7 +1225,48 @@ async function runExportLoop(
     }
     engine.seek(originalPlayhead)
     if (originalPlaying) engine.play()
+    frameCoordinator.dispose('Render export finished.')
   }
+}
+
+interface ActiveRenderSubtreeFeatures {
+  hasShader: boolean
+  hasVideo: boolean
+}
+
+const ROOT_COMPOSITING_PROPERTY_IDS = new Set([
+  'appearance.opacity',
+  'appearance.fill',
+  'appearance.cornerRadius',
+  'appearance.blendMode',
+])
+
+function inspectActiveRenderSubtree(
+  api: ReturnType<typeof useSceneAPI>,
+  rootId: NodeId | null,
+): ActiveRenderSubtreeFeatures {
+  const result: ActiveRenderSubtreeFeatures = {
+    hasShader: false,
+    hasVideo: false,
+  }
+  if (!rootId) return result
+
+  const root = api.getNode(rootId)
+  if (!root) return result
+  const pending = [...root.children]
+  const visited = new Set<NodeId>([rootId])
+  while (pending.length > 0) {
+    const nodeId = pending.pop()!
+    if (visited.has(nodeId)) continue
+    visited.add(nodeId)
+    const node = api.getNode(nodeId)
+    if (!node) continue
+    if (node.kind === 'shader') result.hasShader = true
+    if (node.kind === 'video') result.hasVideo = true
+    if (result.hasShader && result.hasVideo) break
+    pending.push(...node.children)
+  }
+  return result
 }
 
 function reportProgress(
@@ -1331,14 +1617,16 @@ async function waitForRender3dVideosReady(timeoutMs = 900): Promise<void> {
     const videos = (
       window as Window & { __hypermotionRender3dVideos?: HTMLVideoElement[] }
     ).__hypermotionRender3dVideos ?? []
+    if (videos.length === 0) return
     if (
-      videos.length === 0 ||
       videos.every(
         (video) =>
           video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA &&
           !video.seeking,
       )
     ) {
+      // Let the decoded frame become the element's current presentation image;
+      // the caller follows this with an exact second GPU render request.
       await waitForFrames(1)
       return
     }

--- a/src/render/RenderWindowApp.tsx
+++ b/src/render/RenderWindowApp.tsx
@@ -762,6 +762,9 @@ async function runExportLoop(
       // when it spawned us. Resizing again would be redundant + might
       // race against the visible-window dimensions.
       outputSize: targetDims,
+      // Avoid PNG encoding and decoding on every worker frame. The main
+      // process retains a tagged PNG fallback if native bitmap capture fails.
+      transport: 'bitmap',
     })
   } catch (e) {
     reportError(
@@ -775,6 +778,10 @@ async function runExportLoop(
   let smoothedFrameMs = 0
   let outputIndex = 0
   let isFirstFrameOverall = true
+  // Crossfades need a third retained surface while the two scene captures
+  // are blended. Reuse it for the complete job to avoid allocating a full
+  // output-sized canvas on every transition frame.
+  const sequenceCompositeCanvas = document.createElement('canvas')
 
   try {
     reportProgress(requestId, { phase: 'rendering', frame: 0, totalFrames })
@@ -808,7 +815,7 @@ async function runExportLoop(
           weight: number
         }> = []
 
-        for (const layer of captureLayers) {
+        for (const [layerIndex, layer] of captureLayers.entries()) {
           const targetSceneId = layer.item?.scene.id ?? null
           const changedScene =
             targetSceneId !== null &&
@@ -829,7 +836,11 @@ async function runExportLoop(
 
           let layerCanvas: HTMLCanvasElement
           try {
-            layerCanvas = await capture.capture()
+            layerCanvas = await capture.capture({
+              // A transition retains both captures until compositing, so each
+              // needs its own pooled slot. Ordinary frames use slot zero.
+              surface: layerIndex,
+            })
           } catch (e) {
             throw new Error(
               `Failed to capture frame ${outputIndex + 1}/${totalFrames}: ${
@@ -862,7 +873,10 @@ async function runExportLoop(
           })
         }
 
-        const canvasEl = compositeSequenceLayers(captured)
+        const canvasEl = compositeSequenceLayers(
+          captured,
+          sequenceCompositeCanvas,
+        )
 
         if (!encoder) {
           try {
@@ -1003,14 +1017,22 @@ function reportError(requestId: string, message: string): void {
  */
 function compositeSequenceLayers(
   layers: readonly { canvas: HTMLCanvasElement; weight: number }[],
+  output: HTMLCanvasElement,
 ): HTMLCanvasElement {
   const first = layers[0]
   if (!first) throw new Error('No scene surface was captured for this frame.')
   if (layers.length === 1) return first.canvas
-  const output = document.createElement('canvas')
-  output.width = first.canvas.width
-  output.height = first.canvas.height
-  const context = output.getContext('2d')
+  if (
+    output.width !== first.canvas.width ||
+    output.height !== first.canvas.height
+  ) {
+    output.width = first.canvas.width
+    output.height = first.canvas.height
+  }
+  const context = output.getContext('2d', {
+    alpha: false,
+    colorSpace: 'srgb',
+  })
   if (!context) throw new Error('Unable to create sequence compositor.')
   context.globalAlpha = 1
   context.drawImage(first.canvas, 0, 0, output.width, output.height)

--- a/src/render/directGpuExportEligibility.test.ts
+++ b/src/render/directGpuExportEligibility.test.ts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import type { Appearance, NodeId } from '@/scene/types'
+import {
+  resolveDirectGpuExportEligibility,
+  type DirectGpuExportEligibilityInput,
+} from './directGpuExportEligibility'
+
+const opaqueAppearance: Appearance = {
+  opacity: 1,
+  fill: { kind: 'solid', color: '#ffffff' },
+  stroke: null,
+  cornerRadius: 0,
+  cornerRadii: { tl: 0, tr: 0, br: 0, bl: 0 },
+  cornerSmoothing: 0.6,
+  blendMode: 'normal',
+  effects: [],
+}
+
+type TreeNode = ReturnType<DirectGpuExportEligibilityInput['getNode']>
+
+function frame(
+  appearance: Appearance = opaqueAppearance,
+  children: NodeId[] = [],
+): NonNullable<DirectGpuExportEligibilityInput['activeRoot']> {
+  return {
+    id: 'root',
+    kind: 'frame',
+    children,
+    visible: true,
+    appearance,
+  }
+}
+
+function node(
+  id: NodeId,
+  kind: 'rect' | 'video' | 'shader',
+  children: NodeId[] = [],
+): NonNullable<TreeNode> {
+  return { id, kind, children }
+}
+
+function input(
+  patch: Partial<DirectGpuExportEligibilityInput> = {},
+): DirectGpuExportEligibilityInput {
+  const nodes = new Map<NodeId, NonNullable<TreeNode>>()
+  return {
+    format: 'mp4',
+    sequenceLayerCount: 1,
+    receipt: {
+      backend: 'webgl',
+      surface: { width: 1920, height: 1080 },
+    },
+    target: { width: 1920, height: 1080 },
+    activeCamera: { kind: 'camera', background: null },
+    activeRoot: frame(),
+    getNode: (id) => nodes.get(id) ?? null,
+    ...patch,
+  }
+}
+
+function reason(patch: Partial<DirectGpuExportEligibilityInput>): string {
+  return resolveDirectGpuExportEligibility(input(patch)).reason
+}
+
+function appearance(patch: Partial<Appearance>): Appearance {
+  return { ...opaqueAppearance, ...patch }
+}
+
+describe('resolveDirectGpuExportEligibility', () => {
+  it('accepts an opaque, single-layer MP4 frame on an exact WebGL surface', () => {
+    expect(resolveDirectGpuExportEligibility(input())).toEqual({
+      eligible: true,
+      reason: 'eligible',
+    })
+  })
+
+  it.each([
+    ['format-not-mp4', { format: 'gif' }],
+    ['sequence-layer-count', { sequenceLayerCount: 0 }],
+    ['sequence-layer-count', { sequenceLayerCount: 2 }],
+    ['missing-receipt', { receipt: null }],
+    [
+      'receipt-not-webgl',
+      { receipt: { backend: 'dom', surface: { width: 1920, height: 1080 } } },
+    ],
+    ['missing-surface', { receipt: { backend: 'webgl', surface: null } }],
+    [
+      'surface-size-mismatch',
+      { receipt: { backend: 'webgl', surface: { width: 3840, height: 2160 } } },
+    ],
+    ['missing-active-camera', { activeCamera: null }],
+    [
+      'camera-background',
+      {
+        activeCamera: {
+          kind: 'camera' as const,
+          background: { kind: 'solid' as const, color: '#000000' },
+        },
+      },
+    ],
+    ['missing-active-root', { activeRoot: null }],
+  ] satisfies ReadonlyArray<
+    readonly [string, Partial<DirectGpuExportEligibilityInput>]
+  >)('rejects %s', (expected, patch) => {
+    expect(reason(patch)).toBe(expected)
+  })
+
+  it('requires a visible frame root', () => {
+    expect(
+      reason({ activeRoot: { ...frame(), kind: 'rect' } }),
+    ).toBe('active-root-not-frame')
+    expect(reason({ activeRoot: { ...frame(), visible: false } })).toBe(
+      'root-not-visible',
+    )
+  })
+
+  it('requires an authored or animated fully opaque solid root fill', () => {
+    expect(
+      reason({ activeRoot: frame(appearance({ fill: null })) }),
+    ).toBe('root-fill-not-solid')
+    expect(
+      reason({
+        activeRoot: frame(
+          appearance({
+            fill: {
+              kind: 'linear',
+              angle: 0,
+              stops: [
+                { at: 0, color: '#000000' },
+                { at: 1, color: '#ffffff' },
+              ],
+            },
+          }),
+        ),
+      }),
+    ).toBe('root-fill-not-solid')
+    expect(
+      reason({
+        activeRoot: frame(
+          appearance({ fill: { kind: 'solid', color: '#ffffff80' } }),
+        ),
+      }),
+    ).toBe('root-fill-not-opaque')
+
+    // The resolved animation value overrides the authored fill for this frame.
+    expect(reason({ animatedSceneFillCss: 'linear-gradient(red, blue)' })).toBe(
+      'root-fill-not-solid',
+    )
+    expect(reason({ animatedSceneFillCss: 'rgb(10 20 30 / 40%)' })).toBe(
+      'root-fill-not-opaque',
+    )
+    expect(
+      resolveDirectGpuExportEligibility(
+        input({ animatedSceneFillCss: 'oklch(0.62 0.21 250 / 100%)' }),
+      ),
+    ).toEqual({ eligible: true, reason: 'eligible' })
+  })
+
+  it('rejects animated root compositing boundaries', () => {
+    expect(reason({ rootHasVisualAnimation: true })).toBe(
+      'root-visual-animation',
+    )
+  })
+
+  it.each([
+    ['root-opacity', appearance({ opacity: 0.999 })],
+    ['root-corner-radius', appearance({ cornerRadius: 1 })],
+    [
+      'root-corner-radii',
+      appearance({ cornerRadii: { tl: 0, tr: 0, br: 2, bl: 0 } }),
+    ],
+    [
+      'root-stroke',
+      appearance({
+        stroke: {
+          color: '#000000',
+          width: 0,
+          align: 'inside',
+          style: 'solid',
+          dashLength: 0,
+          dashGap: 0,
+        },
+      }),
+    ],
+    [
+      'root-effects',
+      appearance({ effects: [{ kind: 'blur', amount: 0, visible: false }] }),
+    ],
+    ['root-blend-mode', appearance({ blendMode: 'multiply' })],
+  ] satisfies ReadonlyArray<readonly [string, Appearance]>)(
+    'rejects %s on the root appearance',
+    (expected, rootAppearance) => {
+      expect(reason({ activeRoot: frame(rootAppearance) })).toBe(expected)
+    },
+  )
+
+  it.each([
+    ['subtree-video', 'video'],
+    ['subtree-shader', 'shader'],
+  ] as const)(
+    'rejects %s anywhere in the active-root subtree',
+    (expected, kind) => {
+      const nested = node('nested', 'rect', ['unsupported'])
+      const unsupported = node('unsupported', kind)
+      const nodes = new Map([
+        [nested.id, nested],
+        [unsupported.id, unsupported],
+      ])
+      expect(
+        reason({
+          activeRoot: frame(opaqueAppearance, ['nested']),
+          getNode: (id) => nodes.get(id) ?? null,
+        }),
+      ).toBe(expected)
+    },
+  )
+
+  it('rejects malformed child references instead of assuming a safe subtree', () => {
+    expect(
+      reason({
+        activeRoot: frame(opaqueAppearance, ['missing']),
+        getNode: () => null,
+      }),
+    ).toBe('subtree-node-missing')
+  })
+})

--- a/src/render/directGpuExportEligibility.ts
+++ b/src/render/directGpuExportEligibility.ts
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Appearance, CameraNode, Node, NodeId } from '@/scene/types'
+
+export type DirectGpuExportIneligibilityReason =
+  | 'format-not-mp4'
+  | 'sequence-layer-count'
+  | 'missing-receipt'
+  | 'receipt-not-webgl'
+  | 'missing-surface'
+  | 'surface-size-mismatch'
+  | 'missing-active-camera'
+  | 'camera-background'
+  | 'missing-active-root'
+  | 'active-root-not-frame'
+  | 'root-not-visible'
+  | 'root-opacity'
+  | 'root-fill-not-solid'
+  | 'root-fill-not-opaque'
+  | 'root-corner-radius'
+  | 'root-corner-radii'
+  | 'root-stroke'
+  | 'root-effects'
+  | 'root-blend-mode'
+  | 'root-visual-animation'
+  | 'subtree-node-missing'
+  | 'subtree-video'
+  | 'subtree-shader'
+
+export type DirectGpuExportEligibility =
+  | { readonly eligible: true; readonly reason: 'eligible' }
+  | {
+      readonly eligible: false
+      readonly reason: DirectGpuExportIneligibilityReason
+    }
+
+export interface DirectGpuSurface {
+  /** Intrinsic drawing-buffer width, not its CSS width. */
+  readonly width: number
+  /** Intrinsic drawing-buffer height, not its CSS height. */
+  readonly height: number
+}
+
+export interface DirectGpuFrameReceipt {
+  readonly backend: string
+  readonly surface: DirectGpuSurface | null
+}
+
+type DirectGpuRoot = Pick<
+  Node,
+  'id' | 'kind' | 'children' | 'visible' | 'appearance'
+>
+type DirectGpuSubtreeNode = Pick<Node, 'id' | 'kind' | 'children'>
+type DirectGpuCamera = Pick<CameraNode, 'kind' | 'background'>
+
+export interface DirectGpuExportEligibilityInput {
+  readonly format: string
+  readonly sequenceLayerCount: number
+  readonly receipt: DirectGpuFrameReceipt | null
+  readonly target: { readonly width: number; readonly height: number }
+  readonly activeCamera: DirectGpuCamera | null
+  readonly activeRoot: DirectGpuRoot | null
+  /** Root-boundary animation is page compositing, not part of the 3D canvas. */
+  readonly rootHasVisualAnimation?: boolean
+  /** Resolve descendants of activeRoot. The root itself need not be included. */
+  readonly getNode: (id: NodeId) => DirectGpuSubtreeNode | null
+  /**
+   * Current animated scene fill, when animation has resolved one. Undefined
+   * means use the authored root fill; null means the current frame has no fill.
+   */
+  readonly animatedSceneFillCss?: string | null
+}
+
+const ELIGIBLE: DirectGpuExportEligibility = Object.freeze({
+  eligible: true,
+  reason: 'eligible',
+})
+
+function ineligible(
+  reason: DirectGpuExportIneligibilityReason,
+): DirectGpuExportEligibility {
+  return { eligible: false, reason }
+}
+
+/**
+ * Decide whether a rendered frame can bypass Electron capture and feed its
+ * WebGL surface directly to the MP4 encoder without changing visible output.
+ *
+ * This deliberately rejects uncertain cases. The existing capture renderer is
+ * the fidelity fallback, so a false negative costs performance while a false
+ * positive can corrupt an export.
+ */
+export function resolveDirectGpuExportEligibility(
+  input: DirectGpuExportEligibilityInput,
+): DirectGpuExportEligibility {
+  if (input.format !== 'mp4') return ineligible('format-not-mp4')
+  if (input.sequenceLayerCount !== 1) {
+    return ineligible('sequence-layer-count')
+  }
+
+  const receipt = input.receipt
+  if (!receipt) return ineligible('missing-receipt')
+  if (receipt.backend !== 'webgl') return ineligible('receipt-not-webgl')
+  const surface = receipt.surface
+  if (!surface) return ineligible('missing-surface')
+  if (
+    surface.width !== input.target.width ||
+    surface.height !== input.target.height
+  ) {
+    return ineligible('surface-size-mismatch')
+  }
+
+  const camera = input.activeCamera
+  if (!camera || camera.kind !== 'camera') {
+    return ineligible('missing-active-camera')
+  }
+  if (camera.background !== null) return ineligible('camera-background')
+
+  const root = input.activeRoot
+  if (!root) return ineligible('missing-active-root')
+  if (root.kind !== 'frame') return ineligible('active-root-not-frame')
+  if (!root.visible) return ineligible('root-not-visible')
+
+  const appearance = root.appearance
+  if (appearance.opacity !== 1) return ineligible('root-opacity')
+
+  const currentFill = classifyCurrentRootFill(
+    appearance,
+    input.animatedSceneFillCss,
+  )
+  if (currentFill === 'not-solid') return ineligible('root-fill-not-solid')
+  if (currentFill === 'not-opaque') return ineligible('root-fill-not-opaque')
+
+  if (appearance.cornerRadius !== 0) {
+    return ineligible('root-corner-radius')
+  }
+  if (
+    appearance.cornerRadii &&
+    Object.values(appearance.cornerRadii).some((radius) => radius !== 0)
+  ) {
+    return ineligible('root-corner-radii')
+  }
+  if (appearance.stroke !== null) return ineligible('root-stroke')
+  if (appearance.effects.length > 0) return ineligible('root-effects')
+  if ((appearance.blendMode ?? 'normal') !== 'normal') {
+    return ineligible('root-blend-mode')
+  }
+  if (input.rootHasVisualAnimation) {
+    return ineligible('root-visual-animation')
+  }
+
+  const pending = [...root.children]
+  const visited = new Set<NodeId>([root.id])
+  while (pending.length > 0) {
+    const nodeId = pending.pop()!
+    if (visited.has(nodeId)) continue
+    visited.add(nodeId)
+
+    const node = input.getNode(nodeId)
+    if (!node) return ineligible('subtree-node-missing')
+    if (node.kind === 'video') return ineligible('subtree-video')
+    if (node.kind === 'shader') return ineligible('subtree-shader')
+    pending.push(...node.children)
+  }
+
+  return ELIGIBLE
+}
+
+type RootFillClassification = 'opaque-solid' | 'not-solid' | 'not-opaque'
+
+const OPAQUE_NAMED_COLORS = new Set([
+  'aqua',
+  'black',
+  'blue',
+  'fuchsia',
+  'gray',
+  'green',
+  'lime',
+  'maroon',
+  'navy',
+  'olive',
+  'orange',
+  'purple',
+  'red',
+  'silver',
+  'teal',
+  'white',
+  'yellow',
+])
+
+function classifyCurrentRootFill(
+  appearance: Appearance,
+  animatedSceneFillCss: string | null | undefined,
+): RootFillClassification {
+  if (animatedSceneFillCss !== undefined) {
+    return classifyCssColor(animatedSceneFillCss)
+  }
+  if (appearance.fill?.kind !== 'solid') return 'not-solid'
+  return classifyCssColor(appearance.fill.color)
+}
+
+/**
+ * Conservative opacity check for the color forms authored by Hyper Motion.
+ * Dynamic CSS and paint functions are rejected because their final alpha
+ * cannot be proven without browser style resolution.
+ */
+function classifyCssColor(css: string | null): RootFillClassification {
+  if (css === null) return 'not-solid'
+  const value = css.trim().toLowerCase()
+  if (!value) return 'not-solid'
+  if (
+    value.includes('gradient(') ||
+    value.startsWith('url(') ||
+    value.includes('var(') ||
+    value.includes('env(') ||
+    value.includes('color-mix(')
+  ) {
+    return 'not-solid'
+  }
+  if (value === 'transparent') return 'not-opaque'
+  if (
+    value === 'currentcolor' ||
+    value === 'inherit' ||
+    value === 'initial' ||
+    value === 'unset' ||
+    value === 'revert' ||
+    value === 'revert-layer'
+  ) {
+    return 'not-solid'
+  }
+
+  const hex = value.match(/^#([0-9a-f]+)$/)?.[1]
+  if (hex) {
+    if (hex.length === 3 || hex.length === 6) return 'opaque-solid'
+    if (hex.length === 4) {
+      return hex[3] === 'f' ? 'opaque-solid' : 'not-opaque'
+    }
+    if (hex.length === 8) {
+      return hex.slice(6) === 'ff' ? 'opaque-solid' : 'not-opaque'
+    }
+    return 'not-solid'
+  }
+
+  // App-authored colors normally use hex/oklch. Keep the unambiguous named
+  // legacy colors without assuming that every alphabetic string is valid CSS.
+  if (OPAQUE_NAMED_COLORS.has(value)) return 'opaque-solid'
+
+  const functionMatch = value.match(
+    /^(rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\((.*)\)$/s,
+  )
+  if (!functionMatch) return 'not-solid'
+  const body = functionMatch[2].trim()
+  if (!body || /\b(?:var|env|calc|none)\s*\(/.test(body)) return 'not-solid'
+
+  const slash = body.lastIndexOf('/')
+  if (slash >= 0) {
+    const alpha = parseCssAlpha(body.slice(slash + 1))
+    if (alpha === null) return 'not-solid'
+    return alpha >= 1 ? 'opaque-solid' : 'not-opaque'
+  }
+
+  if (functionMatch[1] === 'rgba' || functionMatch[1] === 'hsla') {
+    const parts = body.split(',')
+    if (parts.length === 4) {
+      const alpha = parseCssAlpha(parts[3])
+      if (alpha === null) return 'not-solid'
+      return alpha >= 1 ? 'opaque-solid' : 'not-opaque'
+    }
+  }
+
+  return 'opaque-solid'
+}
+
+function parseCssAlpha(token: string): number | null {
+  const value = token.trim()
+  const percentage = value.match(/^([+-]?(?:\d+\.?\d*|\.\d+))%$/)
+  if (percentage) {
+    const numeric = Number(percentage[1])
+    return Number.isFinite(numeric) ? numeric / 100 : null
+  }
+  if (!/^[+-]?(?:\d+\.?\d*|\.\d+)$/.test(value)) return null
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? numeric : null
+}

--- a/src/render/frameReady.test.ts
+++ b/src/render/frameReady.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  FrameReadyBarrier,
+  FrameReadyCancelledError,
+  FrameReadyDisposedError,
+  FrameReadyTimeoutError,
+} from './frameReady'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('FrameReadyBarrier', () => {
+  it('allocates monotonic token and pass identities', async () => {
+    const barrier = new FrameReadyBarrier()
+    const first = barrier.begin()
+    const second = barrier.begin({ pass: 7 })
+    const third = barrier.begin()
+
+    expect(first.identity).toEqual({ token: 1, pass: 1 })
+    expect(second.identity).toEqual({ token: 2, pass: 7 })
+    expect(third.identity).toEqual({ token: 3, pass: 8 })
+    expect(() => barrier.begin({ pass: 7 })).toThrow(/stale/)
+
+    barrier.acknowledge(first.identity)
+    barrier.acknowledge(second.identity)
+    barrier.acknowledge(third.identity)
+    await Promise.all([first.promise, second.promise, third.promise])
+  })
+
+  it('resolves only an exact token and pass acknowledgement', async () => {
+    const barrier = new FrameReadyBarrier()
+    const request = barrier.begin()
+    let settled = false
+    void request.promise.then(() => {
+      settled = true
+    })
+
+    expect(
+      barrier.acknowledge({
+        token: request.identity.token - 1,
+        pass: request.identity.pass,
+      }),
+    ).toBe(false)
+    expect(
+      barrier.acknowledge({
+        token: request.identity.token,
+        pass: request.identity.pass + 1,
+      }),
+    ).toBe(false)
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    expect(barrier.pendingCount).toBe(1)
+
+    expect(barrier.acknowledge(request.identity)).toBe(true)
+    await expect(request.promise).resolves.toEqual(request.identity)
+    expect(settled).toBe(true)
+    expect(barrier.pendingCount).toBe(0)
+    expect(barrier.acknowledge(request.identity)).toBe(false)
+  })
+
+  it('rejects and removes a request when its timeout expires', async () => {
+    vi.useFakeTimers()
+    const barrier = new FrameReadyBarrier({ timeoutMs: 25 })
+    const request = barrier.begin()
+    const rejection = expect(request.promise).rejects.toMatchObject({
+      name: 'FrameReadyTimeoutError',
+      identity: request.identity,
+      timeoutMs: 25,
+    })
+
+    await vi.advanceTimersByTimeAsync(25)
+    await rejection
+    expect(barrier.pendingCount).toBe(0)
+    expect(barrier.acknowledge(request.identity)).toBe(false)
+    expect(new FrameReadyTimeoutError(request.identity, 25)).toBeInstanceOf(
+      Error,
+    )
+  })
+
+  it('supports targeted cancellation without disturbing other requests', async () => {
+    const barrier = new FrameReadyBarrier()
+    const cancelled = barrier.begin()
+    const ready = barrier.begin()
+    const rejection = expect(cancelled.promise).rejects.toBeInstanceOf(
+      FrameReadyCancelledError,
+    )
+
+    expect(cancelled.cancel('superseded')).toBe(true)
+    await rejection
+    expect(cancelled.cancel()).toBe(false)
+    expect(barrier.pendingCount).toBe(1)
+
+    barrier.acknowledge(ready.identity)
+    await expect(ready.promise).resolves.toEqual(ready.identity)
+  })
+
+  it('cancels every outstanding request on cancellation or disposal', async () => {
+    const barrier = new FrameReadyBarrier()
+    const first = barrier.begin()
+    const second = barrier.begin()
+    const firstRejection = expect(first.promise).rejects.toBeInstanceOf(
+      FrameReadyCancelledError,
+    )
+    const secondRejection = expect(second.promise).rejects.toBeInstanceOf(
+      FrameReadyCancelledError,
+    )
+
+    expect(barrier.cancelAll('new export')).toBe(2)
+    await Promise.all([firstRejection, secondRejection])
+    expect(barrier.pendingCount).toBe(0)
+
+    const outstanding = barrier.begin()
+    const disposed = expect(outstanding.promise).rejects.toBeInstanceOf(
+      FrameReadyDisposedError,
+    )
+    expect(barrier.dispose('worker closed')).toBe(1)
+    await disposed
+    expect(barrier.isDisposed).toBe(true)
+    expect(barrier.dispose()).toBe(0)
+    expect(() => barrier.begin()).toThrow(FrameReadyDisposedError)
+  })
+})

--- a/src/render/frameReady.ts
+++ b/src/render/frameReady.ts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface FrameReadyIdentity {
+  readonly token: number
+  readonly pass: number
+}
+
+export interface FrameReadyRequest {
+  readonly identity: FrameReadyIdentity
+  readonly promise: Promise<FrameReadyIdentity>
+  cancel: (reason?: unknown) => boolean
+}
+
+export interface FrameReadyBarrierOptions {
+  timeoutMs?: number
+}
+
+export interface BeginFrameReadyOptions {
+  /**
+   * Render pass associated with this request. Passes must increase strictly so
+   * an acknowledgement from an earlier React/GPU commit cannot satisfy a later
+   * capture request. Omit this to let the barrier allocate the next pass.
+   */
+  pass?: number
+  timeoutMs?: number
+}
+
+interface PendingFrameReadyRequest {
+  identity: FrameReadyIdentity
+  resolve: (identity: FrameReadyIdentity) => void
+  reject: (reason: unknown) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000
+
+function identityLabel(identity: FrameReadyIdentity): string {
+  return `token ${identity.token}, pass ${identity.pass}`
+}
+
+function validCounter(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0
+}
+
+function validTimeout(value: number): boolean {
+  return Number.isFinite(value) && value > 0
+}
+
+export class FrameReadyTimeoutError extends Error {
+  readonly identity: FrameReadyIdentity
+  readonly timeoutMs: number
+
+  constructor(identity: FrameReadyIdentity, timeoutMs: number) {
+    super(
+      `Frame readiness timed out after ${timeoutMs}ms (${identityLabel(identity)}).`,
+    )
+    this.name = 'FrameReadyTimeoutError'
+    this.identity = identity
+    this.timeoutMs = timeoutMs
+  }
+}
+
+export class FrameReadyCancelledError extends Error {
+  readonly identity: FrameReadyIdentity
+  readonly reason: unknown
+
+  constructor(identity: FrameReadyIdentity, reason?: unknown) {
+    const detail =
+      reason instanceof Error
+        ? `: ${reason.message}`
+        : typeof reason === 'string' && reason.length > 0
+          ? `: ${reason}`
+          : ''
+    super(`Frame readiness was cancelled (${identityLabel(identity)})${detail}.`)
+    this.name = 'FrameReadyCancelledError'
+    this.identity = identity
+    this.reason = reason
+  }
+}
+
+export class FrameReadyDisposedError extends Error {
+  readonly reason: unknown
+
+  constructor(reason?: unknown) {
+    const detail =
+      reason instanceof Error
+        ? `: ${reason.message}`
+        : typeof reason === 'string' && reason.length > 0
+          ? `: ${reason}`
+          : ''
+    super(`Frame-ready barrier was disposed${detail}.`)
+    this.name = 'FrameReadyDisposedError'
+    this.reason = reason
+  }
+}
+
+/**
+ * Coordinates deterministic frame requests with renderer acknowledgements.
+ *
+ * Tokens are allocated by the barrier and passes are strictly monotonic. An
+ * acknowledgement must match both values exactly; stale or speculative
+ * acknowledgements are ignored without disturbing pending requests.
+ */
+export class FrameReadyBarrier {
+  private readonly defaultTimeoutMs: number
+  private readonly pending = new Map<number, PendingFrameReadyRequest>()
+  private nextToken = 1
+  private nextPass = 1
+  private disposedError: FrameReadyDisposedError | null = null
+
+  constructor(options: FrameReadyBarrierOptions = {}) {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    if (!validTimeout(timeoutMs)) {
+      throw new RangeError('Frame-ready timeout must be a positive number.')
+    }
+    this.defaultTimeoutMs = timeoutMs
+  }
+
+  get pendingCount(): number {
+    return this.pending.size
+  }
+
+  get isDisposed(): boolean {
+    return this.disposedError !== null
+  }
+
+  begin(options: BeginFrameReadyOptions = {}): FrameReadyRequest {
+    if (this.disposedError) throw this.disposedError
+
+    const pass = options.pass ?? this.nextPass
+    if (!validCounter(pass)) {
+      throw new RangeError('Frame-ready pass must be a positive safe integer.')
+    }
+    if (pass < this.nextPass) {
+      throw new RangeError(
+        `Frame-ready pass ${pass} is stale; the next pass is ${this.nextPass}.`,
+      )
+    }
+
+    const timeoutMs = options.timeoutMs ?? this.defaultTimeoutMs
+    if (!validTimeout(timeoutMs)) {
+      throw new RangeError('Frame-ready timeout must be a positive number.')
+    }
+
+    const identity = Object.freeze({ token: this.nextToken, pass })
+    this.nextToken += 1
+    this.nextPass = pass + 1
+
+    let resolvePromise!: (identity: FrameReadyIdentity) => void
+    let rejectPromise!: (reason: unknown) => void
+    const promise = new Promise<FrameReadyIdentity>((resolve, reject) => {
+      resolvePromise = resolve
+      rejectPromise = reject
+    })
+
+    const timer = setTimeout(() => {
+      const pending = this.take(identity)
+      if (!pending) return
+      pending.reject(new FrameReadyTimeoutError(identity, timeoutMs))
+    }, timeoutMs)
+
+    this.pending.set(identity.token, {
+      identity,
+      resolve: resolvePromise,
+      reject: rejectPromise,
+      timer,
+    })
+
+    return {
+      identity,
+      promise,
+      cancel: (reason?: unknown) => this.cancel(identity, reason),
+    }
+  }
+
+  acknowledge(identity: FrameReadyIdentity): boolean {
+    const pending = this.take(identity)
+    if (!pending) return false
+    pending.resolve(pending.identity)
+    return true
+  }
+
+  cancel(identity: FrameReadyIdentity, reason?: unknown): boolean {
+    const pending = this.take(identity)
+    if (!pending) return false
+    pending.reject(new FrameReadyCancelledError(pending.identity, reason))
+    return true
+  }
+
+  cancelAll(reason?: unknown): number {
+    const requests = [...this.pending.values()]
+    this.pending.clear()
+    for (const pending of requests) {
+      clearTimeout(pending.timer)
+      pending.reject(new FrameReadyCancelledError(pending.identity, reason))
+    }
+    return requests.length
+  }
+
+  dispose(reason?: unknown): number {
+    if (this.disposedError) return 0
+    this.disposedError = new FrameReadyDisposedError(reason)
+    const requests = [...this.pending.values()]
+    this.pending.clear()
+    for (const pending of requests) {
+      clearTimeout(pending.timer)
+      pending.reject(this.disposedError)
+    }
+    return requests.length
+  }
+
+  private take(identity: FrameReadyIdentity): PendingFrameReadyRequest | null {
+    const pending = this.pending.get(identity.token)
+    if (!pending || pending.identity.pass !== identity.pass) return null
+    this.pending.delete(identity.token)
+    clearTimeout(pending.timer)
+    return pending
+  }
+}

--- a/src/render/renderCameraBackend.ts
+++ b/src/render/renderCameraBackend.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Keep one WebGL viewport alive while cuts switch between cameras owned by the
+ * same composition. Camera changes are ordinary prop updates; remounting the
+ * renderer here destroys its context and exposes a transitional cut frame.
+ */
+export function renderCameraBackendKey(
+  compositionId: string | null | undefined,
+  cameraId: string | null,
+): string {
+  return `${compositionId ?? 'legacy'}:${cameraId ? 'camera' : 'none'}`
+}

--- a/src/render/renderCameraBackendKey.test.ts
+++ b/src/render/renderCameraBackendKey.test.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { renderCameraBackendKey } from './renderCameraBackend'
+
+describe('renderCameraBackendKey', () => {
+  it('keeps one WebGL viewport mounted across camera cuts', () => {
+    expect(renderCameraBackendKey('scene-a', 'wide')).toBe(
+      renderCameraBackendKey('scene-a', 'detail'),
+    )
+  })
+
+  it('remounts when the composition or camera backend changes', () => {
+    expect(renderCameraBackendKey('scene-a', 'wide')).not.toBe(
+      renderCameraBackendKey('scene-b', 'wide'),
+    )
+    expect(renderCameraBackendKey('scene-a', 'wide')).not.toBe(
+      renderCameraBackendKey('scene-a', null),
+    )
+  })
+})

--- a/src/render3d/ThreeSceneViewport.tsx
+++ b/src/render3d/ThreeSceneViewport.tsx
@@ -23,6 +23,7 @@ import {
 import {
   numberFlowVisualFrameAtProgress,
   numberFlowVisualOptionsFromConfig,
+  type NumberFlowVisualFrame,
 } from '@/anim/numberFlow'
 import {
   resolveTextMotionRailAmount,
@@ -62,6 +63,7 @@ import {
   createPlaneBuildContext,
   depthBlurAmount,
   effectiveApertureStrength,
+  projectWorldPoint,
   resolveCamera3D,
   type PlaneBuildContext,
   type PlaneClip3D,
@@ -181,6 +183,17 @@ interface ThreeSceneViewportProps {
   /** Invalidates the captured scene graph when roots or node topology change. */
   sceneVersion: number
   onAvailabilityChange?: (available: boolean) => void
+  /**
+   * Monotonic export-frame identity. Supplying a new identity forces one
+   * complete synchronous GPU render even when the authored scene state is
+   * otherwise referentially unchanged.
+   */
+  renderRequest?: { token: number; pass: number } | null
+  /** Fired immediately after the requested frame reaches the WebGL surface. */
+  onFrameRendered?: (
+    request: { token: number; pass: number },
+    surface: HTMLCanvasElement,
+  ) => void
   /** Camera gesture/scrub is transient; keep GPU DOF on its realtime budget. */
   interactiveCameraPreview?: boolean
   /** Keep GPU resources mounted while suppressing all scene/post rendering. */
@@ -494,6 +507,8 @@ export function ThreeSceneViewport({
   playhead = 0,
   sceneVersion,
   onAvailabilityChange,
+  renderRequest = null,
+  onFrameRendered,
   interactiveCameraPreview = false,
   suspended = false,
 }: ThreeSceneViewportProps) {
@@ -691,6 +706,10 @@ export function ThreeSceneViewport({
         antialias: true,
         alpha: true,
         powerPreference: 'high-performance',
+        // Final export consumes this canvas directly through VideoFrame. Keep
+        // the submitted drawing buffer alive across the acknowledgement
+        // microtask; editor canvases retain Three's cheaper default behavior.
+        preserveDrawingBuffer: finalRender,
       })
     } catch (error) {
       console.warn('3D helper disabled: WebGL context creation failed.', error)
@@ -813,6 +832,11 @@ export function ThreeSceneViewport({
           playhead,
         )
       : playheadDrivenTextureRanges.size > 0
+    // Export frame passes are explicit render requests. A video element may
+    // finish metadata/decode without changing any React input; force its
+    // synchronization on every pass so a follow-up request can initiate the
+    // exact seek and then paint the decoded presentation frame.
+    const requestedVideoSync = hasVideoPlane && renderRequest !== null
     const planeStateChanged =
       !previousPlaneSync ||
       previousPlaneSync.planes !== planes ||
@@ -831,6 +855,7 @@ export function ThreeSceneViewport({
       (hasVideoPlane &&
         (previousPlaneSync.playing !== playing ||
           previousPlaneSync.playhead !== playhead)) ||
+      requestedVideoSync ||
       playheadDrivenTextureChanged ||
       hasDynamicDepthOfField ||
       previousPlaneSync.dynamicDepthOfField !== hasDynamicDepthOfField
@@ -957,6 +982,13 @@ export function ThreeSceneViewport({
         renderer.render(scene, perspective)
       }
     }
+    // Keep this callback adjacent to the final renderer submission. Export
+    // consumes the drawing buffer synchronously from this acknowledgement;
+    // deferring it to a passive effect can observe a cleared/stale WebGL
+    // surface when preserveDrawingBuffer is disabled.
+    if (renderRequest) {
+      onFrameRendered?.(renderRequest, renderer.domElement)
+    }
   }, [
     api,
     planeBuildContext,
@@ -987,6 +1019,8 @@ export function ThreeSceneViewport({
     // Changing the zoom-derived pixel-ratio bucket reallocates and clears the
     // WebGL drawing buffer. Render again immediately after the resize effect.
     renderPixelRatio,
+    renderRequest,
+    onFrameRendered,
   ])
 
   if (webglUnavailable) return null
@@ -1281,18 +1315,48 @@ function syncPlanes(
         sampleCount,
         interactiveCameraPreview,
         texturePixelRatio,
+        finalRender,
       })
       records.set(plane.nodeId, nextRecord)
       continue
     }
     const videoNode = plane.node.kind === 'video' ? plane.node : null
     const textureRect = plane.textureRect ?? plane.rect
+    const requestedTextureScale = projectedPlaneTextureScale({
+      plane,
+      camera,
+      viewportSize,
+      screenPixelRatio,
+      fallbackScale: texturePixelRatio,
+    })
+    const previousTextureScale =
+      record?.textureKind === 'canvas'
+        ? Number(
+            (record.texture.image as HTMLCanvasElement | undefined)?.dataset
+              .textureScale,
+          )
+        : 0
+    const textureScale = videoNode
+      ? 1
+      : textureScaleForRect(
+          textureRect,
+          Math.max(
+            requestedTextureScale,
+            Number.isFinite(previousTextureScale) ? previousTextureScale : 0,
+          ),
+          {
+            maximumScale:
+              finalRender ? 8 : playing || interactiveCameraPreview ? 2 : 4,
+            bucketStep: finalRender ? 0.5 : 0.25,
+          },
+        )
     const textureSignature = [
       plane.contentMode,
       Number(textureRect.x.toFixed(3)),
       Number(textureRect.y.toFixed(3)),
       Number(textureRect.width.toFixed(3)),
       Number(textureRect.height.toFixed(3)),
+      Number(textureScale.toFixed(4)),
       planeTextureAnimationSignature(
         planeBuildContext,
         plane,
@@ -1322,6 +1386,7 @@ function syncPlanes(
           emittedPlaneNodeIds,
           animated,
           playhead,
+          textureScale,
         )
       : null
     if (!record) {
@@ -1512,6 +1577,7 @@ interface TextSegmentPlaneSyncOptions {
   sampleCount: number
   interactiveCameraPreview: boolean
   texturePixelRatio: number
+  finalRender: boolean
 }
 
 /**
@@ -1541,6 +1607,7 @@ function syncTextSegmentPlane({
   sampleCount,
   interactiveCameraPreview,
   texturePixelRatio,
+  finalRender,
 }: TextSegmentPlaneSyncOptions): PlaneRecord {
   if (plane.node.kind !== 'text') {
     throw new Error('A segment-text plane must reference a text node')
@@ -1569,7 +1636,18 @@ function syncTextSegmentPlane({
     (point.z - camera.position.z) * cameraForward.z
   const atlasScale = textureScaleForRect(
     plane.rect,
-    texturePixelRatio,
+    projectedPlaneTextureScale({
+      plane,
+      camera,
+      viewportSize,
+      screenPixelRatio,
+      fallbackScale: texturePixelRatio,
+    }),
+    {
+      maximumScale:
+        finalRender ? 8 : playing || interactiveCameraPreview ? 2 : 4,
+      bucketStep: finalRender ? 0.5 : 0.25,
+    },
   )
   const lineHeightPx = Math.max(
     1,
@@ -2142,7 +2220,13 @@ function resolveTextSegmentGeometryStates(
           config.id === 'scramble' ||
           config.id === 'number-flow')
       state.opacity = atlasDrivenLayerReveal ? 1 : visual.opacity
-      state.effectBlur = numberFlowFrame?.blurRadius ?? visual.blur
+      // Staggered Number Flow bakes blur into each independently timed digit
+      // column. Applying the material blur as well would blur static digits
+      // and separators a second time, diverging from the DOM/export fallback.
+      state.effectBlur =
+        numberFlowFrame && config.numberFlowDigitMode === 'staggered'
+          ? 0
+          : (numberFlowFrame?.blurRadius ?? visual.blur)
       state.scale = visual.scale
       state.skew = visual.skew
       state.rotationX =
@@ -2493,6 +2577,23 @@ function textSegmentTextureSignature(
       maskWidth: frame.maskWidthEm,
       spinDistance: config.numberFlowSpinDistance,
       blurRadius: config.blurRadius,
+      digitMode: config.numberFlowDigitMode,
+      digitOrder: config.numberFlowDigitOrder,
+      digitStagger: config.numberFlowDigitStagger,
+      tokens:
+        config.numberFlowDigitMode === 'staggered'
+          ? frame.tokens.map((token) => ({
+              key: token.key,
+              outgoing: token.outgoingChar,
+              incoming: token.incomingChar,
+              phase: Number(token.phase.toFixed(4)),
+              outgoingOffset: Number(token.outgoingOffsetEm.toFixed(4)),
+              incomingOffset: Number(token.incomingOffsetEm.toFixed(4)),
+              outgoingOpacity: Number(token.outgoingOpacity.toFixed(4)),
+              incomingOpacity: Number(token.incomingOpacity.toFixed(4)),
+              blurRadius: Number(token.blurRadius.toFixed(4)),
+            }))
+          : null,
     }
   } else if (config?.id === 'tracking' && config.applyTo !== 'letters') {
     dynamicFrame = Math.round(
@@ -3106,19 +3207,12 @@ function paintTextSegmentAtlasCell(
             ? Math.max(0, rect.height - textHeight)
             : 0
       if (numberFlowFrame) {
-        const paintNumberLayer = (
-          layerText: string,
-          offsetEm: number,
-          opacity: number,
-        ) => {
-          if (opacity <= 0.001) return
-          ctx.save()
-          ctx.globalAlpha *= opacity
-          paintText(
+        if (config.numberFlowDigitMode === 'staggered') {
+          paintNumberFlowTokenColumns(
             ctx,
-            layerText,
+            numberFlowFrame,
             entry.padding,
-            entry.padding + alignedY + offsetEm * lineHeightPx,
+            entry.padding + alignedY,
             rect.width,
             fontSize,
             lineHeight,
@@ -3126,18 +3220,40 @@ function paintTextSegmentAtlasCell(
             node.textAlign ?? 'start',
             node.textDecoration ?? 'none',
           )
-          ctx.restore()
+        } else {
+          const paintNumberLayer = (
+            layerText: string,
+            offsetEm: number,
+            opacity: number,
+          ) => {
+            if (opacity <= 0.001) return
+            ctx.save()
+            ctx.globalAlpha *= opacity
+            paintText(
+              ctx,
+              layerText,
+              entry.padding,
+              entry.padding + alignedY + offsetEm * lineHeightPx,
+              rect.width,
+              fontSize,
+              lineHeight,
+              tracking,
+              node.textAlign ?? 'start',
+              node.textDecoration ?? 'none',
+            )
+            ctx.restore()
+          }
+          paintNumberLayer(
+            numberFlowFrame.outgoingText,
+            numberFlowFrame.outgoingOffsetEm,
+            numberFlowFrame.outgoingOpacity,
+          )
+          paintNumberLayer(
+            numberFlowFrame.incomingText,
+            numberFlowFrame.incomingOffsetEm,
+            numberFlowFrame.incomingOpacity,
+          )
         }
-        paintNumberLayer(
-          numberFlowFrame.outgoingText,
-          numberFlowFrame.outgoingOffsetEm,
-          numberFlowFrame.outgoingOpacity,
-        )
-        paintNumberLayer(
-          numberFlowFrame.incomingText,
-          numberFlowFrame.incomingOffsetEm,
-          numberFlowFrame.incomingOpacity,
-        )
       } else {
         paintText(
           ctx,
@@ -3304,6 +3420,79 @@ function clearPlanes(scene: THREE.Scene, records: Map<NodeId, PlaneRecord>) {
   publishRender3dVideos(records)
 }
 
+interface ProjectedPlaneTextureScaleOptions {
+  plane: Plane3D
+  camera: ResolvedCamera3D
+  viewportSize: THREE.Vector2
+  screenPixelRatio: number
+  fallbackScale: number
+}
+
+/**
+ * Resolve how many texture pixels each authored plane unit needs after the
+ * camera projects it into the output framebuffer. A fixed DPR is insufficient
+ * for a tilted card that is magnified to fill a 4K frame: Three would otherwise
+ * enlarge a much smaller flattened bitmap and expose soft glyph edges.
+ */
+function projectedPlaneTextureScale({
+  plane,
+  camera,
+  viewportSize,
+  screenPixelRatio,
+  fallbackScale,
+}: ProjectedPlaneTextureScaleOptions): number {
+  const rect = plane.textureRect ?? plane.rect
+  const center = plane.textureCenter ?? plane.center
+  const width = Math.max(1, Math.abs(rect.width))
+  const height = Math.max(1, Math.abs(rect.height))
+  const halfWidth = (width * Math.abs(plane.scaleX)) / 2
+  const halfHeight = (height * Math.abs(plane.scaleY)) / 2
+  const corner = (horizontal: number, vertical: number) => ({
+    x:
+      center.x +
+      plane.right.x * halfWidth * horizontal +
+      plane.down.x * halfHeight * vertical,
+    y:
+      center.y +
+      plane.right.y * halfWidth * horizontal +
+      plane.down.y * halfHeight * vertical,
+    z:
+      center.z +
+      plane.right.z * halfWidth * horizontal +
+      plane.down.z * halfHeight * vertical,
+  })
+  const viewport = {
+    width: Math.max(1, viewportSize.x),
+    height: Math.max(1, viewportSize.y),
+  }
+  const projected = [
+    corner(-1, -1),
+    corner(1, -1),
+    corner(1, 1),
+    corner(-1, 1),
+  ].map((point) => projectWorldPoint(point, camera, viewport))
+  const edgeLength = (from: number, to: number) =>
+    Math.hypot(
+      projected[to]!.x - projected[from]!.x,
+      projected[to]!.y - projected[from]!.y,
+    )
+  const projectedUnitsPerAuthoredUnit = Math.max(
+    edgeLength(0, 1) / width,
+    edgeLength(3, 2) / width,
+    edgeLength(0, 3) / height,
+    edgeLength(1, 2) / height,
+  )
+  const fallback = Number.isFinite(fallbackScale)
+    ? Math.max(1, fallbackScale)
+    : 1
+  const projectedScale =
+    projectedUnitsPerAuthoredUnit *
+    (Number.isFinite(screenPixelRatio) ? Math.max(0.25, screenPixelRatio) : 1)
+  return Number.isFinite(projectedScale)
+    ? Math.max(fallback, projectedScale)
+    : fallback
+}
+
 function renderPlaneCanvas(
   api: SceneAPI,
   layout: SolvedLayout,
@@ -3311,6 +3500,7 @@ function renderPlaneCanvas(
   emittedPlaneNodeIds: ReadonlySet<NodeId>,
   animated: Record<NodeId, AnimatedValue>,
   playhead: number,
+  textureScale: number,
 ): HTMLCanvasElement {
   // Clipping is applied by the material's world-space clipping planes. Baking
   // the same mask into this bitmap makes it move with an animated layer and
@@ -3322,6 +3512,7 @@ function renderPlaneCanvas(
     emittedPlaneNodeIds,
     animated,
     playhead,
+    textureScale,
   )
 }
 
@@ -3332,6 +3523,7 @@ function renderSharpPlaneCanvas(
   emittedPlaneNodeIds: ReadonlySet<NodeId>,
   animated: Record<NodeId, AnimatedValue>,
   playhead: number,
+  textureScale: number,
 ): HTMLCanvasElement {
   if (plane.contentMode === 'self') {
     return renderPlaneTexture(
@@ -3340,6 +3532,7 @@ function renderSharpPlaneCanvas(
       animated[plane.nodeId],
       playhead,
       plane.textureRect ?? plane.rect,
+      textureScale,
     )
   }
   const textureRect = plane.textureRect ?? plane.rect
@@ -3352,6 +3545,7 @@ function renderSharpPlaneCanvas(
       emittedPlaneNodeIds,
       animated,
       playhead,
+      textureScale,
     ) ??
     renderPlaneTexture(
       plane.node,
@@ -3359,6 +3553,7 @@ function renderSharpPlaneCanvas(
       animated[plane.nodeId],
       playhead,
       plane.textureRect ?? plane.rect,
+      textureScale,
     )
   )
 }
@@ -3680,12 +3875,13 @@ function renderPlaneTexture(
   anim: AnimatedValue | undefined,
   playhead: number,
   textureRect: Rect = rect,
+  textureScale = textureScaleForRect(textureRect),
 ): HTMLCanvasElement {
   const w = Math.max(1, Math.ceil(rect.width))
   const h = Math.max(1, Math.ceil(rect.height))
   const canvasWidth = Math.max(1, Math.ceil(textureRect.width))
   const canvasHeight = Math.max(1, Math.ceil(textureRect.height))
-  const scale = textureScaleForRect(textureRect)
+  const scale = textureScale
   const canvas = document.createElement('canvas')
   canvas.width = Math.max(1, Math.ceil(canvasWidth * scale))
   canvas.height = Math.max(1, Math.ceil(canvasHeight * scale))
@@ -3712,11 +3908,12 @@ function renderSubtreeTexture(
   emittedPlaneNodeIds: ReadonlySet<NodeId> = new Set(),
   animated: Record<NodeId, AnimatedValue> = {},
   playhead = 0,
+  textureScale = textureScaleForRect(rootRect),
 ): HTMLCanvasElement | null {
   if (typeof document === 'undefined') return null
   const width = Math.max(1, Math.ceil(rootRect.width))
   const height = Math.max(1, Math.ceil(rootRect.height))
-  const scale = textureScaleForRect(rootRect)
+  const scale = textureScale
   const canvas = document.createElement('canvas')
   canvas.width = Math.max(1, Math.ceil(width * scale))
   canvas.height = Math.max(1, Math.ceil(height * scale))
@@ -4687,16 +4884,31 @@ function paintAnimatedTextNode(
     targetCtx.beginPath()
     targetCtx.rect(scratchCtx ? 0 : x, scratchCtx ? 0 : y, maxWidth, maxHeight)
     targetCtx.clip()
-    paintNumberLayer(
-      frame.outgoingText,
-      frame.outgoingOffsetEm,
-      frame.outgoingOpacity,
-    )
-    paintNumberLayer(
-      frame.incomingText,
-      frame.incomingOffsetEm,
-      frame.incomingOpacity,
-    )
+    if (config.numberFlowDigitMode === 'staggered') {
+      paintNumberFlowTokenColumns(
+        targetCtx,
+        frame,
+        targetX,
+        targetY,
+        maxWidth,
+        fontSize,
+        lineHeight,
+        authoredTracking,
+        node.textAlign ?? 'start',
+        node.textDecoration ?? 'none',
+      )
+    } else {
+      paintNumberLayer(
+        frame.outgoingText,
+        frame.outgoingOffsetEm,
+        frame.outgoingOpacity,
+      )
+      paintNumberLayer(
+        frame.incomingText,
+        frame.incomingOffsetEm,
+        frame.incomingOpacity,
+      )
+    }
     targetCtx.restore()
     if (scratchCtx) {
       if (frame.maskHeightEm > 0) {
@@ -5513,6 +5725,222 @@ function measureCanvasTextWidth(
   const base = ctx.measureText(text).width
   if (!Number.isFinite(tracking) || tracking === 0) return base
   return base + Math.max(0, Array.from(text).length - 1) * tracking
+}
+
+/**
+ * Paint independently animated Number Flow columns without relying on
+ * wall-clock Web Animations. Digits reserve one numeric column even when a
+ * carry introduces or removes a place, so seeks and frame exports keep the
+ * same horizontal geometry throughout the authored segment.
+ */
+function paintNumberFlowTokenColumns(
+  ctx: CanvasRenderingContext2D,
+  frame: NumberFlowVisualFrame,
+  x: number,
+  y: number,
+  maxWidth: number,
+  fontSize: number,
+  lineHeight: number,
+  tracking = 0,
+  align: Extract<Node, { kind: 'text' }>['textAlign'] = 'start',
+  decoration: Extract<Node, { kind: 'text' }>['textDecoration'] = 'none',
+) {
+  const tokens = frame.tokens
+  if (tokens.length === 0) return
+
+  const characterWidth = (value: string) =>
+    value ? ctx.measureText(value).width : 0
+  const widestDigitWidth = Math.max(
+    ...Array.from('0123456789').map(characterWidth),
+  )
+  const reserveCharacter = (token: NumberFlowVisualFrame['tokens'][number]) => {
+    if (token.kind === 'digit') return '0'
+    if (token.key === 'separator:sign') return '-'
+    if (token.key.startsWith('separator:group:')) return ','
+    if (token.key === 'separator:decimal') return '.'
+    return token.outgoingChar || token.incomingChar
+  }
+  type TokenEntry = {
+    token: NumberFlowVisualFrame['tokens'][number]
+    width: number
+    layoutCharacter: string
+  }
+  type TokenLine = {
+    entries: TokenEntry[]
+    canJustify: boolean
+  }
+  const entries: TokenEntry[] = tokens.map((token) => ({
+    token,
+    width:
+      token.kind === 'digit'
+        ? widestDigitWidth
+        : Math.max(
+            characterWidth(token.outgoingChar),
+            characterWidth(token.incomingChar),
+            characterWidth(reserveCharacter(token)),
+          ),
+    layoutCharacter:
+      token.kind === 'digit'
+        ? '0'
+        : token.outgoingChar || token.incomingChar || reserveCharacter(token),
+  }))
+  const lineWidth = (lineEntries: TokenEntry[]) =>
+    lineEntries.reduce((sum, entry) => sum + entry.width, 0) +
+    Math.max(0, lineEntries.length - 1) * tracking
+  const trimLeadingWhitespace = (lineEntries: TokenEntry[]) => {
+    let start = 0
+    while (
+      start < lineEntries.length &&
+      /^\s$/.test(lineEntries[start]!.layoutCharacter)
+    ) {
+      start += 1
+    }
+    return lineEntries.slice(start)
+  }
+  const trimTrailingWhitespace = (lineEntries: TokenEntry[]) => {
+    let end = lineEntries.length
+    while (
+      end > 0 &&
+      /^\s$/.test(lineEntries[end - 1]!.layoutCharacter)
+    ) {
+      end -= 1
+    }
+    return lineEntries.slice(0, end)
+  }
+  const lines: TokenLine[] = []
+  const paragraphs: TokenEntry[][] = [[]]
+  for (const entry of entries) {
+    if (entry.layoutCharacter === '\n') {
+      paragraphs.push([])
+    } else {
+      paragraphs[paragraphs.length - 1]!.push(entry)
+    }
+  }
+  for (const paragraph of paragraphs) {
+    if (paragraph.length === 0) {
+      lines.push({ entries: [], canJustify: false })
+      continue
+    }
+    const runs: TokenEntry[][] = []
+    for (const entry of paragraph) {
+      const whitespace = /^\s$/.test(entry.layoutCharacter)
+      const previous = runs[runs.length - 1]
+      const previousWhitespace = previous
+        ? /^\s$/.test(previous[0]!.layoutCharacter)
+        : !whitespace
+      if (!previous || previousWhitespace !== whitespace) {
+        runs.push([entry])
+      } else {
+        previous.push(entry)
+      }
+    }
+    let current: TokenEntry[] = []
+    const paragraphLines: TokenEntry[][] = []
+    for (const run of runs) {
+      const candidate = [...current, ...run]
+      if (current.length === 0 || lineWidth(candidate) <= maxWidth) {
+        current = candidate
+      } else {
+        paragraphLines.push(trimTrailingWhitespace(current))
+        current = trimLeadingWhitespace(run)
+      }
+    }
+    paragraphLines.push(trimTrailingWhitespace(current))
+    paragraphLines.forEach((lineEntries, index) => {
+      lines.push({
+        entries: lineEntries,
+        canJustify:
+          index < paragraphLines.length - 1 &&
+          lineEntries.some((entry) => /^\s$/.test(entry.layoutCharacter)),
+      })
+    })
+  }
+  const lineHeightPx = Math.max(1, fontSize * lineHeight)
+
+  const paintCharacter = (
+    cursorX: number,
+    lineY: number,
+    value: string,
+    columnWidth: number,
+    offsetEm: number,
+    opacity: number,
+    blurRadius: number,
+  ) => {
+    if (!value || opacity <= 0.001) return
+    const width = characterWidth(value)
+    ctx.save()
+    ctx.globalAlpha *= opacity
+    if (blurRadius > 0.01) ctx.filter = `blur(${blurRadius}px)`
+    ctx.fillText(
+      value,
+      cursorX + Math.max(0, (columnWidth - width) / 2),
+      canvasTextBaseline(
+        ctx,
+        lineY + offsetEm * lineHeightPx,
+        fontSize,
+        lineHeight,
+      ),
+    )
+    ctx.restore()
+  }
+
+  lines.forEach((line, lineIndex) => {
+    const totalWidth = lineWidth(line.entries)
+    const lineX =
+      align === 'center'
+        ? x + Math.max(0, (maxWidth - totalWidth) / 2)
+        : align === 'end'
+          ? x + Math.max(0, maxWidth - totalWidth)
+          : x
+    const whitespaceCount = line.canJustify
+      ? line.entries.filter((entry) => /^\s$/.test(entry.layoutCharacter))
+          .length
+      : 0
+    const extraPerWhitespace =
+      align === 'justify' && whitespaceCount > 0
+        ? Math.max(0, maxWidth - totalWidth) / whitespaceCount
+        : 0
+    const lineY = y + lineIndex * lineHeightPx
+    let cursorX = lineX
+
+    for (const entry of line.entries) {
+      const { token, width: columnWidth } = entry
+      paintCharacter(
+        cursorX,
+        lineY,
+        token.outgoingChar,
+        columnWidth,
+        token.outgoingOffsetEm,
+        token.outgoingOpacity,
+        token.blurRadius,
+      )
+      if (token.active || token.incomingChar !== token.outgoingChar) {
+        paintCharacter(
+          cursorX,
+          lineY,
+          token.incomingChar,
+          columnWidth,
+          token.incomingOffsetEm,
+          token.incomingOpacity,
+          token.blurRadius,
+        )
+      }
+      cursorX +=
+        columnWidth +
+        tracking +
+        (/^\s$/.test(entry.layoutCharacter) ? extraPerWhitespace : 0)
+    }
+
+    paintCanvasTextDecoration(
+      ctx,
+      decoration,
+      lineX,
+      lineY,
+      align === 'justify' && line.canJustify ? maxWidth : totalWidth,
+      fontSize,
+      lineHeight,
+    )
+  })
 }
 
 function paintImagePlaceholder(ctx: CanvasRenderingContext2D, width: number, height: number) {

--- a/src/render3d/texturePolicy.test.ts
+++ b/src/render3d/texturePolicy.test.ts
@@ -39,6 +39,29 @@ describe('WebGL plane texture policy', () => {
     expect(2208 * 1816 * 4).toBe(16_038_912)
   })
 
+  it('lets final renders request native 4K texture density', () => {
+    const scale = textureScaleForRect(
+      { width: 960, height: 540 },
+      3.15,
+      { maximumScale: 8, bucketStep: 0.5 },
+    )
+
+    expect(scale).toBe(3.5)
+    expect(Math.ceil(960 * scale)).toBe(3360)
+    expect(Math.ceil(540 * scale)).toBe(1890)
+  })
+
+  it('keeps projection-aware export textures inside the dimension bound', () => {
+    const scale = textureScaleForRect(
+      { width: 1440, height: 1080 },
+      6.2,
+      { maximumScale: 8, bucketStep: 0.5 },
+    )
+
+    expect(scale).toBeCloseTo(4096 / 1440)
+    expect(Math.ceil(1440 * scale)).toBe(4096)
+  })
+
   it('reuses a canvas texture when only the workspace view changes', () => {
     const revision = {}
     const cached = {

--- a/src/render3d/texturePolicy.ts
+++ b/src/render3d/texturePolicy.ts
@@ -15,6 +15,22 @@ export interface CachedPlaneTextureState {
   textureSignature: string
 }
 
+export interface TextureScaleOptions {
+  /**
+   * Realtime previews stay capped at 2x. Final renders may opt into a higher
+   * ceiling when a camera projects a plane across more output pixels than its
+   * authored bounds contain.
+   */
+  maximumScale?: number
+  /** Keep individual CanvasTextures inside a conservative GPU-safe bound. */
+  maximumDimension?: number
+  /**
+   * Round upward so small camera changes reuse the same raster instead of
+   * repainting and uploading a texture on every animation frame.
+   */
+  bucketStep?: number
+}
+
 /**
  * Match the editor framebuffer to the scene's on-screen footprint. A 4K
  * artboard viewed at 25% should not allocate an 8K Retina render target.
@@ -96,13 +112,30 @@ export function textureScaleForRect(
   rect: Pick<Rect, 'width' | 'height'>,
   devicePixelRatio =
     typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1,
+  options: TextureScaleOptions = {},
 ): number {
-  const desired = Math.min(
-    MAX_TEXTURE_SCALE,
-    Math.max(1, devicePixelRatio),
+  const maximumScale = Number.isFinite(options.maximumScale)
+    ? Math.max(1, options.maximumScale!)
+    : MAX_TEXTURE_SCALE
+  const maximumDimension = Number.isFinite(options.maximumDimension)
+    ? Math.max(1, options.maximumDimension!)
+    : MAX_TEXTURE_DIMENSION
+  const requested = Math.min(
+    maximumScale,
+    Math.max(1, Number.isFinite(devicePixelRatio) ? devicePixelRatio : 1),
   )
+  const bucketStep = Number.isFinite(options.bucketStep)
+    ? Math.max(0, options.bucketStep!)
+    : 0
+  const desired =
+    bucketStep > 0
+      ? Math.min(
+          maximumScale,
+          Math.ceil((requested - Number.EPSILON) / bucketStep) * bucketStep,
+        )
+      : requested
   const maxSide = Math.max(1, Math.ceil(Math.max(rect.width, rect.height)))
-  return Math.max(1, Math.min(desired, MAX_TEXTURE_DIMENSION / maxSide))
+  return Math.max(1, Math.min(desired, maximumDimension / maxSide))
 }
 
 /** Workspace-only view changes reuse the existing bitmap. */

--- a/src/ui/Canvas.tsx
+++ b/src/ui/Canvas.tsx
@@ -132,6 +132,7 @@ import {
   numberFlowTextAtProgress,
   numberFlowVisualFrameAtProgress,
   numberFlowVisualOptionsFromConfig,
+  type NumberFlowVisualToken,
 } from '@/anim/numberFlow'
 import { scrambleTextForSegment } from '@/anim/textScramble'
 import {
@@ -5998,6 +5999,64 @@ function renderTextSegmentContent(
       textAlign: 'inherit',
       willChange: 'transform, opacity, filter',
     })
+    if (
+      config.numberFlowDigitMode === 'staggered' &&
+      frame.tokens.length > 0
+    ) {
+      const prefixText = frame.tokens
+        .filter((token) => token.kind === 'prefix')
+        .map((token) => token.outgoingChar)
+        .join('')
+      const numericTokens = frame.tokens.filter(
+        (token) => token.kind === 'digit' || token.kind === 'separator',
+      )
+      const suffixText = frame.tokens
+        .filter((token) => token.kind === 'suffix')
+        .map((token) => token.outgoingChar)
+        .join('')
+
+      return (
+        <span
+          aria-label={frame.settledText}
+          style={{
+            position: 'relative',
+            display: 'block',
+            width: '100%',
+            WebkitMaskImage: sideMask,
+            maskImage: sideMask,
+          }}
+        >
+          <span
+            style={{
+              position: 'relative',
+              display: 'block',
+              width: '100%',
+              WebkitMaskImage: edgeMask,
+              maskImage: edgeMask,
+            }}
+          >
+            <span aria-hidden style={{ whiteSpace: 'inherit' }}>
+              {prefixText}
+              {numericTokens.length > 0 ? (
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'baseline',
+                    verticalAlign: 'baseline',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {numericTokens.map((token) => (
+                    <NumberFlowTokenColumn key={token.key} token={token} />
+                  ))}
+                </span>
+              ) : null}
+              {suffixText}
+            </span>
+          </span>
+        </span>
+      )
+    }
     return (
       <span
         style={{
@@ -6062,6 +6121,86 @@ function renderTextSegmentContent(
       </span>
     </>
   )
+}
+
+function NumberFlowTokenColumn({
+  token,
+}: {
+  token: NumberFlowVisualToken
+}) {
+  const measureChars = numberFlowTokenMeasureChars(token)
+  const tokenLayerStyle = (
+    offsetEm: number,
+    opacity: number,
+  ): CSSProperties => ({
+    gridArea: '1 / 1',
+    justifySelf: 'center',
+    whiteSpace: 'pre',
+    transform: `translateY(${offsetEm}em)`,
+    opacity,
+    filter:
+      token.blurRadius > 0.01
+        ? `blur(${token.blurRadius}px)`
+        : undefined,
+    pointerEvents: 'none',
+    willChange: 'transform, opacity, filter',
+  })
+
+  return (
+    <span
+      style={{
+        position: 'relative',
+        display: 'inline-grid',
+        gridTemplateColumns: 'max-content',
+        gridTemplateRows: '1fr',
+        verticalAlign: 'baseline',
+      }}
+    >
+      {measureChars.map((character, index) => (
+        <span
+          key={`${token.key}:measure:${index}`}
+          aria-hidden
+          style={{
+            gridArea: '1 / 1',
+            visibility: 'hidden',
+            whiteSpace: 'pre',
+          }}
+        >
+          {character}
+        </span>
+      ))}
+      <span
+        aria-hidden
+        style={tokenLayerStyle(
+          token.outgoingOffsetEm,
+          token.outgoingOpacity,
+        )}
+      >
+        {token.outgoingChar}
+      </span>
+      <span
+        aria-hidden
+        style={tokenLayerStyle(
+          token.incomingOffsetEm,
+          token.incomingOpacity,
+        )}
+      >
+        {token.incomingChar}
+      </span>
+    </span>
+  )
+}
+
+function numberFlowTokenMeasureChars(
+  token: NumberFlowVisualToken,
+): string[] {
+  if (token.kind === 'digit') return Array.from('0123456789')
+  if (token.kind !== 'separator') {
+    return [token.outgoingChar || token.incomingChar || '\u200b']
+  }
+  if (token.key === 'separator:sign') return ['-']
+  if (token.key === 'separator:decimal') return ['.']
+  return [',']
 }
 
 type MediaVideoProps = {

--- a/src/ui/ExportMenu.tsx
+++ b/src/ui/ExportMenu.tsx
@@ -11,8 +11,13 @@ import {
   type ExportFormatId,
   type ExportQualityId,
   type ExportRange,
-  resolveDimensions,
 } from '@/export'
+import {
+  chooseExportDirectory,
+  getDefaultExportDirectory,
+  sanitizeExportTitle,
+  writeExportBlob,
+} from '@/export/destination'
 import { useSceneAPI, useSceneVersion } from '@/scene'
 import { useUI } from '@/state/ui'
 import { useProjectAPI } from '@/project'
@@ -114,6 +119,36 @@ export function ExportMenu({
       ? selectedComposition?.workArea ??
         (selectedCompositionIsActive ? workAreaRange : null)
       : null
+  const bridge =
+    typeof window === 'undefined' ? undefined : window.hypermotion
+  const [exportTitleState, setExportTitleState] = useState(() => ({
+    sourceName: exportName,
+    value: sanitizeExportTitle(exportName),
+  }))
+  const exportTitle =
+    exportTitleState.sourceName === exportName
+      ? exportTitleState.value
+      : sanitizeExportTitle(exportName)
+  const setExportTitle = (value: string) => {
+    setExportTitleState({ sourceName: exportName, value })
+  }
+  const [folderPath, setFolderPath] = useState('')
+  const [folderPending, setFolderPending] = useState(Boolean(bridge))
+
+  useEffect(() => {
+    if (!bridge) return
+    let active = true
+    void getDefaultExportDirectory(bridge)
+      .then((directory) => {
+        if (active) setFolderPath(directory)
+      })
+      .finally(() => {
+        if (active) setFolderPending(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [bridge])
 
   // Format. Default MP4 — share-ready, captures the most cases. Drives
   // the file extension downstream + which pipeline the orchestrator
@@ -223,6 +258,7 @@ export function ExportMenu({
 
   const exportDisabled =
     exportRunning ||
+    (Boolean(bridge) && !folderPath) ||
     (exportScope === 'scene' && !selectedComposition) ||
     (rangeMode === 'chapter' && selectedChapters.length === 0)
 
@@ -251,13 +287,6 @@ export function ExportMenu({
       ? range.segments.reduce((acc, s) => acc + (s.endSec - s.startSec), 0)
       : rangeEnd - rangeStart
   const frameCount = Math.max(1, Math.round(totalSelectedSec * fps))
-
-  // Resolved output dimensions for the filename estimate footer.
-  const sceneCanvasMeta = useMemo(
-    () => ({ width: meta.canvas.width, height: meta.canvas.height }),
-    [meta.canvas.width, meta.canvas.height],
-  )
-  const dims = resolveDimensions(quality, sceneCanvasMeta)
 
   // Position the panel below the trigger, flipping above when there's
   // not enough room. Mirrors the previous behaviour.
@@ -306,10 +335,12 @@ export function ExportMenu({
 
   const onExport = () => {
     if (exportDisabled) return
+    const safeTitle = sanitizeExportTitle(exportTitle, exportName)
+    setExportTitle(safeTitle)
     onClose()
     void exportScene({
       api,
-      sceneName: exportName,
+      sceneName: safeTitle,
       durationSec: exportDuration,
       scope: exportScope,
       compositionSceneId:
@@ -324,18 +355,22 @@ export function ExportMenu({
       exportFps: fps,
       range,
       filenameTag,
+      onBlob:
+        bridge && folderPath
+          ? async (blob, resolvedFileName) => {
+              await writeExportBlob(
+                bridge,
+                folderPath,
+                resolvedFileName,
+                blob,
+              )
+            }
+          : undefined,
       // No pipeline override: the orchestrator picks captureRect when
       // running under Electron and falls back to tab capture in the
       // web tree. The previous Fast/HQ chip distinction was redundant.
     })
   }
-
-  const fileName = useMemo(() => {
-    const base = (exportName || 'export')
-      .replace(/[^a-zA-Z0-9-_ ]/g, '')
-      .trim()
-    return `${base || 'export'}.${format.extension}`
-  }, [exportName, format.extension])
 
   const totalFrames = Math.max(1, Math.round(exportDuration * fps))
   const hasChapters =
@@ -357,9 +392,8 @@ export function ExportMenu({
       }}
       className="hm-popover-surface z-[100] overflow-hidden border border-border"
     >
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
-        <span className="text-[12px] font-medium text-text">Export</span>
+      {/* Compact job metadata; the redundant dialog title is intentionally omitted. */}
+      <div className="flex items-center justify-end border-b border-border px-4 py-2.5">
         <span className="font-mono text-[10px] tabular-nums text-text-dim">
           {exportDuration.toFixed(2)}s · {totalFrames}f @ {fps}fps
         </span>
@@ -367,6 +401,63 @@ export function ExportMenu({
 
       {/* Body — spec sheet rows */}
       <div className="px-4 py-3">
+        <FieldRow label="Title">
+          <input
+            type="text"
+            value={exportTitle}
+            aria-label="Export title"
+            spellCheck={false}
+            onChange={(event) => setExportTitle(event.target.value)}
+            onBlur={() =>
+              setExportTitle(sanitizeExportTitle(exportTitle, exportName))
+            }
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') event.currentTarget.blur()
+              if (event.key === 'Escape') {
+                event.preventDefault()
+                setExportTitle(sanitizeExportTitle(exportName))
+                event.currentTarget.blur()
+              }
+            }}
+            className="hm-control-surface hm-control-compact h-8 w-full px-3 text-[11px] text-text outline-none"
+          />
+        </FieldRow>
+
+        <FieldRow label="Folder">
+          <button
+            type="button"
+            aria-label="Choose export folder"
+            aria-busy={folderPending}
+            title={folderPath || undefined}
+            disabled={!bridge || folderPending}
+            onClick={() => {
+              if (!bridge) return
+              setFolderPending(true)
+              void chooseExportDirectory(
+                bridge,
+                folderPath,
+                exportTitle,
+                formatId,
+              )
+                .then((selection) => {
+                  if (!selection) return
+                  setFolderPath(selection.directory)
+                  setExportTitle(selection.title)
+                })
+                .finally(() => setFolderPending(false))
+            }}
+            className="hm-control-surface hm-control-compact flex h-8 w-full min-w-0 items-center px-3 text-left font-mono text-[10px] text-text-muted outline-none disabled:cursor-default disabled:opacity-60"
+          >
+            <span className="truncate">
+              {folderPending
+                ? 'Loading folder…'
+                : folderPath || (bridge ? 'Choose a folder' : 'Downloads')}
+            </span>
+          </button>
+        </FieldRow>
+
+        <div className="my-2 border-t border-border" />
+
         <FieldRow label="Output">
           <Segments>
             <SegmentBtn
@@ -561,11 +652,8 @@ export function ExportMenu({
       </div>
 
       {/* Footer */}
-      <div className="flex items-center gap-2 border-t border-border bg-panel px-4 py-2.5">
-        <span className="font-mono text-[10px] tabular-nums text-text-dim">
-          {fileName} · {dims.width} × {dims.height}
-        </span>
-        <div className="ml-auto flex items-center gap-1.5">
+      <div className="flex items-center justify-end gap-2 border-t border-border bg-panel px-4 py-2.5">
+        <div className="flex items-center gap-1.5">
           <button
             type="button"
             onClick={onClose}
@@ -584,7 +672,7 @@ export function ExportMenu({
                 : 'bg-accent text-white hover:brightness-110',
             ].join(' ')}
           >
-            {exportRunning ? 'Export in progress' : `Export ${format.label}`}
+            {exportRunning ? 'Export in progress' : 'Export'}
           </button>
         </div>
       </div>

--- a/src/ui/PresetsPanel.tsx
+++ b/src/ui/PresetsPanel.tsx
@@ -1273,6 +1273,50 @@ function TextAnimationPanel({ playhead }: { playhead: number }) {
 
       {isNumberFlow ? (
         <ControlCard title="Number motion">
+          <ParamRow label="Digit animation">
+            <SelectField<TextAnimationConfig['numberFlowDigitMode']>
+              value={current.numberFlowDigitMode}
+              options={[
+                ['together', 'Together'],
+                ['staggered', 'One by one'],
+              ]}
+              onChange={(numberFlowDigitMode) =>
+                patch({ numberFlowDigitMode })
+              }
+              ariaLabel="Number flow digit animation"
+            />
+          </ParamRow>
+          {current.numberFlowDigitMode === 'staggered' ? (
+            <>
+              <ParamRow label="Order">
+                <SelectField<TextAnimationConfig['numberFlowDigitOrder']>
+                  value={current.numberFlowDigitOrder}
+                  options={[
+                    ['forward', 'Left to right'],
+                    ['backward', 'Right to left'],
+                  ]}
+                  onChange={(numberFlowDigitOrder) =>
+                    patch({ numberFlowDigitOrder })
+                  }
+                  ariaLabel="Number flow digit order"
+                />
+              </ParamRow>
+              <ParamRow label="Digit stagger">
+                <NumberField
+                  value={Math.round(current.numberFlowDigitStagger * 100)}
+                  onCommit={(value) =>
+                    patch({ numberFlowDigitStagger: value / 100 })
+                  }
+                  min={0}
+                  max={90}
+                  suffix="%"
+                  width="w-24"
+                  ariaLabel="Number flow digit stagger"
+                />
+              </ParamRow>
+              <div className="my-2 border-t border-border" />
+            </>
+          ) : null}
           <ParamRow label="Spin distance">
             <NumberField
               value={Math.round(current.numberFlowSpinDistance * 100)}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,12 @@
-import { defineConfig } from 'vite'
+import { realpathSync } from 'node:fs'
+import { defineConfig, searchForWorkspaceRoot } from 'vite'
 import { fileURLToPath, URL } from 'node:url'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import electron from 'vite-plugin-electron'
+
+const projectRoot = fileURLToPath(new URL('.', import.meta.url))
+const dependencyRoot = realpathSync(new URL('./node_modules', import.meta.url))
 
 /**
  * Vite config — same renderer setup as the web build, with Electron
@@ -25,6 +29,15 @@ import electron from 'vite-plugin-electron'
  */
 export default defineConfig({
   base: './',
+  server: {
+    fs: {
+      // Codex worktrees may share dependencies through a node_modules
+      // symlink. Keep Vite's normal workspace boundary and explicitly allow
+      // only that symlink's resolved dependency directory so local font
+      // assets (including Bricolage Grotesque) remain available in dev.
+      allow: [searchForWorkspaceRoot(projectRoot), dependencyRoot],
+    },
+  },
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
## What changed

- speed up headless frame capture with validated bitmap conversion
- serve bundled Bricolage Grotesque assets from linked dependencies in development
- add direct GPU export eligibility and deterministic frame-ready synchronization
- improve high-resolution 3D texture rasterization and camera transition stability
- add editable export title and native destination-folder saving
- add one-by-one NumberFlow digit animation, ordering, and stagger controls

## Why

These changes improve render speed, exported image clarity, camera-cut stability, export destination control, and numeric animation flexibility while preserving the existing scene-export workflow.

## Validation

- TypeScript typecheck
- focused ESLint over all changed source files
- 117 focused rendering, export, and NumberFlow tests
- production Vite and Electron build
- clean working tree and diff check