### PR TITLE
Clarify CLI render watchdog comments

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2138,7 +2138,7 @@ ipcMain.handle('export:headless-error', (_e, message: string) => {
   console.error(`[headless] renderer reported error: ${message}`)
   // Drop an error sentinel at `<output>.error` so the CLI driver
   // doesn't poll forever waiting for `<output>.done`. Without this,
-  // the CLI hits its 5-minute timeout and the agent never gets a
+  // the CLI hits its render watchdog and the agent never gets a
   // proper rejection — observed as "the call is stuck."
   if (headlessRequest?.outputPath) {
     try {

--- a/src/headlessExport.ts
+++ b/src/headlessExport.ts
@@ -127,7 +127,7 @@ async function runHeadlessRender(req: HeadlessRequest): Promise<void> {
   // MediaRecorder), which requires a user gesture on macOS Chromium.
   // In headless mode there's no gesture — the call hangs forever.
   // Fail fast with a clear message so the agent can fall back to MP4
-  // or GIF instead of waiting out the 5-minute CLI timeout. Rebuilding
+  // or GIF instead of waiting out the CLI render watchdog. Rebuilding
   // WebM on top of capturePage (frame-by-frame WebM encoding) is the
   // proper fix.
   //


### PR DESCRIPTION
## Summary

- replace stale 5-minute timeout wording with the current CLI render watchdog terminology
- keep renderer and headless-export comments aligned with the 30-minute driver default

## Verification

- focused checks passed when the commit was created
- confirmed the dedicated CLI timeout test still asserts 30 minutes
- git diff --check